### PR TITLE
Add workaround for background images swallowing mouse events for saving throw quickrolls.

### DIFF
--- a/dist/beyond20.css
+++ b/dist/beyond20.css
@@ -80,7 +80,7 @@
 .beyond20-roll-die-result {
     flex: 1 0 auto;
     margin: 1px;
- 
+
     text-align: center;
     border: thin solid black;
     border-radius: 2px;
@@ -152,4 +152,9 @@
 }
 .beyond20-form-row > * {
     flex: 2;
+}
+
+/* Prevent background / border images from swallowing quickroll mouse events */
+.ddbc-box-background {
+    pointer-events: none;
 }

--- a/src/extension/beyond20.css
+++ b/src/extension/beyond20.css
@@ -80,7 +80,7 @@
 .beyond20-roll-die-result {
     flex: 1 0 auto;
     margin: 1px;
- 
+
     text-align: center;
     border: thin solid black;
     border-radius: 2px;
@@ -152,4 +152,9 @@
 }
 .beyond20-form-row > * {
     flex: 2;
+}
+
+/* Prevent background / border images from swallowing quickroll mouse events */
+.ddbc-box-background {
+    pointer-events: none;
 }


### PR DESCRIPTION
This fixes #290.

Feel free to merge or ignore and implement yourself however you'd prefer :)