### PR TITLE
Fix several Unarmed Strike Edge Cases

### DIFF
--- a/dist/background.js
+++ b/dist/background.js
@@ -545,8 +545,14 @@ const character_settings = {
         "default": false
     },
     "brutal-critical": {
-        "title": "Brutal Critical/Savage Attacks: Roll extra die",
-        "description": "Roll extra damage die on crit for Brutal Critical and Savage Attacks features",
+        "title": "Brutal Critical: Roll extra die",
+        "description": "Roll extra damage die on crit for Brutal Critical feature",
+        "type": "bool",
+        "default": true
+    },
+    "savage-attacks": {
+        "title": "Savage Attacks: Roll extra die",
+        "description": "Roll extra damage die on crit for Savage Attacks feature",
         "type": "bool",
         "default": true
     },

--- a/dist/default_popup.js
+++ b/dist/default_popup.js
@@ -501,8 +501,14 @@ const character_settings = {
         "default": false
     },
     "brutal-critical": {
-        "title": "Brutal Critical/Savage Attacks: Roll extra die",
-        "description": "Roll extra damage die on crit for Brutal Critical and Savage Attacks features",
+        "title": "Brutal Critical: Roll extra die",
+        "description": "Roll extra damage die on crit for Brutal Critical feature",
+        "type": "bool",
+        "default": true
+    },
+    "savage-attacks": {
+        "title": "Savage Attacks: Roll extra die",
+        "description": "Roll extra damage die on crit for Savage Attacks feature",
         "type": "bool",
         "default": true
     },

--- a/dist/dndbeyond_encounter.js
+++ b/dist/dndbeyond_encounter.js
@@ -500,8 +500,14 @@ const character_settings = {
         "default": false
     },
     "brutal-critical": {
-        "title": "Brutal Critical/Savage Attacks: Roll extra die",
-        "description": "Roll extra damage die on crit for Brutal Critical and Savage Attacks features",
+        "title": "Brutal Critical: Roll extra die",
+        "description": "Roll extra damage die on crit for Brutal Critical feature",
+        "type": "bool",
+        "default": true
+    },
+    "savage-attacks": {
+        "title": "Savage Attacks: Roll extra die",
+        "description": "Roll extra damage die on crit for Savage Attacks feature",
         "type": "bool",
         "default": true
     },
@@ -2673,7 +2679,7 @@ function damagesToCrits(character, damages) {
     return crits;
 }
 
-function buildAttackRoll(character, attack_source, name, description, properties, damages = [], damage_types = [], to_hit = null, brutal = 0) {
+function buildAttackRoll(character, attack_source, name, description, properties, damages = [], damage_types = [], to_hit = null, brutal = 0, savage = 0) {
     const roll_properties = {
         "name": name,
         "attack-source": attack_source,
@@ -2736,6 +2742,21 @@ function buildAttackRoll(character, attack_source, name, description, properties
                 if (highest_dice != 0) {
                     crit_damages.push(`${brutal}d${highest_dice}`);
                     crit_damage_types.push("Brutal");
+                }
+            }
+            if (savage > 0) {
+                let highest_dice = 0;
+                for (let dmg of crit_damages) {
+                    const match = dmg.match(/[0-9]*d([0-9]+)/);
+                    if (match !== undefined) {
+                        const sides = parseInt(match[1]);
+                        if (sides > highest_dice)
+                            highest_dice = sides;
+                    }
+                }
+                if (highest_dice != 0) {
+                    crit_damages.push(`${savage}d${highest_dice}`);
+                    crit_damage_types.push("Savage Attacks");
                 }
             }
             roll_properties["critical-damages"] = crit_damages;

--- a/dist/dndbeyond_item.js
+++ b/dist/dndbeyond_item.js
@@ -500,8 +500,14 @@ const character_settings = {
         "default": false
     },
     "brutal-critical": {
-        "title": "Brutal Critical/Savage Attacks: Roll extra die",
-        "description": "Roll extra damage die on crit for Brutal Critical and Savage Attacks features",
+        "title": "Brutal Critical: Roll extra die",
+        "description": "Roll extra damage die on crit for Brutal Critical feature",
+        "type": "bool",
+        "default": true
+    },
+    "savage-attacks": {
+        "title": "Savage Attacks: Roll extra die",
+        "description": "Roll extra damage die on crit for Savage Attacks feature",
         "type": "bool",
         "default": true
     },
@@ -2673,7 +2679,7 @@ function damagesToCrits(character, damages) {
     return crits;
 }
 
-function buildAttackRoll(character, attack_source, name, description, properties, damages = [], damage_types = [], to_hit = null, brutal = 0) {
+function buildAttackRoll(character, attack_source, name, description, properties, damages = [], damage_types = [], to_hit = null, brutal = 0, savage = 0) {
     const roll_properties = {
         "name": name,
         "attack-source": attack_source,
@@ -2736,6 +2742,21 @@ function buildAttackRoll(character, attack_source, name, description, properties
                 if (highest_dice != 0) {
                     crit_damages.push(`${brutal}d${highest_dice}`);
                     crit_damage_types.push("Brutal");
+                }
+            }
+            if (savage > 0) {
+                let highest_dice = 0;
+                for (let dmg of crit_damages) {
+                    const match = dmg.match(/[0-9]*d([0-9]+)/);
+                    if (match !== undefined) {
+                        const sides = parseInt(match[1]);
+                        if (sides > highest_dice)
+                            highest_dice = sides;
+                    }
+                }
+                if (highest_dice != 0) {
+                    crit_damages.push(`${savage}d${highest_dice}`);
+                    crit_damage_types.push("Savage Attacks");
                 }
             }
             roll_properties["critical-damages"] = crit_damages;

--- a/dist/dndbeyond_monster.js
+++ b/dist/dndbeyond_monster.js
@@ -500,8 +500,14 @@ const character_settings = {
         "default": false
     },
     "brutal-critical": {
-        "title": "Brutal Critical/Savage Attacks: Roll extra die",
-        "description": "Roll extra damage die on crit for Brutal Critical and Savage Attacks features",
+        "title": "Brutal Critical: Roll extra die",
+        "description": "Roll extra damage die on crit for Brutal Critical feature",
+        "type": "bool",
+        "default": true
+    },
+    "savage-attacks": {
+        "title": "Savage Attacks: Roll extra die",
+        "description": "Roll extra damage die on crit for Savage Attacks feature",
         "type": "bool",
         "default": true
     },
@@ -2673,7 +2679,7 @@ function damagesToCrits(character, damages) {
     return crits;
 }
 
-function buildAttackRoll(character, attack_source, name, description, properties, damages = [], damage_types = [], to_hit = null, brutal = 0) {
+function buildAttackRoll(character, attack_source, name, description, properties, damages = [], damage_types = [], to_hit = null, brutal = 0, savage = 0) {
     const roll_properties = {
         "name": name,
         "attack-source": attack_source,
@@ -2736,6 +2742,21 @@ function buildAttackRoll(character, attack_source, name, description, properties
                 if (highest_dice != 0) {
                     crit_damages.push(`${brutal}d${highest_dice}`);
                     crit_damage_types.push("Brutal");
+                }
+            }
+            if (savage > 0) {
+                let highest_dice = 0;
+                for (let dmg of crit_damages) {
+                    const match = dmg.match(/[0-9]*d([0-9]+)/);
+                    if (match !== undefined) {
+                        const sides = parseInt(match[1]);
+                        if (sides > highest_dice)
+                            highest_dice = sides;
+                    }
+                }
+                if (highest_dice != 0) {
+                    crit_damages.push(`${savage}d${highest_dice}`);
+                    crit_damage_types.push("Savage Attacks");
                 }
             }
             roll_properties["critical-damages"] = crit_damages;

--- a/dist/dndbeyond_spell.js
+++ b/dist/dndbeyond_spell.js
@@ -500,8 +500,14 @@ const character_settings = {
         "default": false
     },
     "brutal-critical": {
-        "title": "Brutal Critical/Savage Attacks: Roll extra die",
-        "description": "Roll extra damage die on crit for Brutal Critical and Savage Attacks features",
+        "title": "Brutal Critical: Roll extra die",
+        "description": "Roll extra damage die on crit for Brutal Critical feature",
+        "type": "bool",
+        "default": true
+    },
+    "savage-attacks": {
+        "title": "Savage Attacks: Roll extra die",
+        "description": "Roll extra damage die on crit for Savage Attacks feature",
         "type": "bool",
         "default": true
     },
@@ -2673,7 +2679,7 @@ function damagesToCrits(character, damages) {
     return crits;
 }
 
-function buildAttackRoll(character, attack_source, name, description, properties, damages = [], damage_types = [], to_hit = null, brutal = 0) {
+function buildAttackRoll(character, attack_source, name, description, properties, damages = [], damage_types = [], to_hit = null, brutal = 0, savage = 0) {
     const roll_properties = {
         "name": name,
         "attack-source": attack_source,
@@ -2736,6 +2742,21 @@ function buildAttackRoll(character, attack_source, name, description, properties
                 if (highest_dice != 0) {
                     crit_damages.push(`${brutal}d${highest_dice}`);
                     crit_damage_types.push("Brutal");
+                }
+            }
+            if (savage > 0) {
+                let highest_dice = 0;
+                for (let dmg of crit_damages) {
+                    const match = dmg.match(/[0-9]*d([0-9]+)/);
+                    if (match !== undefined) {
+                        const sides = parseInt(match[1]);
+                        if (sides > highest_dice)
+                            highest_dice = sides;
+                    }
+                }
+                if (highest_dice != 0) {
+                    crit_damages.push(`${savage}d${highest_dice}`);
+                    crit_damage_types.push("Savage Attacks");
                 }
             }
             roll_properties["critical-damages"] = crit_damages;

--- a/dist/dndbeyond_vehicle.js
+++ b/dist/dndbeyond_vehicle.js
@@ -500,8 +500,14 @@ const character_settings = {
         "default": false
     },
     "brutal-critical": {
-        "title": "Brutal Critical/Savage Attacks: Roll extra die",
-        "description": "Roll extra damage die on crit for Brutal Critical and Savage Attacks features",
+        "title": "Brutal Critical: Roll extra die",
+        "description": "Roll extra damage die on crit for Brutal Critical feature",
+        "type": "bool",
+        "default": true
+    },
+    "savage-attacks": {
+        "title": "Savage Attacks: Roll extra die",
+        "description": "Roll extra damage die on crit for Savage Attacks feature",
         "type": "bool",
         "default": true
     },
@@ -2673,7 +2679,7 @@ function damagesToCrits(character, damages) {
     return crits;
 }
 
-function buildAttackRoll(character, attack_source, name, description, properties, damages = [], damage_types = [], to_hit = null, brutal = 0) {
+function buildAttackRoll(character, attack_source, name, description, properties, damages = [], damage_types = [], to_hit = null, brutal = 0, savage = 0) {
     const roll_properties = {
         "name": name,
         "attack-source": attack_source,
@@ -2736,6 +2742,21 @@ function buildAttackRoll(character, attack_source, name, description, properties
                 if (highest_dice != 0) {
                     crit_damages.push(`${brutal}d${highest_dice}`);
                     crit_damage_types.push("Brutal");
+                }
+            }
+            if (savage > 0) {
+                let highest_dice = 0;
+                for (let dmg of crit_damages) {
+                    const match = dmg.match(/[0-9]*d([0-9]+)/);
+                    if (match !== undefined) {
+                        const sides = parseInt(match[1]);
+                        if (sides > highest_dice)
+                            highest_dice = sides;
+                    }
+                }
+                if (highest_dice != 0) {
+                    crit_damages.push(`${savage}d${highest_dice}`);
+                    crit_damage_types.push("Savage Attacks");
                 }
             }
             roll_properties["critical-damages"] = crit_damages;

--- a/dist/fvtt.js
+++ b/dist/fvtt.js
@@ -500,8 +500,14 @@ const character_settings = {
         "default": false
     },
     "brutal-critical": {
-        "title": "Brutal Critical/Savage Attacks: Roll extra die",
-        "description": "Roll extra damage die on crit for Brutal Critical and Savage Attacks features",
+        "title": "Brutal Critical: Roll extra die",
+        "description": "Roll extra damage die on crit for Brutal Critical feature",
+        "type": "bool",
+        "default": true
+    },
+    "savage-attacks": {
+        "title": "Savage Attacks: Roll extra die",
+        "description": "Roll extra damage die on crit for Savage Attacks feature",
         "type": "bool",
         "default": true
     },

--- a/dist/fvtt_script.js
+++ b/dist/fvtt_script.js
@@ -501,8 +501,14 @@ const character_settings = {
         "default": false
     },
     "brutal-critical": {
-        "title": "Brutal Critical/Savage Attacks: Roll extra die",
-        "description": "Roll extra damage die on crit for Brutal Critical and Savage Attacks features",
+        "title": "Brutal Critical: Roll extra die",
+        "description": "Roll extra damage die on crit for Brutal Critical feature",
+        "type": "bool",
+        "default": true
+    },
+    "savage-attacks": {
+        "title": "Savage Attacks: Roll extra die",
+        "description": "Roll extra damage die on crit for Savage Attacks feature",
         "type": "bool",
         "default": true
     },

--- a/dist/options.js
+++ b/dist/options.js
@@ -500,8 +500,14 @@ const character_settings = {
         "default": false
     },
     "brutal-critical": {
-        "title": "Brutal Critical/Savage Attacks: Roll extra die",
-        "description": "Roll extra damage die on crit for Brutal Critical and Savage Attacks features",
+        "title": "Brutal Critical: Roll extra die",
+        "description": "Roll extra damage die on crit for Brutal Critical feature",
+        "type": "bool",
+        "default": true
+    },
+    "savage-attacks": {
+        "title": "Savage Attacks: Roll extra die",
+        "description": "Roll extra damage die on crit for Savage Attacks feature",
         "type": "bool",
         "default": true
     },

--- a/dist/popup.js
+++ b/dist/popup.js
@@ -545,8 +545,14 @@ const character_settings = {
         "default": false
     },
     "brutal-critical": {
-        "title": "Brutal Critical/Savage Attacks: Roll extra die",
-        "description": "Roll extra damage die on crit for Brutal Critical and Savage Attacks features",
+        "title": "Brutal Critical: Roll extra die",
+        "description": "Roll extra damage die on crit for Brutal Critical feature",
+        "type": "bool",
+        "default": true
+    },
+    "savage-attacks": {
+        "title": "Savage Attacks: Roll extra die",
+        "description": "Roll extra damage die on crit for Savage Attacks feature",
         "type": "bool",
         "default": true
     },
@@ -1186,9 +1192,12 @@ function populateCharacter(response) {
             e = createHTMLOption("great-weapon-master", false, character_settings);
             options.append(e);
         }
-        if (response["class-features"].includes("Brutal Critical") ||
-            response["racial-traits"].includes("Savage Attacks")) {
+        if (response["class-features"].includes("Brutal Critical")) {
             e = createHTMLOption("brutal-critical", false, character_settings);
+            options.append(e);
+        }
+        if (response["racial-traits"].includes("Savage Attacks")) {
+            e = createHTMLOption("savage-attacks", false, character_settings);
             options.append(e);
         }
         if (response["class-features"].includes("Rage")) {

--- a/dist/roll20.js
+++ b/dist/roll20.js
@@ -500,8 +500,14 @@ const character_settings = {
         "default": false
     },
     "brutal-critical": {
-        "title": "Brutal Critical/Savage Attacks: Roll extra die",
-        "description": "Roll extra damage die on crit for Brutal Critical and Savage Attacks features",
+        "title": "Brutal Critical: Roll extra die",
+        "description": "Roll extra damage die on crit for Brutal Critical feature",
+        "type": "bool",
+        "default": true
+    },
+    "savage-attacks": {
+        "title": "Savage Attacks: Roll extra die",
+        "description": "Roll extra damage die on crit for Savage Attacks feature",
         "type": "bool",
         "default": true
     },

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -347,8 +347,14 @@ const character_settings = {
         "default": false
     },
     "brutal-critical": {
-        "title": "Brutal Critical/Savage Attacks: Roll extra die",
-        "description": "Roll extra damage die on crit for Brutal Critical and Savage Attacks features",
+        "title": "Brutal Critical: Roll extra die",
+        "description": "Roll extra damage die on crit for Brutal Critical feature",
+        "type": "bool",
+        "default": true
+    },
+    "savage-attacks": {
+        "title": "Savage Attacks: Roll extra die",
+        "description": "Roll extra damage die on crit for Savage Attacks feature",
         "type": "bool",
         "default": true
     },

--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -91,7 +91,7 @@ function damagesToCrits(character, damages) {
     return crits;
 }
 
-function buildAttackRoll(character, attack_source, name, description, properties, damages = [], damage_types = [], to_hit = null, brutal = 0) {
+function buildAttackRoll(character, attack_source, name, description, properties, damages = [], damage_types = [], to_hit = null, brutal = 0, savage = 0) {
     const roll_properties = {
         "name": name,
         "attack-source": attack_source,
@@ -154,6 +154,21 @@ function buildAttackRoll(character, attack_source, name, description, properties
                 if (highest_dice != 0) {
                     crit_damages.push(`${brutal}d${highest_dice}`);
                     crit_damage_types.push("Brutal");
+                }
+            }
+            if (savage > 0) {
+                let highest_dice = 0;
+                for (let dmg of crit_damages) {
+                    const match = dmg.match(/[0-9]*d([0-9]+)/);
+                    if (match !== undefined) {
+                        const sides = parseInt(match[1]);
+                        if (sides > highest_dice)
+                            highest_dice = sides;
+                    }
+                }
+                if (highest_dice != 0) {
+                    crit_damages.push(`${savage}d${highest_dice}`);
+                    crit_damage_types.push("Savage Attacks");
                 }
             }
             roll_properties["critical-damages"] = crit_damages;

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -351,8 +351,13 @@ function rollItem(force_display = false) {
                     const barbarian_level = character.getClassLevel("Barbarian");
                     brutal += 1 + Math.floor((barbarian_level - 9) / 4);
                 }
+            }
+        }
+        let savage = 0;
+        if (properties["Attack Type"] == "Melee") {
+            if (character.getSetting("savage-attacks")) {
                 if (character.hasRacialTrait("Savage Attacks"))
-                    brutal += 1;
+                    savage += 1;
             }
         }
         const roll_properties = buildAttackRoll(character,
@@ -363,7 +368,8 @@ function rollItem(force_display = false) {
             damages,
             damage_types,
             to_hit,
-            brutal);
+            brutal,
+            savage);
         roll_properties["item-type"] = item_type;
         if (critical_limit != 20)
             roll_properties["critical-limit"] = critical_limit;
@@ -437,6 +443,7 @@ function rollAction(paneClass) {
         }
 
         let brutal = 0;
+        let savage = 0;
         let critical_limit = 20;
         if (character.hasClassFeature("Hexblade’s Curse") &&
             character.getSetting("warlock-hexblade-curse", false))
@@ -452,25 +459,28 @@ function rollAction(paneClass) {
                 critical_limit = 19;
             if (character.hasClassFeature("Superior Critical"))
                 critical_limit = 18;
-
             if (character.getSetting("brutal-critical")) {
                 if (character.hasClassFeature("Brutal Critical")) {
                     const barbarian_level = character.getClassLevel("Barbarian");
                     brutal += 1 + Math.floor((barbarian_level - 9) / 4);
                 }
-                if (character.hasRacialTrait("Savage Attacks"))
-                    brutal += 1;
             }
+            if (character.hasClassFeature("Giant Might") && character.getSetting("fighter-giant-might", false)) {
+                const fighter_level = character.getClassLevel("Fighter");
+                damages.push(fighter_level < 10 ? "1d6" : "1d8");
+                damage_types.push("Giant Might");
+            }
+        }
+        if (action_name == "Polearm Master - Bonus Attack" || action_name == "Unarmed Strike") {
             if (character.hasClassFeature("Rage") && character.getSetting("barbarian-rage", false)) {
                 const barbarian_level = character.getClassLevel("Barbarian");
                 const rage_damage = barbarian_level < 9 ? 2 : (barbarian_level < 16 ? 3 : 4);
                 damages.push(String(rage_damage));
                 damage_types.push("Rage");
             }
-            if (character.hasClassFeature("Giant Might") && character.getSetting("fighter-giant-might", false)) {
-                const fighter_level = character.getClassLevel("Fighter");
-                damages.push(fighter_level < 10 ? "1d6" : "1d8");
-                damage_types.push("Giant Might");
+            if (character.getSetting("savage-attacks")) {
+                if (character.hasRacialTrait("Savage Attacks"))
+                    savage += 1;
             }
         }
 
@@ -489,7 +499,8 @@ function rollAction(paneClass) {
             damages,
             damage_types,
             properties["To Hit"] !== undefined ? properties["To Hit"] : null,
-            brutal);
+            brutal,
+            savage);
 
         if (critical_limit != 20)
             roll_properties["critical-limit"] = critical_limit;

--- a/src/extension/popup.js
+++ b/src/extension/popup.js
@@ -114,9 +114,12 @@ function populateCharacter(response) {
             e = createHTMLOption("great-weapon-master", false, character_settings);
             options.append(e);
         }
-        if (response["class-features"].includes("Brutal Critical") ||
-            response["racial-traits"].includes("Savage Attacks")) {
+        if (response["class-features"].includes("Brutal Critical")) {
             e = createHTMLOption("brutal-critical", false, character_settings);
+            options.append(e);
+        }
+        if (response["racial-traits"].includes("Savage Attacks")) {
+            e = createHTMLOption("savage-attacks", false, character_settings);
             options.append(e);
         }
         if (response["class-features"].includes("Rage")) {


### PR DESCRIPTION
Separate Savage Attacks from Brutal Critical
Unarmed Strikes considered a "Melee Weapon Attack"
https://twitter.com/JeremyECrawford/status/608776737917263872
Unarmed Strike should take Rage Damage
Unarmed Strike for a Half-Orc Monk should take Savage Attacks, as Unarmed Strikes (in that case) has a damage die
Also covers any Half-Orc Unarmed Strike with "Tavern Brawler" Feat
https://www.dndbeyond.com/feats/tavern-brawler