### PR TITLE
Savage Attacks Clarification

### DIFF
--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -2733,7 +2733,8 @@ function buildAttackRoll(character, attack_source, name, description, properties
                 }
                 if (highest_dice != 0) {
                     crit_damages.push(`${brutal}d${highest_dice}`);
-                    crit_damage_types.push("Brutal");
+                    crit_damage_types.push(character.hasClassFeature("Brutal Critical") && character.hasRacialTrait("Savage Attacks") ?
+                    "Savage Attacks & Brutal" :  character.hasClassFeature("Brutal Critical") ? "Brutal" : "Savage");
                 }
             }
             roll_properties["critical-damages"] = crit_damages;

--- a/dist/dndbeyond_encounter.js
+++ b/dist/dndbeyond_encounter.js
@@ -2733,7 +2733,8 @@ function buildAttackRoll(character, attack_source, name, description, properties
                 }
                 if (highest_dice != 0) {
                     crit_damages.push(`${brutal}d${highest_dice}`);
-                    crit_damage_types.push("Brutal");
+                    crit_damage_types.push(character.hasClassFeature("Brutal Critical") && character.hasRacialTrait("Savage Attacks") ?
+                    "Savage Attacks & Brutal" :  character.hasClassFeature("Brutal Critical") ? "Brutal" : "Savage");
                 }
             }
             roll_properties["critical-damages"] = crit_damages;

--- a/dist/dndbeyond_item.js
+++ b/dist/dndbeyond_item.js
@@ -2733,7 +2733,8 @@ function buildAttackRoll(character, attack_source, name, description, properties
                 }
                 if (highest_dice != 0) {
                     crit_damages.push(`${brutal}d${highest_dice}`);
-                    crit_damage_types.push("Brutal");
+                    crit_damage_types.push(character.hasClassFeature("Brutal Critical") && character.hasRacialTrait("Savage Attacks") ?
+                    "Savage Attacks & Brutal" :  character.hasClassFeature("Brutal Critical") ? "Brutal" : "Savage");
                 }
             }
             roll_properties["critical-damages"] = crit_damages;

--- a/dist/dndbeyond_monster.js
+++ b/dist/dndbeyond_monster.js
@@ -2733,7 +2733,8 @@ function buildAttackRoll(character, attack_source, name, description, properties
                 }
                 if (highest_dice != 0) {
                     crit_damages.push(`${brutal}d${highest_dice}`);
-                    crit_damage_types.push("Brutal");
+                    crit_damage_types.push(character.hasClassFeature("Brutal Critical") && character.hasRacialTrait("Savage Attacks") ?
+                    "Savage Attacks & Brutal" :  character.hasClassFeature("Brutal Critical") ? "Brutal" : "Savage");
                 }
             }
             roll_properties["critical-damages"] = crit_damages;

--- a/dist/dndbeyond_spell.js
+++ b/dist/dndbeyond_spell.js
@@ -2733,7 +2733,8 @@ function buildAttackRoll(character, attack_source, name, description, properties
                 }
                 if (highest_dice != 0) {
                     crit_damages.push(`${brutal}d${highest_dice}`);
-                    crit_damage_types.push("Brutal");
+                    crit_damage_types.push(character.hasClassFeature("Brutal Critical") && character.hasRacialTrait("Savage Attacks") ?
+                    "Savage Attacks & Brutal" :  character.hasClassFeature("Brutal Critical") ? "Brutal" : "Savage");
                 }
             }
             roll_properties["critical-damages"] = crit_damages;

--- a/dist/dndbeyond_vehicle.js
+++ b/dist/dndbeyond_vehicle.js
@@ -2733,7 +2733,8 @@ function buildAttackRoll(character, attack_source, name, description, properties
                 }
                 if (highest_dice != 0) {
                     crit_damages.push(`${brutal}d${highest_dice}`);
-                    crit_damage_types.push("Brutal");
+                    crit_damage_types.push(character.hasClassFeature("Brutal Critical") && character.hasRacialTrait("Savage Attacks") ?
+                    "Savage Attacks & Brutal" :  character.hasClassFeature("Brutal Critical") ? "Brutal" : "Savage");
                 }
             }
             roll_properties["critical-damages"] = crit_damages;

--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -153,7 +153,8 @@ function buildAttackRoll(character, attack_source, name, description, properties
                 }
                 if (highest_dice != 0) {
                     crit_damages.push(`${brutal}d${highest_dice}`);
-                    crit_damage_types.push("Brutal");
+                    crit_damage_types.push(character.hasClassFeature("Brutal Critical") && character.hasRacialTrait("Savage Attacks") ?
+                    "Savage Attacks & Brutal" :  character.hasClassFeature("Brutal Critical") ? "Brutal" : "Savage");
                 }
             }
             roll_properties["critical-damages"] = crit_damages;


### PR DESCRIPTION
Fixes #287

Still leaves the fact that when you "Roll both damages" for a versatile weapon (ie, 1d8 for 1-handed Longsword, 1d10 for 2-handed Longsword) Savage Attacks and Brutal Critical will only roll from the secondary (2-handed) damage die. Not sure how worth it this is to fix.