### PR TITLE
Beyond20 inside frames

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -58,7 +58,8 @@
 				"libs/alertify.min.js",
 				"libs/jquery-3.4.1.min.js",
 				"dist/dndbeyond_character.js"
-			]
+			],
+			"all_frames":true
 		},
 		{
 			"matches": [
@@ -74,7 +75,8 @@
 				"libs/alertify.min.js",
 				"libs/jquery-3.4.1.min.js",
 				"dist/dndbeyond_monster.js"
-			]
+			],
+			"all_frames": true
 		},
 		{
 			"matches": [
@@ -90,7 +92,8 @@
 				"libs/alertify.min.js",
 				"libs/jquery-3.4.1.min.js",
 				"dist/dndbeyond_vehicle.js"
-			]
+			],
+			"all_frames": true
 		},
 		{
 			"matches": [
@@ -106,7 +109,8 @@
 				"libs/alertify.min.js",
 				"libs/jquery-3.4.1.min.js",
 				"dist/dndbeyond_spell.js"
-			]
+			],
+			"all_frames": true
 		},
 		{
 			"matches": [
@@ -124,7 +128,8 @@
 				"libs/alertify.min.js",
 				"libs/jquery-3.4.1.min.js",
 				"dist/dndbeyond_encounter.js"
-			]
+			],
+			"all_frames": true
 		},
 		{
 			"matches": [
@@ -141,7 +146,8 @@
 				"libs/alertify.min.js",
 				"libs/jquery-3.4.1.min.js",
 				"dist/dndbeyond_item.js"
-			]
+			],
+			"all_frames": true
 		},
 		{
 			"matches": [

--- a/manifest_ff.json
+++ b/manifest_ff.json
@@ -61,7 +61,8 @@
 				"libs/alertify.min.js",
 				"libs/jquery-3.4.1.min.js",
 				"src/dndbeyond_character.js"
-			]
+			],
+			"all_frames": true
 		},
 		{
 			"matches": [
@@ -77,7 +78,8 @@
 				"libs/alertify.min.js",
 				"libs/jquery-3.4.1.min.js",
 				"src/dndbeyond_monster.js"
-			]
+			],
+			"all_frames": true
 		},
 		{
 			"matches": [
@@ -93,7 +95,8 @@
 				"libs/alertify.min.js",
 				"libs/jquery-3.4.1.min.js",
 				"src/dndbeyond_vehicle.js"
-			]
+			],
+			"all_frames": true
 		},
 		{
 			"matches": [
@@ -109,7 +112,8 @@
 				"libs/alertify.min.js",
 				"libs/jquery-3.4.1.min.js",
 				"src/dndbeyond_spell.js"
-			]
+			],
+			"all_frames": true
 		},
 		{
 			"matches": [
@@ -127,7 +131,8 @@
 				"libs/alertify.min.js",
 				"libs/jquery-3.4.1.min.js",
 				"src/dndbeyond_encounter.js"
-			]
+			],
+			"all_frames": true
 		},
 		{
 			"matches": [
@@ -144,7 +149,8 @@
 				"libs/alertify.min.js",
 				"libs/jquery-3.4.1.min.js",
 				"src/dndbeyond_items.js"
-			]
+			],
+			"all_frames": true
 		},
 		{
 			"matches": [


### PR DESCRIPTION
added `"all_frames": true` to the content scripts inside the manifest. This allows beyond20 to work inside iframes (which I want to have, because I'm writing a DM-Screen Plugin with an optional iframe for the character sheet)