### PR TITLE
Implement Path of the Zealot Divine Fury

### DIFF
--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -4442,7 +4442,7 @@ function rollItem(force_display = false) {
         if (character.hasClassFeature("Rage") && character.getSetting("barbarian-rage", false) && character.hasClassFeature("Divine Fury") &&
             properties["Attack Type"] == "Melee") {
             const barbarian_level = character.getClassLevel("Barbarian");
-            damages.push(String(`1d6+${Math.floor(barbarian_level / 2)}`));
+            damages.push(`1d6+${Math.floor(barbarian_level / 2)}`);
             damage_types.push("Divine Fury");
         }
         if (character.getSetting("sharpshooter", false) &&
@@ -4702,7 +4702,7 @@ function rollAction(paneClass) {
             }
             if (character.hasClassFeature("Rage") && character.getSetting("barbarian-rage", false) && character.hasClassFeature("Divine Fury")) {
                 const barbarian_level = character.getClassLevel("Barbarian");
-                damages.push(String(`1d6+${Math.floor(barbarian_level / 2)}`));
+                damages.push(`1d6+${Math.floor(barbarian_level / 2)}`);
                 damage_types.push("Divine Fury");
             }
             if (character.hasClassFeature("Giant Might") && character.getSetting("fighter-giant-might", false)) {

--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -4439,6 +4439,12 @@ function rollItem(force_display = false) {
             damages.push(String(rage_damage));
             damage_types.push("Rage");
         }
+        if (character.hasClassFeature("Rage") && character.getSetting("barbarian-rage", false) && character.hasClassFeature("Divine Fury") &&
+            properties["Attack Type"] == "Melee") {
+            const barbarian_level = character.getClassLevel("Barbarian");
+            damages.push(String(`1d6+${Math.floor(barbarian_level / 2)}`));
+            damage_types.push("Divine Fury");
+        }
         if (character.getSetting("sharpshooter", false) &&
             properties["Attack Type"] == "Ranged" &&
             properties["Proficient"] == "Yes") {
@@ -4693,6 +4699,11 @@ function rollAction(paneClass) {
                 const rage_damage = barbarian_level < 9 ? 2 : (barbarian_level < 16 ? 3 : 4);
                 damages.push(String(rage_damage));
                 damage_types.push("Rage");
+            }
+            if (character.hasClassFeature("Rage") && character.getSetting("barbarian-rage", false) && character.hasClassFeature("Divine Fury")) {
+                const barbarian_level = character.getClassLevel("Barbarian");
+                damages.push(String(`1d6+${Math.floor(barbarian_level / 2)}`));
+                damage_types.push("Divine Fury");
             }
             if (character.hasClassFeature("Giant Might") && character.getSetting("fighter-giant-might", false)) {
                 const fighter_level = character.getClassLevel("Fighter");

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -226,7 +226,7 @@ function rollItem(force_display = false) {
         if (character.hasClassFeature("Rage") && character.getSetting("barbarian-rage", false) && character.hasClassFeature("Divine Fury") &&
             properties["Attack Type"] == "Melee") {
             const barbarian_level = character.getClassLevel("Barbarian");
-            damages.push(String(`1d6+${Math.floor(barbarian_level / 2)}`));
+            damages.push(`1d6+${Math.floor(barbarian_level / 2)}`);
             damage_types.push("Divine Fury");
         }
         if (character.getSetting("sharpshooter", false) &&
@@ -486,7 +486,7 @@ function rollAction(paneClass) {
             }
             if (character.hasClassFeature("Rage") && character.getSetting("barbarian-rage", false) && character.hasClassFeature("Divine Fury")) {
                 const barbarian_level = character.getClassLevel("Barbarian");
-                damages.push(String(`1d6+${Math.floor(barbarian_level / 2)}`));
+                damages.push(`1d6+${Math.floor(barbarian_level / 2)}`);
                 damage_types.push("Divine Fury");
             }
             if (character.hasClassFeature("Giant Might") && character.getSetting("fighter-giant-might", false)) {

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -223,6 +223,12 @@ function rollItem(force_display = false) {
             damages.push(String(rage_damage));
             damage_types.push("Rage");
         }
+        if (character.hasClassFeature("Rage") && character.getSetting("barbarian-rage", false) && character.hasClassFeature("Divine Fury") &&
+            properties["Attack Type"] == "Melee") {
+            const barbarian_level = character.getClassLevel("Barbarian");
+            damages.push(String(`1d6+${Math.floor(barbarian_level / 2)}`));
+            damage_types.push("Divine Fury");
+        }
         if (character.getSetting("sharpshooter", false) &&
             properties["Attack Type"] == "Ranged" &&
             properties["Proficient"] == "Yes") {
@@ -477,6 +483,11 @@ function rollAction(paneClass) {
                 const rage_damage = barbarian_level < 9 ? 2 : (barbarian_level < 16 ? 3 : 4);
                 damages.push(String(rage_damage));
                 damage_types.push("Rage");
+            }
+            if (character.hasClassFeature("Rage") && character.getSetting("barbarian-rage", false) && character.hasClassFeature("Divine Fury")) {
+                const barbarian_level = character.getClassLevel("Barbarian");
+                damages.push(String(`1d6+${Math.floor(barbarian_level / 2)}`));
+                damage_types.push("Divine Fury");
             }
             if (character.hasClassFeature("Giant Might") && character.getSetting("fighter-giant-might", false)) {
                 const fighter_level = character.getClassLevel("Fighter");


### PR DESCRIPTION
Fixes #336

https://www.dndbeyond.com/classes/barbarian#PathoftheZealot

Divine Fury
Starting when you choose this path at 3rd level, you can channel divine fury into your weapon strikes. While you’re raging, the first creature you hit on each of your turns with a weapon attack takes extra damage equal to 1d6 + half your barbarian level. The extra damage is necrotic or radiant; you choose the type of damage when you gain this feature.