### PR TITLE
Implement Artificer: Battlesmith Arcane Jolt

### DIFF
--- a/dist/astral.js
+++ b/dist/astral.js
@@ -732,6 +732,7 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+<<<<<<< HEAD
     "cleric-blessed-strikes": {
         "title": "Cleric: Blessed Strikes",
         "description": "Deal an extra 1d8 damage on damaging cantrips and weapon attacks",
@@ -753,6 +754,11 @@ const character_settings = {
     "eldritch-invocation-lifedinker": {
         "title": "Eldritch Invocation: Lifedrinker",
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
+=======
+    "artificer-arcane-jolt": {
+        "title": "Artificer: Use Arcane Jolt",
+        "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
+>>>>>>> 820de29 (Implement Artificer: Battlesmith Arcane Jolt)
         "type": "bool",
         "default": false
     }

--- a/dist/astral.js
+++ b/dist/astral.js
@@ -422,6 +422,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "default": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/dist/astral.js
+++ b/dist/astral.js
@@ -422,13 +422,6 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
-    "roll20-spell-description-display": {
-        "title": "Display Spell Descriptions in spell attacks",
-        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
-        "type": "bool",
-        "default": false
-    },
-
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",
@@ -739,7 +732,6 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
-<<<<<<< HEAD
     "cleric-blessed-strikes": {
         "title": "Cleric: Blessed Strikes",
         "description": "Deal an extra 1d8 damage on damaging cantrips and weapon attacks",
@@ -761,11 +753,12 @@ const character_settings = {
     "eldritch-invocation-lifedinker": {
         "title": "Eldritch Invocation: Lifedrinker",
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
-=======
+        "type": "bool",
+        "default": false
+    },
     "artificer-arcane-jolt": {
         "title": "Artificer: Use Arcane Jolt",
         "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
->>>>>>> 820de29 (Implement Artificer: Battlesmith Arcane Jolt)
         "type": "bool",
         "default": false
     }

--- a/dist/astral_script.js
+++ b/dist/astral_script.js
@@ -732,6 +732,7 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+<<<<<<< HEAD
     "cleric-blessed-strikes": {
         "title": "Cleric: Blessed Strikes",
         "description": "Deal an extra 1d8 damage on damaging cantrips and weapon attacks",
@@ -753,6 +754,11 @@ const character_settings = {
     "eldritch-invocation-lifedinker": {
         "title": "Eldritch Invocation: Lifedrinker",
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
+=======
+    "artificer-arcane-jolt": {
+        "title": "Artificer: Use Arcane Jolt",
+        "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
+>>>>>>> 820de29 (Implement Artificer: Battlesmith Arcane Jolt)
         "type": "bool",
         "default": false
     }

--- a/dist/astral_script.js
+++ b/dist/astral_script.js
@@ -422,6 +422,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "default": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/dist/astral_script.js
+++ b/dist/astral_script.js
@@ -422,13 +422,6 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
-    "roll20-spell-description-display": {
-        "title": "Display Spell Descriptions in spell attacks",
-        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
-        "type": "bool",
-        "default": false
-    },
-
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",
@@ -739,7 +732,6 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
-<<<<<<< HEAD
     "cleric-blessed-strikes": {
         "title": "Cleric: Blessed Strikes",
         "description": "Deal an extra 1d8 damage on damaging cantrips and weapon attacks",
@@ -761,11 +753,12 @@ const character_settings = {
     "eldritch-invocation-lifedinker": {
         "title": "Eldritch Invocation: Lifedrinker",
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
-=======
+        "type": "bool",
+        "default": false
+    },
     "artificer-arcane-jolt": {
         "title": "Artificer: Use Arcane Jolt",
         "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
->>>>>>> 820de29 (Implement Artificer: Battlesmith Arcane Jolt)
         "type": "bool",
         "default": false
     }

--- a/dist/background.js
+++ b/dist/background.js
@@ -468,6 +468,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "default": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/dist/background.js
+++ b/dist/background.js
@@ -778,6 +778,7 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+<<<<<<< HEAD
     "cleric-blessed-strikes": {
         "title": "Cleric: Blessed Strikes",
         "description": "Deal an extra 1d8 damage on damaging cantrips and weapon attacks",
@@ -799,6 +800,11 @@ const character_settings = {
     "eldritch-invocation-lifedinker": {
         "title": "Eldritch Invocation: Lifedrinker",
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
+=======
+    "artificer-arcane-jolt": {
+        "title": "Artificer: Use Arcane Jolt",
+        "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
+>>>>>>> 820de29 (Implement Artificer: Battlesmith Arcane Jolt)
         "type": "bool",
         "default": false
     }

--- a/dist/background.js
+++ b/dist/background.js
@@ -468,13 +468,6 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
-    "roll20-spell-description-display": {
-        "title": "Display Spell Descriptions in spell attacks",
-        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
-        "type": "bool",
-        "default": false
-    },
-
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",
@@ -785,7 +778,6 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
-<<<<<<< HEAD
     "cleric-blessed-strikes": {
         "title": "Cleric: Blessed Strikes",
         "description": "Deal an extra 1d8 damage on damaging cantrips and weapon attacks",
@@ -807,11 +799,12 @@ const character_settings = {
     "eldritch-invocation-lifedinker": {
         "title": "Eldritch Invocation: Lifedrinker",
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
-=======
+        "type": "bool",
+        "default": false
+    },
     "artificer-arcane-jolt": {
         "title": "Artificer: Use Arcane Jolt",
         "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
->>>>>>> 820de29 (Implement Artificer: Battlesmith Arcane Jolt)
         "type": "bool",
         "default": false
     }

--- a/dist/default_popup.js
+++ b/dist/default_popup.js
@@ -423,6 +423,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "default": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/dist/default_popup.js
+++ b/dist/default_popup.js
@@ -733,6 +733,7 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+<<<<<<< HEAD
     "cleric-blessed-strikes": {
         "title": "Cleric: Blessed Strikes",
         "description": "Deal an extra 1d8 damage on damaging cantrips and weapon attacks",
@@ -754,6 +755,11 @@ const character_settings = {
     "eldritch-invocation-lifedinker": {
         "title": "Eldritch Invocation: Lifedrinker",
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
+=======
+    "artificer-arcane-jolt": {
+        "title": "Artificer: Use Arcane Jolt",
+        "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
+>>>>>>> 820de29 (Implement Artificer: Battlesmith Arcane Jolt)
         "type": "bool",
         "default": false
     }

--- a/dist/default_popup.js
+++ b/dist/default_popup.js
@@ -423,13 +423,6 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
-    "roll20-spell-description-display": {
-        "title": "Display Spell Descriptions in spell attacks",
-        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
-        "type": "bool",
-        "default": false
-    },
-
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",
@@ -740,7 +733,6 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
-<<<<<<< HEAD
     "cleric-blessed-strikes": {
         "title": "Cleric: Blessed Strikes",
         "description": "Deal an extra 1d8 damage on damaging cantrips and weapon attacks",
@@ -762,11 +754,12 @@ const character_settings = {
     "eldritch-invocation-lifedinker": {
         "title": "Eldritch Invocation: Lifedrinker",
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
-=======
+        "type": "bool",
+        "default": false
+    },
     "artificer-arcane-jolt": {
         "title": "Artificer: Use Arcane Jolt",
         "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
->>>>>>> 820de29 (Implement Artificer: Battlesmith Arcane Jolt)
         "type": "bool",
         "default": false
     }

--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -732,6 +732,7 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+<<<<<<< HEAD
     "cleric-blessed-strikes": {
         "title": "Cleric: Blessed Strikes",
         "description": "Deal an extra 1d8 damage on damaging cantrips and weapon attacks",
@@ -753,6 +754,11 @@ const character_settings = {
     "eldritch-invocation-lifedinker": {
         "title": "Eldritch Invocation: Lifedrinker",
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
+=======
+    "artificer-arcane-jolt": {
+        "title": "Artificer: Use Arcane Jolt",
+        "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
+>>>>>>> 820de29 (Implement Artificer: Battlesmith Arcane Jolt)
         "type": "bool",
         "default": false
     }
@@ -5415,6 +5421,17 @@ function rollItem(force_display = false, force_to_hit_only = false, force_damage
                     brutal += 1;
             }
         }
+
+        //Artificer Battlemaster Arcane Jolt
+        // TODO: Implement for Steel Defender at later date
+        if (damages.length > 0 &&
+            character.hasClassFeature("Arcane Jolt") &&
+            character.getSetting("artificer-arcane-jolt", false) &&
+            item_type.indexOf(", Common") === -1) {
+            damages.push(character._level < 15 ? "2d6" : "4d6");
+            damage_types.push("Arcane Jolt");
+        }
+
         const roll_properties = buildAttackRoll(character,
             "item",
             item_name,

--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -422,6 +422,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "default": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -422,13 +422,6 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
-    "roll20-spell-description-display": {
-        "title": "Display Spell Descriptions in spell attacks",
-        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
-        "type": "bool",
-        "default": false
-    },
-
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",
@@ -739,7 +732,6 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
-<<<<<<< HEAD
     "cleric-blessed-strikes": {
         "title": "Cleric: Blessed Strikes",
         "description": "Deal an extra 1d8 damage on damaging cantrips and weapon attacks",
@@ -761,11 +753,12 @@ const character_settings = {
     "eldritch-invocation-lifedinker": {
         "title": "Eldritch Invocation: Lifedrinker",
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
-=======
+        "type": "bool",
+        "default": false
+    },
     "artificer-arcane-jolt": {
         "title": "Artificer: Use Arcane Jolt",
         "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
->>>>>>> 820de29 (Implement Artificer: Battlesmith Arcane Jolt)
         "type": "bool",
         "default": false
     }

--- a/dist/dndbeyond_encounter.js
+++ b/dist/dndbeyond_encounter.js
@@ -732,6 +732,7 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+<<<<<<< HEAD
     "cleric-blessed-strikes": {
         "title": "Cleric: Blessed Strikes",
         "description": "Deal an extra 1d8 damage on damaging cantrips and weapon attacks",
@@ -753,6 +754,11 @@ const character_settings = {
     "eldritch-invocation-lifedinker": {
         "title": "Eldritch Invocation: Lifedrinker",
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
+=======
+    "artificer-arcane-jolt": {
+        "title": "Artificer: Use Arcane Jolt",
+        "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
+>>>>>>> 820de29 (Implement Artificer: Battlesmith Arcane Jolt)
         "type": "bool",
         "default": false
     }

--- a/dist/dndbeyond_encounter.js
+++ b/dist/dndbeyond_encounter.js
@@ -422,6 +422,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "default": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/dist/dndbeyond_encounter.js
+++ b/dist/dndbeyond_encounter.js
@@ -422,13 +422,6 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
-    "roll20-spell-description-display": {
-        "title": "Display Spell Descriptions in spell attacks",
-        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
-        "type": "bool",
-        "default": false
-    },
-
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",
@@ -739,7 +732,6 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
-<<<<<<< HEAD
     "cleric-blessed-strikes": {
         "title": "Cleric: Blessed Strikes",
         "description": "Deal an extra 1d8 damage on damaging cantrips and weapon attacks",
@@ -761,11 +753,12 @@ const character_settings = {
     "eldritch-invocation-lifedinker": {
         "title": "Eldritch Invocation: Lifedrinker",
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
-=======
+        "type": "bool",
+        "default": false
+    },
     "artificer-arcane-jolt": {
         "title": "Artificer: Use Arcane Jolt",
         "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
->>>>>>> 820de29 (Implement Artificer: Battlesmith Arcane Jolt)
         "type": "bool",
         "default": false
     }

--- a/dist/dndbeyond_item.js
+++ b/dist/dndbeyond_item.js
@@ -732,6 +732,7 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+<<<<<<< HEAD
     "cleric-blessed-strikes": {
         "title": "Cleric: Blessed Strikes",
         "description": "Deal an extra 1d8 damage on damaging cantrips and weapon attacks",
@@ -753,6 +754,11 @@ const character_settings = {
     "eldritch-invocation-lifedinker": {
         "title": "Eldritch Invocation: Lifedrinker",
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
+=======
+    "artificer-arcane-jolt": {
+        "title": "Artificer: Use Arcane Jolt",
+        "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
+>>>>>>> 820de29 (Implement Artificer: Battlesmith Arcane Jolt)
         "type": "bool",
         "default": false
     }

--- a/dist/dndbeyond_item.js
+++ b/dist/dndbeyond_item.js
@@ -422,6 +422,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "default": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/dist/dndbeyond_item.js
+++ b/dist/dndbeyond_item.js
@@ -422,13 +422,6 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
-    "roll20-spell-description-display": {
-        "title": "Display Spell Descriptions in spell attacks",
-        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
-        "type": "bool",
-        "default": false
-    },
-
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",
@@ -739,7 +732,6 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
-<<<<<<< HEAD
     "cleric-blessed-strikes": {
         "title": "Cleric: Blessed Strikes",
         "description": "Deal an extra 1d8 damage on damaging cantrips and weapon attacks",
@@ -761,11 +753,12 @@ const character_settings = {
     "eldritch-invocation-lifedinker": {
         "title": "Eldritch Invocation: Lifedrinker",
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
-=======
+        "type": "bool",
+        "default": false
+    },
     "artificer-arcane-jolt": {
         "title": "Artificer: Use Arcane Jolt",
         "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
->>>>>>> 820de29 (Implement Artificer: Battlesmith Arcane Jolt)
         "type": "bool",
         "default": false
     }

--- a/dist/dndbeyond_monster.js
+++ b/dist/dndbeyond_monster.js
@@ -732,6 +732,7 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+<<<<<<< HEAD
     "cleric-blessed-strikes": {
         "title": "Cleric: Blessed Strikes",
         "description": "Deal an extra 1d8 damage on damaging cantrips and weapon attacks",
@@ -753,6 +754,11 @@ const character_settings = {
     "eldritch-invocation-lifedinker": {
         "title": "Eldritch Invocation: Lifedrinker",
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
+=======
+    "artificer-arcane-jolt": {
+        "title": "Artificer: Use Arcane Jolt",
+        "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
+>>>>>>> 820de29 (Implement Artificer: Battlesmith Arcane Jolt)
         "type": "bool",
         "default": false
     }

--- a/dist/dndbeyond_monster.js
+++ b/dist/dndbeyond_monster.js
@@ -422,6 +422,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "default": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/dist/dndbeyond_monster.js
+++ b/dist/dndbeyond_monster.js
@@ -422,13 +422,6 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
-    "roll20-spell-description-display": {
-        "title": "Display Spell Descriptions in spell attacks",
-        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
-        "type": "bool",
-        "default": false
-    },
-
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",
@@ -739,7 +732,6 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
-<<<<<<< HEAD
     "cleric-blessed-strikes": {
         "title": "Cleric: Blessed Strikes",
         "description": "Deal an extra 1d8 damage on damaging cantrips and weapon attacks",
@@ -761,11 +753,12 @@ const character_settings = {
     "eldritch-invocation-lifedinker": {
         "title": "Eldritch Invocation: Lifedrinker",
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
-=======
+        "type": "bool",
+        "default": false
+    },
     "artificer-arcane-jolt": {
         "title": "Artificer: Use Arcane Jolt",
         "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
->>>>>>> 820de29 (Implement Artificer: Battlesmith Arcane Jolt)
         "type": "bool",
         "default": false
     }

--- a/dist/dndbeyond_spell.js
+++ b/dist/dndbeyond_spell.js
@@ -732,6 +732,7 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+<<<<<<< HEAD
     "cleric-blessed-strikes": {
         "title": "Cleric: Blessed Strikes",
         "description": "Deal an extra 1d8 damage on damaging cantrips and weapon attacks",
@@ -753,6 +754,11 @@ const character_settings = {
     "eldritch-invocation-lifedinker": {
         "title": "Eldritch Invocation: Lifedrinker",
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
+=======
+    "artificer-arcane-jolt": {
+        "title": "Artificer: Use Arcane Jolt",
+        "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
+>>>>>>> 820de29 (Implement Artificer: Battlesmith Arcane Jolt)
         "type": "bool",
         "default": false
     }

--- a/dist/dndbeyond_spell.js
+++ b/dist/dndbeyond_spell.js
@@ -422,6 +422,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "default": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/dist/dndbeyond_spell.js
+++ b/dist/dndbeyond_spell.js
@@ -422,13 +422,6 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
-    "roll20-spell-description-display": {
-        "title": "Display Spell Descriptions in spell attacks",
-        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
-        "type": "bool",
-        "default": false
-    },
-
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",
@@ -739,7 +732,6 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
-<<<<<<< HEAD
     "cleric-blessed-strikes": {
         "title": "Cleric: Blessed Strikes",
         "description": "Deal an extra 1d8 damage on damaging cantrips and weapon attacks",
@@ -761,11 +753,12 @@ const character_settings = {
     "eldritch-invocation-lifedinker": {
         "title": "Eldritch Invocation: Lifedrinker",
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
-=======
+        "type": "bool",
+        "default": false
+    },
     "artificer-arcane-jolt": {
         "title": "Artificer: Use Arcane Jolt",
         "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
->>>>>>> 820de29 (Implement Artificer: Battlesmith Arcane Jolt)
         "type": "bool",
         "default": false
     }

--- a/dist/dndbeyond_vehicle.js
+++ b/dist/dndbeyond_vehicle.js
@@ -732,6 +732,7 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+<<<<<<< HEAD
     "cleric-blessed-strikes": {
         "title": "Cleric: Blessed Strikes",
         "description": "Deal an extra 1d8 damage on damaging cantrips and weapon attacks",
@@ -753,6 +754,11 @@ const character_settings = {
     "eldritch-invocation-lifedinker": {
         "title": "Eldritch Invocation: Lifedrinker",
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
+=======
+    "artificer-arcane-jolt": {
+        "title": "Artificer: Use Arcane Jolt",
+        "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
+>>>>>>> 820de29 (Implement Artificer: Battlesmith Arcane Jolt)
         "type": "bool",
         "default": false
     }

--- a/dist/dndbeyond_vehicle.js
+++ b/dist/dndbeyond_vehicle.js
@@ -422,6 +422,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "default": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/dist/dndbeyond_vehicle.js
+++ b/dist/dndbeyond_vehicle.js
@@ -422,13 +422,6 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
-    "roll20-spell-description-display": {
-        "title": "Display Spell Descriptions in spell attacks",
-        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
-        "type": "bool",
-        "default": false
-    },
-
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",
@@ -739,7 +732,6 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
-<<<<<<< HEAD
     "cleric-blessed-strikes": {
         "title": "Cleric: Blessed Strikes",
         "description": "Deal an extra 1d8 damage on damaging cantrips and weapon attacks",
@@ -761,11 +753,12 @@ const character_settings = {
     "eldritch-invocation-lifedinker": {
         "title": "Eldritch Invocation: Lifedrinker",
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
-=======
+        "type": "bool",
+        "default": false
+    },
     "artificer-arcane-jolt": {
         "title": "Artificer: Use Arcane Jolt",
         "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
->>>>>>> 820de29 (Implement Artificer: Battlesmith Arcane Jolt)
         "type": "bool",
         "default": false
     }

--- a/dist/fvtt.js
+++ b/dist/fvtt.js
@@ -732,6 +732,7 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+<<<<<<< HEAD
     "cleric-blessed-strikes": {
         "title": "Cleric: Blessed Strikes",
         "description": "Deal an extra 1d8 damage on damaging cantrips and weapon attacks",
@@ -753,6 +754,11 @@ const character_settings = {
     "eldritch-invocation-lifedinker": {
         "title": "Eldritch Invocation: Lifedrinker",
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
+=======
+    "artificer-arcane-jolt": {
+        "title": "Artificer: Use Arcane Jolt",
+        "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
+>>>>>>> 820de29 (Implement Artificer: Battlesmith Arcane Jolt)
         "type": "bool",
         "default": false
     }

--- a/dist/fvtt.js
+++ b/dist/fvtt.js
@@ -422,6 +422,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "default": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/dist/fvtt.js
+++ b/dist/fvtt.js
@@ -422,13 +422,6 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
-    "roll20-spell-description-display": {
-        "title": "Display Spell Descriptions in spell attacks",
-        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
-        "type": "bool",
-        "default": false
-    },
-
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",
@@ -739,7 +732,6 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
-<<<<<<< HEAD
     "cleric-blessed-strikes": {
         "title": "Cleric: Blessed Strikes",
         "description": "Deal an extra 1d8 damage on damaging cantrips and weapon attacks",
@@ -761,11 +753,12 @@ const character_settings = {
     "eldritch-invocation-lifedinker": {
         "title": "Eldritch Invocation: Lifedrinker",
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
-=======
+        "type": "bool",
+        "default": false
+    },
     "artificer-arcane-jolt": {
         "title": "Artificer: Use Arcane Jolt",
         "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
->>>>>>> 820de29 (Implement Artificer: Battlesmith Arcane Jolt)
         "type": "bool",
         "default": false
     }

--- a/dist/fvtt_script.js
+++ b/dist/fvtt_script.js
@@ -423,6 +423,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "default": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/dist/fvtt_script.js
+++ b/dist/fvtt_script.js
@@ -733,6 +733,7 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+<<<<<<< HEAD
     "cleric-blessed-strikes": {
         "title": "Cleric: Blessed Strikes",
         "description": "Deal an extra 1d8 damage on damaging cantrips and weapon attacks",
@@ -754,6 +755,11 @@ const character_settings = {
     "eldritch-invocation-lifedinker": {
         "title": "Eldritch Invocation: Lifedrinker",
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
+=======
+    "artificer-arcane-jolt": {
+        "title": "Artificer: Use Arcane Jolt",
+        "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
+>>>>>>> 820de29 (Implement Artificer: Battlesmith Arcane Jolt)
         "type": "bool",
         "default": false
     }

--- a/dist/fvtt_script.js
+++ b/dist/fvtt_script.js
@@ -423,13 +423,6 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
-    "roll20-spell-description-display": {
-        "title": "Display Spell Descriptions in spell attacks",
-        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
-        "type": "bool",
-        "default": false
-    },
-
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",
@@ -740,7 +733,6 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
-<<<<<<< HEAD
     "cleric-blessed-strikes": {
         "title": "Cleric: Blessed Strikes",
         "description": "Deal an extra 1d8 damage on damaging cantrips and weapon attacks",
@@ -762,11 +754,12 @@ const character_settings = {
     "eldritch-invocation-lifedinker": {
         "title": "Eldritch Invocation: Lifedrinker",
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
-=======
+        "type": "bool",
+        "default": false
+    },
     "artificer-arcane-jolt": {
         "title": "Artificer: Use Arcane Jolt",
         "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
->>>>>>> 820de29 (Implement Artificer: Battlesmith Arcane Jolt)
         "type": "bool",
         "default": false
     }

--- a/dist/options.js
+++ b/dist/options.js
@@ -732,6 +732,7 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+<<<<<<< HEAD
     "cleric-blessed-strikes": {
         "title": "Cleric: Blessed Strikes",
         "description": "Deal an extra 1d8 damage on damaging cantrips and weapon attacks",
@@ -753,6 +754,11 @@ const character_settings = {
     "eldritch-invocation-lifedinker": {
         "title": "Eldritch Invocation: Lifedrinker",
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
+=======
+    "artificer-arcane-jolt": {
+        "title": "Artificer: Use Arcane Jolt",
+        "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
+>>>>>>> 820de29 (Implement Artificer: Battlesmith Arcane Jolt)
         "type": "bool",
         "default": false
     }

--- a/dist/options.js
+++ b/dist/options.js
@@ -422,6 +422,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "default": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/dist/options.js
+++ b/dist/options.js
@@ -422,13 +422,6 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
-    "roll20-spell-description-display": {
-        "title": "Display Spell Descriptions in spell attacks",
-        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
-        "type": "bool",
-        "default": false
-    },
-
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",
@@ -739,7 +732,6 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
-<<<<<<< HEAD
     "cleric-blessed-strikes": {
         "title": "Cleric: Blessed Strikes",
         "description": "Deal an extra 1d8 damage on damaging cantrips and weapon attacks",
@@ -761,11 +753,12 @@ const character_settings = {
     "eldritch-invocation-lifedinker": {
         "title": "Eldritch Invocation: Lifedrinker",
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
-=======
+        "type": "bool",
+        "default": false
+    },
     "artificer-arcane-jolt": {
         "title": "Artificer: Use Arcane Jolt",
         "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
->>>>>>> 820de29 (Implement Artificer: Battlesmith Arcane Jolt)
         "type": "bool",
         "default": false
     }

--- a/dist/popup.js
+++ b/dist/popup.js
@@ -468,6 +468,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "default": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/dist/popup.js
+++ b/dist/popup.js
@@ -778,6 +778,7 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+<<<<<<< HEAD
     "cleric-blessed-strikes": {
         "title": "Cleric: Blessed Strikes",
         "description": "Deal an extra 1d8 damage on damaging cantrips and weapon attacks",
@@ -799,6 +800,11 @@ const character_settings = {
     "eldritch-invocation-lifedinker": {
         "title": "Eldritch Invocation: Lifedrinker",
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
+=======
+    "artificer-arcane-jolt": {
+        "title": "Artificer: Use Arcane Jolt",
+        "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
+>>>>>>> 820de29 (Implement Artificer: Battlesmith Arcane Jolt)
         "type": "bool",
         "default": false
     }
@@ -1862,6 +1868,10 @@ function populateCharacter(response) {
         }
         if (response["class-features"].includes("Eldritch Invocations: Lifedrinker")) {
             e = createHTMLOption("eldritch-invocation-lifedinker", false, character_settings);
+            options.append(e);
+        }
+        if (response["class-features"].includes("Arcane Jolt")) {
+            e = createHTMLOption("artificer-arcane-jolt", false, character_settings);
             options.append(e);
         }
 

--- a/dist/popup.js
+++ b/dist/popup.js
@@ -468,13 +468,6 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
-    "roll20-spell-description-display": {
-        "title": "Display Spell Descriptions in spell attacks",
-        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
-        "type": "bool",
-        "default": false
-    },
-
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",
@@ -785,7 +778,6 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
-<<<<<<< HEAD
     "cleric-blessed-strikes": {
         "title": "Cleric: Blessed Strikes",
         "description": "Deal an extra 1d8 damage on damaging cantrips and weapon attacks",
@@ -807,11 +799,12 @@ const character_settings = {
     "eldritch-invocation-lifedinker": {
         "title": "Eldritch Invocation: Lifedrinker",
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
-=======
+        "type": "bool",
+        "default": false
+    },
     "artificer-arcane-jolt": {
         "title": "Artificer: Use Arcane Jolt",
         "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
->>>>>>> 820de29 (Implement Artificer: Battlesmith Arcane Jolt)
         "type": "bool",
         "default": false
     }

--- a/dist/roll20.js
+++ b/dist/roll20.js
@@ -732,6 +732,7 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+<<<<<<< HEAD
     "cleric-blessed-strikes": {
         "title": "Cleric: Blessed Strikes",
         "description": "Deal an extra 1d8 damage on damaging cantrips and weapon attacks",
@@ -753,6 +754,11 @@ const character_settings = {
     "eldritch-invocation-lifedinker": {
         "title": "Eldritch Invocation: Lifedrinker",
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
+=======
+    "artificer-arcane-jolt": {
+        "title": "Artificer: Use Arcane Jolt",
+        "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
+>>>>>>> 820de29 (Implement Artificer: Battlesmith Arcane Jolt)
         "type": "bool",
         "default": false
     }

--- a/dist/roll20.js
+++ b/dist/roll20.js
@@ -422,6 +422,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "default": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/dist/roll20.js
+++ b/dist/roll20.js
@@ -422,13 +422,6 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
-    "roll20-spell-description-display": {
-        "title": "Display Spell Descriptions in spell attacks",
-        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
-        "type": "bool",
-        "default": false
-    },
-
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",
@@ -739,7 +732,6 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
-<<<<<<< HEAD
     "cleric-blessed-strikes": {
         "title": "Cleric: Blessed Strikes",
         "description": "Deal an extra 1d8 damage on damaging cantrips and weapon attacks",
@@ -761,11 +753,12 @@ const character_settings = {
     "eldritch-invocation-lifedinker": {
         "title": "Eldritch Invocation: Lifedrinker",
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
-=======
+        "type": "bool",
+        "default": false
+    },
     "artificer-arcane-jolt": {
         "title": "Artificer: Use Arcane Jolt",
         "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
->>>>>>> 820de29 (Implement Artificer: Battlesmith Arcane Jolt)
         "type": "bool",
         "default": false
     }

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -587,6 +587,12 @@ const character_settings = {
         "description": "Your pact weapon drips with necrotic energy, lending extra damage to your strikes",
         "type": "bool",
         "default": false
+    },
+    "artificer-arcane-jolt": {
+        "title": "Artificer: Use Arcane Jolt",
+        "description": "Apply an Arcane Jolt to you or your Steel Defender's Weapon Attacks. Deals extra 2d6 damage, or 4d6 at Artificer Level 15+",
+        "type": "bool",
+        "default": false
     }
 }
 

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -254,13 +254,6 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
-    "roll20-spell-description-display": {
-        "title": "Display Spell Descriptions in spell attacks",
-        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
-        "type": "bool",
-        "default": false
-    },
-
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -254,6 +254,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "default": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -553,6 +553,17 @@ function rollItem(force_display = false, force_to_hit_only = false, force_damage
                     brutal += 1;
             }
         }
+
+        //Artificer Battlemaster Arcane Jolt
+        // TODO: Implement for Steel Defender at later date
+        if (damages.length > 0 &&
+            character.hasClassFeature("Arcane Jolt") &&
+            character.getSetting("artificer-arcane-jolt", false) &&
+            item_type.indexOf(", Common") === -1) {
+            damages.push(character._level < 15 ? "2d6" : "4d6");
+            damage_types.push("Arcane Jolt");
+        }
+
         const roll_properties = buildAttackRoll(character,
             "item",
             item_name,

--- a/src/extension/popup.js
+++ b/src/extension/popup.js
@@ -229,6 +229,10 @@ function populateCharacter(response) {
             e = createHTMLOption("eldritch-invocation-lifedinker", false, character_settings);
             options.append(e);
         }
+        if (response["class-features"].includes("Arcane Jolt")) {
+            e = createHTMLOption("artificer-arcane-jolt", false, character_settings);
+            options.append(e);
+        }
 
         loadSettings(response.settings, character_settings);
     }


### PR DESCRIPTION
Applies to Magical Weapon Attacks
Based on weapon not containing ", Common" in item_type
May be a better way to account for "Magical Weapon" as this also does not cover infusions.