### PR TITLE
Unarmed Strikes fixes

### DIFF
--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -2721,7 +2721,9 @@ function buildAttackRoll(character, attack_source, name, description, properties
                     crit_damage_types.push(damage_types[i]);
                 }
             }
-            if (brutal > 0) {
+            //Handle Unarmed Strike Critical
+            const main_match = damages[0].match(/[0-9]*d([0-9]+)/);
+            if (brutal > 0 && main_match != null) {
                 let highest_dice = 0;
                 for (let dmg of crit_damages) {
                     const match = dmg.match(/[0-9]*d([0-9]+)/);
@@ -4481,7 +4483,7 @@ function rollAction(paneClass) {
             character.getSetting("warlock-hexblade-curse", false))
             critical_limit = 19;
         // Polearm master bonus attack using the other end of the polearm is considered a melee attack.;
-        if (action_name == "Polearm Master - Bonus Attack") {
+        if (action_name == "Polearm Master - Bonus Attack" || action_name == "Unarmed Strike" || action_name == "Tavern Brawler Strike") {
             if (character.hasClassFeature("Fighting Style: Great Weapon Fighting"))
                 damages[0] = damages[0].replace(/[0-9]*d[0-9]+/g, "$&<=2");
             if (character.hasAction("Channel Divinity: Legendary Strike") &&

--- a/dist/dndbeyond_encounter.js
+++ b/dist/dndbeyond_encounter.js
@@ -2721,7 +2721,9 @@ function buildAttackRoll(character, attack_source, name, description, properties
                     crit_damage_types.push(damage_types[i]);
                 }
             }
-            if (brutal > 0) {
+            //Handle Unarmed Strike Critical
+            const main_match = damages[0].match(/[0-9]*d([0-9]+)/);
+            if (brutal > 0 && main_match != null) {
                 let highest_dice = 0;
                 for (let dmg of crit_damages) {
                     const match = dmg.match(/[0-9]*d([0-9]+)/);

--- a/dist/dndbeyond_item.js
+++ b/dist/dndbeyond_item.js
@@ -2721,7 +2721,9 @@ function buildAttackRoll(character, attack_source, name, description, properties
                     crit_damage_types.push(damage_types[i]);
                 }
             }
-            if (brutal > 0) {
+            //Handle Unarmed Strike Critical
+            const main_match = damages[0].match(/[0-9]*d([0-9]+)/);
+            if (brutal > 0 && main_match != null) {
                 let highest_dice = 0;
                 for (let dmg of crit_damages) {
                     const match = dmg.match(/[0-9]*d([0-9]+)/);

--- a/dist/dndbeyond_monster.js
+++ b/dist/dndbeyond_monster.js
@@ -2721,7 +2721,9 @@ function buildAttackRoll(character, attack_source, name, description, properties
                     crit_damage_types.push(damage_types[i]);
                 }
             }
-            if (brutal > 0) {
+            //Handle Unarmed Strike Critical
+            const main_match = damages[0].match(/[0-9]*d([0-9]+)/);
+            if (brutal > 0 && main_match != null) {
                 let highest_dice = 0;
                 for (let dmg of crit_damages) {
                     const match = dmg.match(/[0-9]*d([0-9]+)/);

--- a/dist/dndbeyond_spell.js
+++ b/dist/dndbeyond_spell.js
@@ -2721,7 +2721,9 @@ function buildAttackRoll(character, attack_source, name, description, properties
                     crit_damage_types.push(damage_types[i]);
                 }
             }
-            if (brutal > 0) {
+            //Handle Unarmed Strike Critical
+            const main_match = damages[0].match(/[0-9]*d([0-9]+)/);
+            if (brutal > 0 && main_match != null) {
                 let highest_dice = 0;
                 for (let dmg of crit_damages) {
                     const match = dmg.match(/[0-9]*d([0-9]+)/);

--- a/dist/dndbeyond_vehicle.js
+++ b/dist/dndbeyond_vehicle.js
@@ -2721,7 +2721,9 @@ function buildAttackRoll(character, attack_source, name, description, properties
                     crit_damage_types.push(damage_types[i]);
                 }
             }
-            if (brutal > 0) {
+            //Handle Unarmed Strike Critical
+            const main_match = damages[0].match(/[0-9]*d([0-9]+)/);
+            if (brutal > 0 && main_match != null) {
                 let highest_dice = 0;
                 for (let dmg of crit_damages) {
                     const match = dmg.match(/[0-9]*d([0-9]+)/);

--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -141,7 +141,9 @@ function buildAttackRoll(character, attack_source, name, description, properties
                     crit_damage_types.push(damage_types[i]);
                 }
             }
-            if (brutal > 0) {
+            //Handle Unarmed Strike Critical
+            const main_match = damages[0].match(/[0-9]*d([0-9]+)/);
+            if (brutal > 0 && main_match != null) {
                 let highest_dice = 0;
                 for (let dmg of crit_damages) {
                     const match = dmg.match(/[0-9]*d([0-9]+)/);

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -449,7 +449,7 @@ function rollAction(paneClass) {
             character.getSetting("warlock-hexblade-curse", false))
             critical_limit = 19;
         // Polearm master bonus attack using the other end of the polearm is considered a melee attack.;
-        if (action_name == "Polearm Master - Bonus Attack") {
+        if (action_name == "Polearm Master - Bonus Attack" || action_name == "Unarmed Strike" || action_name == "Tavern Brawler Strike") {
             if (character.hasClassFeature("Fighting Style: Great Weapon Fighting"))
                 damages[0] = damages[0].replace(/[0-9]*d[0-9]+/g, "$&<=2");
             if (character.hasAction("Channel Divinity: Legendary Strike") &&


### PR DESCRIPTION
Applies only if Unarmed Strike has a Damage Die
Works for "Tavern Brawler Strike" as well
Examples:
Monk (1d4)
Tavern Brawler Feat (1d4)
Alter Self cast on Character (1d6)

Fixes edge case where other Critical Damages exist, as these should not be considered for a non-damage die Unarmed Strike