### PR TITLE
Implement Alchemist Artificer: Alchemical Savant

### DIFF
--- a/dist/background.js
+++ b/dist/background.js
@@ -649,6 +649,12 @@ const character_settings = {
         "description": "Unleash your divine soul to deal extra radiant damage equal to your level.",
         "type": "bool",
         "default": false
+    },
+    "artificer-alchemical-savant": {
+        "title": "Artificer: Use Alchemical Savant",
+        "description": "Use an Alchemical Savant for your Artificer spells. Deals extra damage equal to Intelligence Modifier",
+        "type": "bool",
+        "default": false
     }
 }
 

--- a/dist/default_popup.js
+++ b/dist/default_popup.js
@@ -605,6 +605,12 @@ const character_settings = {
         "description": "Unleash your divine soul to deal extra radiant damage equal to your level.",
         "type": "bool",
         "default": false
+    },
+    "artificer-alchemical-savant": {
+        "title": "Artificer: Use Alchemical Savant",
+        "description": "Use an Alchemical Savant for your Artificer spells. Deals extra damage equal to Intelligence Modifier",
+        "type": "bool",
+        "default": false
     }
 }
 

--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -604,6 +604,12 @@ const character_settings = {
         "description": "Unleash your divine soul to deal extra radiant damage equal to your level.",
         "type": "bool",
         "default": false
+    },
+    "artificer-alchemical-savant": {
+        "title": "Artificer: Use Alchemical Savant",
+        "description": "Use an Alchemical Savant for your Artificer spells. Deals extra damage equal to Intelligence Modifier",
+        "type": "bool",
+        "default": false
     }
 }
 
@@ -2215,7 +2221,7 @@ class Beyond20RollRenderer {
                 all_rolls.push(roll);
                 const dmg_type = damage_types[i];
                 let damage_flags = DAMAGE_FLAGS.REGULAR;
-                if (["Healing", "Disciple of Life", "Temp HP"].includes(dmg_type)) {
+                if (["Healing", "Disciple of Life", "Temp HP", "Alchemical Savant Healing"].includes(dmg_type)) {
                     damage_flags = DAMAGE_FLAGS.HEALING;
                 } else if (i == 0) {
                     damage_flags = DAMAGE_FLAGS.REGULAR;
@@ -2269,7 +2275,7 @@ class Beyond20RollRenderer {
                     critical_damage_rolls.push(roll);
                     const dmg_type = critical_damage_types[i];
                     let damage_flags = DAMAGE_FLAGS.REGULAR;
-                    if (["Healing", "Disciple of Life", "Temp HP"].includes(dmg_type)) {
+                    if (["Healing", "Disciple of Life", "Temp HP", "Alchemical Savant Healing"].includes(dmg_type)) {
                         damage_flags = DAMAGE_FLAGS.HEALING;
                     } else if (i == 0) {
                         damage_flags = DAMAGE_FLAGS.REGULAR;
@@ -4877,6 +4883,19 @@ function rollSpell(force_display = false) {
             damage_types.push("Arcane Firearm");
         }
 
+        if (character.hasClassFeature("Alchemical Savant") &&
+            character.getSetting("artificer-alchemical-savant", false) &&
+            damages.length) {
+            for (let i = 0; i < damages.length; i++){
+                if (damage_types[i] === "Acid" || damage_types[i] === "Fire" ||
+                    damage_types[i] === "Necrotic" || damage_types[i] === "Poison") {
+                    damages.push(`${character.getAbility("INT").mod < 2 ? 1 : character.getAbility("INT").mod}`);
+                    damage_types.push("Alchemical Savant");
+                    break;
+                }
+            }
+        }
+
         //Handle Flames of Phlegethos
         if (damages.length > 0 &&
             character.hasFeat("Flames of Phlegethos")) {
@@ -4930,6 +4949,17 @@ function rollSpell(force_display = false) {
             if (dmg.length > 0) {
                 damages.push(dmg);
                 damage_types.push("Healing");
+            }
+        }
+
+        if (character.hasClassFeature("Alchemical Savant") &&
+            character.getSetting("artificer-alchemical-savant", false)) {
+            for (let i = 0; i < damages.length; i++){
+                if (damage_types[i] === "Healing") {
+                    damages.push(`${character.getAbility("INT").mod < 2 ? 1 : character.getAbility("INT").mod}`);
+                    damage_types.push("Alchemical Savant Healing");
+                    break;
+                }
             }
         }
 

--- a/dist/dndbeyond_encounter.js
+++ b/dist/dndbeyond_encounter.js
@@ -604,6 +604,12 @@ const character_settings = {
         "description": "Unleash your divine soul to deal extra radiant damage equal to your level.",
         "type": "bool",
         "default": false
+    },
+    "artificer-alchemical-savant": {
+        "title": "Artificer: Use Alchemical Savant",
+        "description": "Use an Alchemical Savant for your Artificer spells. Deals extra damage equal to Intelligence Modifier",
+        "type": "bool",
+        "default": false
     }
 }
 
@@ -2215,7 +2221,7 @@ class Beyond20RollRenderer {
                 all_rolls.push(roll);
                 const dmg_type = damage_types[i];
                 let damage_flags = DAMAGE_FLAGS.REGULAR;
-                if (["Healing", "Disciple of Life", "Temp HP"].includes(dmg_type)) {
+                if (["Healing", "Disciple of Life", "Temp HP", "Alchemical Savant Healing"].includes(dmg_type)) {
                     damage_flags = DAMAGE_FLAGS.HEALING;
                 } else if (i == 0) {
                     damage_flags = DAMAGE_FLAGS.REGULAR;
@@ -2269,7 +2275,7 @@ class Beyond20RollRenderer {
                     critical_damage_rolls.push(roll);
                     const dmg_type = critical_damage_types[i];
                     let damage_flags = DAMAGE_FLAGS.REGULAR;
-                    if (["Healing", "Disciple of Life", "Temp HP"].includes(dmg_type)) {
+                    if (["Healing", "Disciple of Life", "Temp HP", "Alchemical Savant Healing"].includes(dmg_type)) {
                         damage_flags = DAMAGE_FLAGS.HEALING;
                     } else if (i == 0) {
                         damage_flags = DAMAGE_FLAGS.REGULAR;

--- a/dist/dndbeyond_item.js
+++ b/dist/dndbeyond_item.js
@@ -604,6 +604,12 @@ const character_settings = {
         "description": "Unleash your divine soul to deal extra radiant damage equal to your level.",
         "type": "bool",
         "default": false
+    },
+    "artificer-alchemical-savant": {
+        "title": "Artificer: Use Alchemical Savant",
+        "description": "Use an Alchemical Savant for your Artificer spells. Deals extra damage equal to Intelligence Modifier",
+        "type": "bool",
+        "default": false
     }
 }
 
@@ -2215,7 +2221,7 @@ class Beyond20RollRenderer {
                 all_rolls.push(roll);
                 const dmg_type = damage_types[i];
                 let damage_flags = DAMAGE_FLAGS.REGULAR;
-                if (["Healing", "Disciple of Life", "Temp HP"].includes(dmg_type)) {
+                if (["Healing", "Disciple of Life", "Temp HP", "Alchemical Savant Healing"].includes(dmg_type)) {
                     damage_flags = DAMAGE_FLAGS.HEALING;
                 } else if (i == 0) {
                     damage_flags = DAMAGE_FLAGS.REGULAR;
@@ -2269,7 +2275,7 @@ class Beyond20RollRenderer {
                     critical_damage_rolls.push(roll);
                     const dmg_type = critical_damage_types[i];
                     let damage_flags = DAMAGE_FLAGS.REGULAR;
-                    if (["Healing", "Disciple of Life", "Temp HP"].includes(dmg_type)) {
+                    if (["Healing", "Disciple of Life", "Temp HP", "Alchemical Savant Healing"].includes(dmg_type)) {
                         damage_flags = DAMAGE_FLAGS.HEALING;
                     } else if (i == 0) {
                         damage_flags = DAMAGE_FLAGS.REGULAR;

--- a/dist/dndbeyond_monster.js
+++ b/dist/dndbeyond_monster.js
@@ -604,6 +604,12 @@ const character_settings = {
         "description": "Unleash your divine soul to deal extra radiant damage equal to your level.",
         "type": "bool",
         "default": false
+    },
+    "artificer-alchemical-savant": {
+        "title": "Artificer: Use Alchemical Savant",
+        "description": "Use an Alchemical Savant for your Artificer spells. Deals extra damage equal to Intelligence Modifier",
+        "type": "bool",
+        "default": false
     }
 }
 
@@ -2215,7 +2221,7 @@ class Beyond20RollRenderer {
                 all_rolls.push(roll);
                 const dmg_type = damage_types[i];
                 let damage_flags = DAMAGE_FLAGS.REGULAR;
-                if (["Healing", "Disciple of Life", "Temp HP"].includes(dmg_type)) {
+                if (["Healing", "Disciple of Life", "Temp HP", "Alchemical Savant Healing"].includes(dmg_type)) {
                     damage_flags = DAMAGE_FLAGS.HEALING;
                 } else if (i == 0) {
                     damage_flags = DAMAGE_FLAGS.REGULAR;
@@ -2269,7 +2275,7 @@ class Beyond20RollRenderer {
                     critical_damage_rolls.push(roll);
                     const dmg_type = critical_damage_types[i];
                     let damage_flags = DAMAGE_FLAGS.REGULAR;
-                    if (["Healing", "Disciple of Life", "Temp HP"].includes(dmg_type)) {
+                    if (["Healing", "Disciple of Life", "Temp HP", "Alchemical Savant Healing"].includes(dmg_type)) {
                         damage_flags = DAMAGE_FLAGS.HEALING;
                     } else if (i == 0) {
                         damage_flags = DAMAGE_FLAGS.REGULAR;

--- a/dist/dndbeyond_spell.js
+++ b/dist/dndbeyond_spell.js
@@ -604,6 +604,12 @@ const character_settings = {
         "description": "Unleash your divine soul to deal extra radiant damage equal to your level.",
         "type": "bool",
         "default": false
+    },
+    "artificer-alchemical-savant": {
+        "title": "Artificer: Use Alchemical Savant",
+        "description": "Use an Alchemical Savant for your Artificer spells. Deals extra damage equal to Intelligence Modifier",
+        "type": "bool",
+        "default": false
     }
 }
 
@@ -2215,7 +2221,7 @@ class Beyond20RollRenderer {
                 all_rolls.push(roll);
                 const dmg_type = damage_types[i];
                 let damage_flags = DAMAGE_FLAGS.REGULAR;
-                if (["Healing", "Disciple of Life", "Temp HP"].includes(dmg_type)) {
+                if (["Healing", "Disciple of Life", "Temp HP", "Alchemical Savant Healing"].includes(dmg_type)) {
                     damage_flags = DAMAGE_FLAGS.HEALING;
                 } else if (i == 0) {
                     damage_flags = DAMAGE_FLAGS.REGULAR;
@@ -2269,7 +2275,7 @@ class Beyond20RollRenderer {
                     critical_damage_rolls.push(roll);
                     const dmg_type = critical_damage_types[i];
                     let damage_flags = DAMAGE_FLAGS.REGULAR;
-                    if (["Healing", "Disciple of Life", "Temp HP"].includes(dmg_type)) {
+                    if (["Healing", "Disciple of Life", "Temp HP", "Alchemical Savant Healing"].includes(dmg_type)) {
                         damage_flags = DAMAGE_FLAGS.HEALING;
                     } else if (i == 0) {
                         damage_flags = DAMAGE_FLAGS.REGULAR;

--- a/dist/dndbeyond_vehicle.js
+++ b/dist/dndbeyond_vehicle.js
@@ -604,6 +604,12 @@ const character_settings = {
         "description": "Unleash your divine soul to deal extra radiant damage equal to your level.",
         "type": "bool",
         "default": false
+    },
+    "artificer-alchemical-savant": {
+        "title": "Artificer: Use Alchemical Savant",
+        "description": "Use an Alchemical Savant for your Artificer spells. Deals extra damage equal to Intelligence Modifier",
+        "type": "bool",
+        "default": false
     }
 }
 
@@ -2215,7 +2221,7 @@ class Beyond20RollRenderer {
                 all_rolls.push(roll);
                 const dmg_type = damage_types[i];
                 let damage_flags = DAMAGE_FLAGS.REGULAR;
-                if (["Healing", "Disciple of Life", "Temp HP"].includes(dmg_type)) {
+                if (["Healing", "Disciple of Life", "Temp HP", "Alchemical Savant Healing"].includes(dmg_type)) {
                     damage_flags = DAMAGE_FLAGS.HEALING;
                 } else if (i == 0) {
                     damage_flags = DAMAGE_FLAGS.REGULAR;
@@ -2269,7 +2275,7 @@ class Beyond20RollRenderer {
                     critical_damage_rolls.push(roll);
                     const dmg_type = critical_damage_types[i];
                     let damage_flags = DAMAGE_FLAGS.REGULAR;
-                    if (["Healing", "Disciple of Life", "Temp HP"].includes(dmg_type)) {
+                    if (["Healing", "Disciple of Life", "Temp HP", "Alchemical Savant Healing"].includes(dmg_type)) {
                         damage_flags = DAMAGE_FLAGS.HEALING;
                     } else if (i == 0) {
                         damage_flags = DAMAGE_FLAGS.REGULAR;

--- a/dist/fvtt.js
+++ b/dist/fvtt.js
@@ -604,6 +604,12 @@ const character_settings = {
         "description": "Unleash your divine soul to deal extra radiant damage equal to your level.",
         "type": "bool",
         "default": false
+    },
+    "artificer-alchemical-savant": {
+        "title": "Artificer: Use Alchemical Savant",
+        "description": "Use an Alchemical Savant for your Artificer spells. Deals extra damage equal to Intelligence Modifier",
+        "type": "bool",
+        "default": false
     }
 }
 

--- a/dist/fvtt_script.js
+++ b/dist/fvtt_script.js
@@ -605,6 +605,12 @@ const character_settings = {
         "description": "Unleash your divine soul to deal extra radiant damage equal to your level.",
         "type": "bool",
         "default": false
+    },
+    "artificer-alchemical-savant": {
+        "title": "Artificer: Use Alchemical Savant",
+        "description": "Use an Alchemical Savant for your Artificer spells. Deals extra damage equal to Intelligence Modifier",
+        "type": "bool",
+        "default": false
     }
 }
 
@@ -2216,7 +2222,7 @@ class Beyond20RollRenderer {
                 all_rolls.push(roll);
                 const dmg_type = damage_types[i];
                 let damage_flags = DAMAGE_FLAGS.REGULAR;
-                if (["Healing", "Disciple of Life", "Temp HP"].includes(dmg_type)) {
+                if (["Healing", "Disciple of Life", "Temp HP", "Alchemical Savant Healing"].includes(dmg_type)) {
                     damage_flags = DAMAGE_FLAGS.HEALING;
                 } else if (i == 0) {
                     damage_flags = DAMAGE_FLAGS.REGULAR;
@@ -2270,7 +2276,7 @@ class Beyond20RollRenderer {
                     critical_damage_rolls.push(roll);
                     const dmg_type = critical_damage_types[i];
                     let damage_flags = DAMAGE_FLAGS.REGULAR;
-                    if (["Healing", "Disciple of Life", "Temp HP"].includes(dmg_type)) {
+                    if (["Healing", "Disciple of Life", "Temp HP", "Alchemical Savant Healing"].includes(dmg_type)) {
                         damage_flags = DAMAGE_FLAGS.HEALING;
                     } else if (i == 0) {
                         damage_flags = DAMAGE_FLAGS.REGULAR;

--- a/dist/options.js
+++ b/dist/options.js
@@ -604,6 +604,12 @@ const character_settings = {
         "description": "Unleash your divine soul to deal extra radiant damage equal to your level.",
         "type": "bool",
         "default": false
+    },
+    "artificer-alchemical-savant": {
+        "title": "Artificer: Use Alchemical Savant",
+        "description": "Use an Alchemical Savant for your Artificer spells. Deals extra damage equal to Intelligence Modifier",
+        "type": "bool",
+        "default": false
     }
 }
 

--- a/dist/popup.js
+++ b/dist/popup.js
@@ -649,6 +649,12 @@ const character_settings = {
         "description": "Unleash your divine soul to deal extra radiant damage equal to your level.",
         "type": "bool",
         "default": false
+    },
+    "artificer-alchemical-savant": {
+        "title": "Artificer: Use Alchemical Savant",
+        "description": "Use an Alchemical Savant for your Artificer spells. Deals extra damage equal to Intelligence Modifier",
+        "type": "bool",
+        "default": false
     }
 }
 
@@ -1413,6 +1419,10 @@ function populateCharacter(response) {
         }
         if (response["racial-traits"].includes("Radiant Soul")) {
             e = createHTMLOption("protector-aasimar-radiant-soul", false, character_settings);
+            options.append(e);
+        }
+        if (response["class-features"].includes("Alchemical Savant")) {
+            e = createHTMLOption("artificer-alchemical-savant", false, character_settings);
             options.append(e);
         }
 

--- a/dist/roll20.js
+++ b/dist/roll20.js
@@ -604,6 +604,12 @@ const character_settings = {
         "description": "Unleash your divine soul to deal extra radiant damage equal to your level.",
         "type": "bool",
         "default": false
+    },
+    "artificer-alchemical-savant": {
+        "title": "Artificer: Use Alchemical Savant",
+        "description": "Use an Alchemical Savant for your Artificer spells. Deals extra damage equal to Intelligence Modifier",
+        "type": "bool",
+        "default": false
     }
 }
 
@@ -2215,7 +2221,7 @@ class Beyond20RollRenderer {
                 all_rolls.push(roll);
                 const dmg_type = damage_types[i];
                 let damage_flags = DAMAGE_FLAGS.REGULAR;
-                if (["Healing", "Disciple of Life", "Temp HP"].includes(dmg_type)) {
+                if (["Healing", "Disciple of Life", "Temp HP", "Alchemical Savant Healing"].includes(dmg_type)) {
                     damage_flags = DAMAGE_FLAGS.HEALING;
                 } else if (i == 0) {
                     damage_flags = DAMAGE_FLAGS.REGULAR;
@@ -2269,7 +2275,7 @@ class Beyond20RollRenderer {
                     critical_damage_rolls.push(roll);
                     const dmg_type = critical_damage_types[i];
                     let damage_flags = DAMAGE_FLAGS.REGULAR;
-                    if (["Healing", "Disciple of Life", "Temp HP"].includes(dmg_type)) {
+                    if (["Healing", "Disciple of Life", "Temp HP", "Alchemical Savant Healing"].includes(dmg_type)) {
                         damage_flags = DAMAGE_FLAGS.HEALING;
                     } else if (i == 0) {
                         damage_flags = DAMAGE_FLAGS.REGULAR;

--- a/src/common/roll_renderer.js
+++ b/src/common/roll_renderer.js
@@ -590,7 +590,7 @@ class Beyond20RollRenderer {
                 all_rolls.push(roll);
                 const dmg_type = damage_types[i];
                 let damage_flags = DAMAGE_FLAGS.REGULAR;
-                if (["Healing", "Disciple of Life", "Temp HP"].includes(dmg_type)) {
+                if (["Healing", "Disciple of Life", "Temp HP", "Alchemical Savant Healing"].includes(dmg_type)) {
                     damage_flags = DAMAGE_FLAGS.HEALING;
                 } else if (i == 0) {
                     damage_flags = DAMAGE_FLAGS.REGULAR;
@@ -644,7 +644,7 @@ class Beyond20RollRenderer {
                     critical_damage_rolls.push(roll);
                     const dmg_type = critical_damage_types[i];
                     let damage_flags = DAMAGE_FLAGS.REGULAR;
-                    if (["Healing", "Disciple of Life", "Temp HP"].includes(dmg_type)) {
+                    if (["Healing", "Disciple of Life", "Temp HP", "Alchemical Savant Healing"].includes(dmg_type)) {
                         damage_flags = DAMAGE_FLAGS.HEALING;
                     } else if (i == 0) {
                         damage_flags = DAMAGE_FLAGS.REGULAR;

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -451,6 +451,12 @@ const character_settings = {
         "description": "Unleash your divine soul to deal extra radiant damage equal to your level.",
         "type": "bool",
         "default": false
+    },
+    "artificer-alchemical-savant": {
+        "title": "Artificer: Use Alchemical Savant",
+        "description": "Use an Alchemical Savant for your Artificer spells. Deals extra damage equal to Intelligence Modifier",
+        "type": "bool",
+        "default": false
     }
 }
 

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -631,6 +631,19 @@ function rollSpell(force_display = false) {
             damage_types.push("Arcane Firearm");
         }
 
+        if (character.hasClassFeature("Alchemical Savant") &&
+            character.getSetting("artificer-alchemical-savant", false) &&
+            damages.length) {
+            for (let i = 0; i < damages.length; i++){
+                if (damage_types[i] === "Acid" || damage_types[i] === "Fire" ||
+                    damage_types[i] === "Necrotic" || damage_types[i] === "Poison") {
+                    damages.push(`${character.getAbility("INT").mod < 2 ? 1 : character.getAbility("INT").mod}`);
+                    damage_types.push("Alchemical Savant");
+                    break;
+                }
+            }
+        }
+
         //Handle Flames of Phlegethos
         if (damages.length > 0 &&
             character.hasFeat("Flames of Phlegethos")) {
@@ -684,6 +697,17 @@ function rollSpell(force_display = false) {
             if (dmg.length > 0) {
                 damages.push(dmg);
                 damage_types.push("Healing");
+            }
+        }
+
+        if (character.hasClassFeature("Alchemical Savant") &&
+            character.getSetting("artificer-alchemical-savant", false)) {
+            for (let i = 0; i < damages.length; i++){
+                if (damage_types[i] === "Healing") {
+                    damages.push(`${character.getAbility("INT").mod < 2 ? 1 : character.getAbility("INT").mod}`);
+                    damage_types.push("Alchemical Savant Healing");
+                    break;
+                }
             }
         }
 

--- a/src/extension/popup.js
+++ b/src/extension/popup.js
@@ -179,6 +179,10 @@ function populateCharacter(response) {
             e = createHTMLOption("protector-aasimar-radiant-soul", false, character_settings);
             options.append(e);
         }
+        if (response["class-features"].includes("Alchemical Savant")) {
+            e = createHTMLOption("artificer-alchemical-savant", false, character_settings);
+            options.append(e);
+        }
 
         loadSettings(response.settings, character_settings);
     }


### PR DESCRIPTION
https://www.dndbeyond.com/classes/artificer#Alchemist

Alchemical Savant
At 5th level, you develop masterful command of magical chemicals, enhancing the healing and damage you create through them. Whenever you cast a spell using your alchemist’s supplies as the spellcasting focus, you gain a bonus to one roll of the spell. That roll must restore hit points or be a damage roll that deals acid, fire, necrotic, or poison damage, and the bonus equals your Intelligence modifier (minimum of +1).