### PR TITLE
Implement Various (specifically named) Natural Weapons

### DIFF
--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -4670,7 +4670,7 @@ function rollAction(paneClass) {
         // Polearm master bonus attack using the other end of the polearm is considered a melee attack.
         if (action_name == "Polearm Master - Bonus Attack" || action_name.includes("Unarmed Strike") || action_name == "Tavern Brawler Strike"
             || action_name.includes("Psychic Blade") || action_name.includes("Bite") || action_name.includes("Claws") || action_name.includes("Tail")
-            || action_name.includes("Ram") || action_name.includes("Horns")) {
+            || action_name.includes("Ram") || action_name.includes("Horns") || action_name.includes("Hooves")) {
             if (character.hasClassFeature("Fighting Style: Great Weapon Fighting"))
                 damages[0] = damages[0].replace(/[0-9]*d[0-9]+/g, "$&<=2");
             if (character.hasAction("Channel Divinity: Legendary Strike") &&

--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -4669,7 +4669,7 @@ function rollAction(paneClass) {
             critical_limit = 19;
         // Polearm master bonus attack using the other end of the polearm is considered a melee attack.
         if (action_name == "Polearm Master - Bonus Attack" || action_name.includes("Unarmed Strike") || action_name == "Tavern Brawler Strike"
-            || action_name.includes("Psychic Blade")) {
+            || action_name.includes("Psychic Blade") || action_name.includes("Bite") || action_name.includes("Claws") || action_name.includes("Tail")) {
             if (character.hasClassFeature("Fighting Style: Great Weapon Fighting"))
                 damages[0] = damages[0].replace(/[0-9]*d[0-9]+/g, "$&<=2");
             if (character.hasAction("Channel Divinity: Legendary Strike") &&

--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -4670,7 +4670,7 @@ function rollAction(paneClass) {
         // Polearm master bonus attack using the other end of the polearm is considered a melee attack.
         if (action_name == "Polearm Master - Bonus Attack" || action_name.includes("Unarmed Strike") || action_name == "Tavern Brawler Strike"
             || action_name.includes("Psychic Blade") || action_name.includes("Bite") || action_name.includes("Claws") || action_name.includes("Tail")
-            || action_name.includes("Ram")) {
+            || action_name.includes("Ram") || action_name.includes("Horns")) {
             if (character.hasClassFeature("Fighting Style: Great Weapon Fighting"))
                 damages[0] = damages[0].replace(/[0-9]*d[0-9]+/g, "$&<=2");
             if (character.hasAction("Channel Divinity: Legendary Strike") &&

--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -4669,7 +4669,8 @@ function rollAction(paneClass) {
             critical_limit = 19;
         // Polearm master bonus attack using the other end of the polearm is considered a melee attack.
         if (action_name == "Polearm Master - Bonus Attack" || action_name.includes("Unarmed Strike") || action_name == "Tavern Brawler Strike"
-            || action_name.includes("Psychic Blade") || action_name.includes("Bite") || action_name.includes("Claws") || action_name.includes("Tail")) {
+            || action_name.includes("Psychic Blade") || action_name.includes("Bite") || action_name.includes("Claws") || action_name.includes("Tail")
+            || action_name.includes("Ram")) {
             if (character.hasClassFeature("Fighting Style: Great Weapon Fighting"))
                 damages[0] = damages[0].replace(/[0-9]*d[0-9]+/g, "$&<=2");
             if (character.hasAction("Channel Divinity: Legendary Strike") &&

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -454,7 +454,7 @@ function rollAction(paneClass) {
         // Polearm master bonus attack using the other end of the polearm is considered a melee attack.
         if (action_name == "Polearm Master - Bonus Attack" || action_name.includes("Unarmed Strike") || action_name == "Tavern Brawler Strike"
             || action_name.includes("Psychic Blade") || action_name.includes("Bite") || action_name.includes("Claws") || action_name.includes("Tail")
-            || action_name.includes("Ram") || action_name.includes("Horns")) {
+            || action_name.includes("Ram") || action_name.includes("Horns") || action_name.includes("Hooves")) {
             if (character.hasClassFeature("Fighting Style: Great Weapon Fighting"))
                 damages[0] = damages[0].replace(/[0-9]*d[0-9]+/g, "$&<=2");
             if (character.hasAction("Channel Divinity: Legendary Strike") &&

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -453,7 +453,7 @@ function rollAction(paneClass) {
             critical_limit = 19;
         // Polearm master bonus attack using the other end of the polearm is considered a melee attack.
         if (action_name == "Polearm Master - Bonus Attack" || action_name.includes("Unarmed Strike") || action_name == "Tavern Brawler Strike"
-            || action_name.includes("Psychic Blade")) {
+            || action_name.includes("Psychic Blade") || action_name.includes("Bite") || action_name.includes("Claws") || action_name.includes("Tail")) {
             if (character.hasClassFeature("Fighting Style: Great Weapon Fighting"))
                 damages[0] = damages[0].replace(/[0-9]*d[0-9]+/g, "$&<=2");
             if (character.hasAction("Channel Divinity: Legendary Strike") &&

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -453,7 +453,8 @@ function rollAction(paneClass) {
             critical_limit = 19;
         // Polearm master bonus attack using the other end of the polearm is considered a melee attack.
         if (action_name == "Polearm Master - Bonus Attack" || action_name.includes("Unarmed Strike") || action_name == "Tavern Brawler Strike"
-            || action_name.includes("Psychic Blade") || action_name.includes("Bite") || action_name.includes("Claws") || action_name.includes("Tail")) {
+            || action_name.includes("Psychic Blade") || action_name.includes("Bite") || action_name.includes("Claws") || action_name.includes("Tail")
+            || action_name.includes("Ram")) {
             if (character.hasClassFeature("Fighting Style: Great Weapon Fighting"))
                 damages[0] = damages[0].replace(/[0-9]*d[0-9]+/g, "$&<=2");
             if (character.hasAction("Channel Divinity: Legendary Strike") &&

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -454,7 +454,7 @@ function rollAction(paneClass) {
         // Polearm master bonus attack using the other end of the polearm is considered a melee attack.
         if (action_name == "Polearm Master - Bonus Attack" || action_name.includes("Unarmed Strike") || action_name == "Tavern Brawler Strike"
             || action_name.includes("Psychic Blade") || action_name.includes("Bite") || action_name.includes("Claws") || action_name.includes("Tail")
-            || action_name.includes("Ram")) {
+            || action_name.includes("Ram") || action_name.includes("Horns")) {
             if (character.hasClassFeature("Fighting Style: Great Weapon Fighting"))
                 damages[0] = damages[0].replace(/[0-9]*d[0-9]+/g, "$&<=2");
             if (character.hasAction("Channel Divinity: Legendary Strike") &&


### PR DESCRIPTION
Barbarian Path of the Beast Natural Weapons
Leonin-only Claws attack (will cover anything named "Claw" under rollAction)
Satyr Ram (will cover anything named "Ram" under rollAction)
Minotaur Horns (will cover anything named "Horns" under rollAction)
Centaur Hooves (will cover anything named "Hooves" under rollAction)

Fixes #330
Fixes #331
Fixes #333 
Fixes #334 
Fixes #335 