### PR TITLE
Cleaner Psychic Blade Sneak Attack Fix

### DIFF
--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -4503,7 +4503,8 @@ function rollAction(paneClass) {
             character.getSetting("warlock-hexblade-curse", false))
             critical_limit = 19;
         // Polearm master bonus attack using the other end of the polearm is considered a melee attack.
-        if (action_name == "Polearm Master - Bonus Attack" || action_name.includes("Unarmed Strike") || action_name == "Tavern Brawler Strike") {
+        if (action_name == "Polearm Master - Bonus Attack" || action_name.includes("Unarmed Strike") || action_name == "Tavern Brawler Strike"
+            || action_name.includes("Psychic Blade")) {
             if (character.hasClassFeature("Fighting Style: Great Weapon Fighting"))
                 damages[0] = damages[0].replace(/[0-9]*d[0-9]+/g, "$&<=2");
             if (character.hasAction("Channel Divinity: Legendary Strike") &&
@@ -4535,21 +4536,21 @@ function rollAction(paneClass) {
             }
             if (character.getSetting("bloodhunter-crimson-rite", false) &&
             character.hasClassFeature("Crimson Rite")) {
-            const bloodhunter_level = character.getClassLevel("Blood Hunter");
-            if (bloodhunter_level > 0) {
-                let rite_die = "1d4";
-                if (bloodhunter_level <= 4)
-                    rite_die = "1d4";
-                else if (bloodhunter_level <= 10)
-                    rite_die = "1d6";
-                else if (bloodhunter_level <= 16)
-                    rite_die = "1d8";
-                else
-                    rite_die = "1d10";
-                damages.push(rite_die);
-                damage_types.push("Crimson Rite");
+                const bloodhunter_level = character.getClassLevel("Blood Hunter");
+                if (bloodhunter_level > 0) {
+                    let rite_die = "1d4";
+                    if (bloodhunter_level <= 4)
+                        rite_die = "1d4";
+                    else if (bloodhunter_level <= 10)
+                        rite_die = "1d6";
+                    else if (bloodhunter_level <= 16)
+                        rite_die = "1d8";
+                    else
+                        rite_die = "1d10";
+                    damages.push(rite_die);
+                    damage_types.push("Crimson Rite");
+                }
             }
-        }
         }
 
         //Protector Aasimar: Radiant Soul Damage

--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -4551,6 +4551,14 @@ function rollAction(paneClass) {
                     damage_types.push("Crimson Rite");
                 }
             }
+            if (action_name.includes("Psychic Blade")) {
+                if (character.hasClass("Rogue") &&
+                    character.getSetting("rogue-sneak-attack", false)) {
+                    const sneak_attack = Math.ceil(character._classes["Rogue"] / 2) + "d6";
+                    damages.push(sneak_attack);
+                    damage_types.push("Sneak Attack");
+                }
+            }
         }
 
         //Protector Aasimar: Radiant Soul Damage

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -500,6 +500,14 @@ function rollAction(paneClass) {
                     damage_types.push("Crimson Rite");
                 }
             }
+            if (action_name.includes("Psychic Blade")) {
+                if (character.hasClass("Rogue") &&
+                    character.getSetting("rogue-sneak-attack", false)) {
+                    const sneak_attack = Math.ceil(character._classes["Rogue"] / 2) + "d6";
+                    damages.push(sneak_attack);
+                    damage_types.push("Sneak Attack");
+                }
+            }
         }
 
         //Protector Aasimar: Radiant Soul Damage

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -452,7 +452,8 @@ function rollAction(paneClass) {
             character.getSetting("warlock-hexblade-curse", false))
             critical_limit = 19;
         // Polearm master bonus attack using the other end of the polearm is considered a melee attack.
-        if (action_name == "Polearm Master - Bonus Attack" || action_name.includes("Unarmed Strike") || action_name == "Tavern Brawler Strike") {
+        if (action_name == "Polearm Master - Bonus Attack" || action_name.includes("Unarmed Strike") || action_name == "Tavern Brawler Strike"
+            || action_name.includes("Psychic Blade")) {
             if (character.hasClassFeature("Fighting Style: Great Weapon Fighting"))
                 damages[0] = damages[0].replace(/[0-9]*d[0-9]+/g, "$&<=2");
             if (character.hasAction("Channel Divinity: Legendary Strike") &&
@@ -484,21 +485,21 @@ function rollAction(paneClass) {
             }
             if (character.getSetting("bloodhunter-crimson-rite", false) &&
             character.hasClassFeature("Crimson Rite")) {
-            const bloodhunter_level = character.getClassLevel("Blood Hunter");
-            if (bloodhunter_level > 0) {
-                let rite_die = "1d4";
-                if (bloodhunter_level <= 4)
-                    rite_die = "1d4";
-                else if (bloodhunter_level <= 10)
-                    rite_die = "1d6";
-                else if (bloodhunter_level <= 16)
-                    rite_die = "1d8";
-                else
-                    rite_die = "1d10";
-                damages.push(rite_die);
-                damage_types.push("Crimson Rite");
+                const bloodhunter_level = character.getClassLevel("Blood Hunter");
+                if (bloodhunter_level > 0) {
+                    let rite_die = "1d4";
+                    if (bloodhunter_level <= 4)
+                        rite_die = "1d4";
+                    else if (bloodhunter_level <= 10)
+                        rite_die = "1d6";
+                    else if (bloodhunter_level <= 16)
+                        rite_die = "1d8";
+                    else
+                        rite_die = "1d10";
+                    damages.push(rite_die);
+                    damage_types.push("Crimson Rite");
+                }
             }
-        }
         }
 
         //Protector Aasimar: Radiant Soul Damage


### PR DESCRIPTION
Fixes #311

Rogue Soulknife (UA): Psychic Blades
3rd-level Soulknife feature

You can manifest your psionic power as shimmering blades of psychic energy. When you are about to make a melee or ranged weapon attack against a creature, you can manifest a psychic blade from your free hand and make the attack with that blade. This magic blade is a simple melee weapon with the finesse and thrown properties.

Sneak Attack
Beginning at 1st level, you know how to strike subtly and exploit a foe’s distraction. Once per turn, you can deal an extra 1d6 damage to one creature you hit with an attack if you have advantage on the attack roll. The attack must use a finesse or a ranged weapon

Sneak Attack should therefore apply to Psychic Blades (handled through rollAction).