### PR TITLE
Fixes Elemental Adept & Flames of Phlegethos mixed

### DIFF
--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -4704,8 +4704,8 @@ function rollSpell(force_display = false) {
         for (let elementalAdept of elementalAdepts) {
             for (let i = 0; i < damages.length; i++) {
                 if (damage_types[i] === elementalAdept) {
-                    damages[i] = damages[i].replace(/([0-9]*)d([0-9]+)(.*)/g, (match, amount, faces, mods) => {
-                        return new Array(parseInt(amount) || 1).fill(`1d${faces}min2`).join(" + ") + mods;
+                    damages[i] = damages[i].replace(/([0-9]*)d([0-9]+)(ro<=?[0-9]+)(.*)/g, (match, amount, faces,roll_mods, mods) => {
+                        return new Array(parseInt(amount) || 1).fill(`1d${faces}${roll_mods}min2`).join(" + ") + mods;
                     });
                 }
             }

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -653,8 +653,8 @@ function rollSpell(force_display = false) {
         for (let elementalAdept of elementalAdepts) {
             for (let i = 0; i < damages.length; i++) {
                 if (damage_types[i] === elementalAdept) {
-                    damages[i] = damages[i].replace(/([0-9]*)d([0-9]+)(.*)/g, (match, amount, faces, mods) => {
-                        return new Array(parseInt(amount) || 1).fill(`1d${faces}min2`).join(" + ") + mods;
+                    damages[i] = damages[i].replace(/([0-9]*)d([0-9]+)(ro<=?[0-9]+)(.*)/g, (match, amount, faces,roll_mods, mods) => {
+                        return new Array(parseInt(amount) || 1).fill(`1d${faces}${roll_mods}min2`).join(" + ") + mods;
                     });
                 }
             }


### PR DESCRIPTION
Changes order of operations to apply Elemental Adept

This allows Elemental Adept to have broken damages apart to add "min2" to each damage die, and THEN add the r<=1 to each individual damage die

Fixes #321