### PR TITLE
Implement Oath of Conquest: Invincible Conquerer

### DIFF
--- a/dist/background.js
+++ b/dist/background.js
@@ -649,7 +649,14 @@ const character_settings = {
         "description": "Unleash your divine soul to deal extra radiant damage equal to your level.",
         "type": "bool",
         "default": false
+    },
+    "paladin-invincible-conquerer": {
+        "title": "Oath of Conquest: Invincible Conquerer",
+        "description": "You can harness extraordinary martial prowess for 1 minute.",
+        "type": "bool",
+        "default": false
     }
+    
 }
 
 function getStorage() {

--- a/dist/default_popup.js
+++ b/dist/default_popup.js
@@ -605,7 +605,14 @@ const character_settings = {
         "description": "Unleash your divine soul to deal extra radiant damage equal to your level.",
         "type": "bool",
         "default": false
+    },
+    "paladin-invincible-conquerer": {
+        "title": "Oath of Conquest: Invincible Conquerer",
+        "description": "You can harness extraordinary martial prowess for 1 minute.",
+        "type": "bool",
+        "default": false
     }
+    
 }
 
 function getStorage() {

--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -604,7 +604,14 @@ const character_settings = {
         "description": "Unleash your divine soul to deal extra radiant damage equal to your level.",
         "type": "bool",
         "default": false
+    },
+    "paladin-invincible-conquerer": {
+        "title": "Oath of Conquest: Invincible Conquerer",
+        "description": "You can harness extraordinary martial prowess for 1 minute.",
+        "type": "bool",
+        "default": false
     }
+    
 }
 
 function getStorage() {
@@ -4601,6 +4608,9 @@ function rollItem(force_display = false) {
             critical_limit = 19;
         if (character.hasClassFeature("Improved Critical"))
             critical_limit = 19;
+        if (character.hasClassFeature("Invincible Conqueror") &&
+            character.getSetting("paladin-invincible-conquerer", false))
+            critical_limit = 19;
         if (character.hasClassFeature("Superior Critical"))
             critical_limit = 18;
 
@@ -4715,6 +4725,9 @@ function rollAction(paneClass) {
                 character.getSetting("paladin-legendary-strike", false))
                 critical_limit = 19;
             if (character.hasClassFeature("Improved Critical"))
+                critical_limit = 19;
+            if (character.hasClassFeature("Invincible Conqueror") &&
+                character.getSetting("paladin-invincible-conquerer", false))
                 critical_limit = 19;
             if (character.hasClassFeature("Superior Critical"))
                 critical_limit = 18;

--- a/dist/dndbeyond_encounter.js
+++ b/dist/dndbeyond_encounter.js
@@ -604,7 +604,14 @@ const character_settings = {
         "description": "Unleash your divine soul to deal extra radiant damage equal to your level.",
         "type": "bool",
         "default": false
+    },
+    "paladin-invincible-conquerer": {
+        "title": "Oath of Conquest: Invincible Conquerer",
+        "description": "You can harness extraordinary martial prowess for 1 minute.",
+        "type": "bool",
+        "default": false
     }
+    
 }
 
 function getStorage() {

--- a/dist/dndbeyond_item.js
+++ b/dist/dndbeyond_item.js
@@ -604,7 +604,14 @@ const character_settings = {
         "description": "Unleash your divine soul to deal extra radiant damage equal to your level.",
         "type": "bool",
         "default": false
+    },
+    "paladin-invincible-conquerer": {
+        "title": "Oath of Conquest: Invincible Conquerer",
+        "description": "You can harness extraordinary martial prowess for 1 minute.",
+        "type": "bool",
+        "default": false
     }
+    
 }
 
 function getStorage() {

--- a/dist/dndbeyond_monster.js
+++ b/dist/dndbeyond_monster.js
@@ -604,7 +604,14 @@ const character_settings = {
         "description": "Unleash your divine soul to deal extra radiant damage equal to your level.",
         "type": "bool",
         "default": false
+    },
+    "paladin-invincible-conquerer": {
+        "title": "Oath of Conquest: Invincible Conquerer",
+        "description": "You can harness extraordinary martial prowess for 1 minute.",
+        "type": "bool",
+        "default": false
     }
+    
 }
 
 function getStorage() {

--- a/dist/dndbeyond_spell.js
+++ b/dist/dndbeyond_spell.js
@@ -604,7 +604,14 @@ const character_settings = {
         "description": "Unleash your divine soul to deal extra radiant damage equal to your level.",
         "type": "bool",
         "default": false
+    },
+    "paladin-invincible-conquerer": {
+        "title": "Oath of Conquest: Invincible Conquerer",
+        "description": "You can harness extraordinary martial prowess for 1 minute.",
+        "type": "bool",
+        "default": false
     }
+    
 }
 
 function getStorage() {

--- a/dist/dndbeyond_vehicle.js
+++ b/dist/dndbeyond_vehicle.js
@@ -604,7 +604,14 @@ const character_settings = {
         "description": "Unleash your divine soul to deal extra radiant damage equal to your level.",
         "type": "bool",
         "default": false
+    },
+    "paladin-invincible-conquerer": {
+        "title": "Oath of Conquest: Invincible Conquerer",
+        "description": "You can harness extraordinary martial prowess for 1 minute.",
+        "type": "bool",
+        "default": false
     }
+    
 }
 
 function getStorage() {

--- a/dist/fvtt.js
+++ b/dist/fvtt.js
@@ -604,7 +604,14 @@ const character_settings = {
         "description": "Unleash your divine soul to deal extra radiant damage equal to your level.",
         "type": "bool",
         "default": false
+    },
+    "paladin-invincible-conquerer": {
+        "title": "Oath of Conquest: Invincible Conquerer",
+        "description": "You can harness extraordinary martial prowess for 1 minute.",
+        "type": "bool",
+        "default": false
     }
+    
 }
 
 function getStorage() {

--- a/dist/fvtt_script.js
+++ b/dist/fvtt_script.js
@@ -605,7 +605,14 @@ const character_settings = {
         "description": "Unleash your divine soul to deal extra radiant damage equal to your level.",
         "type": "bool",
         "default": false
+    },
+    "paladin-invincible-conquerer": {
+        "title": "Oath of Conquest: Invincible Conquerer",
+        "description": "You can harness extraordinary martial prowess for 1 minute.",
+        "type": "bool",
+        "default": false
     }
+    
 }
 
 function getStorage() {

--- a/dist/options.js
+++ b/dist/options.js
@@ -604,7 +604,14 @@ const character_settings = {
         "description": "Unleash your divine soul to deal extra radiant damage equal to your level.",
         "type": "bool",
         "default": false
+    },
+    "paladin-invincible-conquerer": {
+        "title": "Oath of Conquest: Invincible Conquerer",
+        "description": "You can harness extraordinary martial prowess for 1 minute.",
+        "type": "bool",
+        "default": false
     }
+    
 }
 
 function getStorage() {

--- a/dist/popup.js
+++ b/dist/popup.js
@@ -649,7 +649,14 @@ const character_settings = {
         "description": "Unleash your divine soul to deal extra radiant damage equal to your level.",
         "type": "bool",
         "default": false
+    },
+    "paladin-invincible-conquerer": {
+        "title": "Oath of Conquest: Invincible Conquerer",
+        "description": "You can harness extraordinary martial prowess for 1 minute.",
+        "type": "bool",
+        "default": false
     }
+    
 }
 
 function getStorage() {
@@ -1413,6 +1420,10 @@ function populateCharacter(response) {
         }
         if (response["racial-traits"].includes("Radiant Soul")) {
             e = createHTMLOption("protector-aasimar-radiant-soul", false, character_settings);
+            options.append(e);
+        }
+        if (response["class-features"].includes("Invincible Conqueror")) {
+            e = createHTMLOption("paladin-invincible-conquerer", false, character_settings);
             options.append(e);
         }
 

--- a/dist/roll20.js
+++ b/dist/roll20.js
@@ -604,7 +604,14 @@ const character_settings = {
         "description": "Unleash your divine soul to deal extra radiant damage equal to your level.",
         "type": "bool",
         "default": false
+    },
+    "paladin-invincible-conquerer": {
+        "title": "Oath of Conquest: Invincible Conquerer",
+        "description": "You can harness extraordinary martial prowess for 1 minute.",
+        "type": "bool",
+        "default": false
     }
+    
 }
 
 function getStorage() {

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -451,7 +451,14 @@ const character_settings = {
         "description": "Unleash your divine soul to deal extra radiant damage equal to your level.",
         "type": "bool",
         "default": false
+    },
+    "paladin-invincible-conquerer": {
+        "title": "Oath of Conquest: Invincible Conquerer",
+        "description": "You can harness extraordinary martial prowess for 1 minute.",
+        "type": "bool",
+        "default": false
     }
+    
 }
 
 function getStorage() {

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -355,6 +355,9 @@ function rollItem(force_display = false) {
             critical_limit = 19;
         if (character.hasClassFeature("Improved Critical"))
             critical_limit = 19;
+        if (character.hasClassFeature("Invincible Conqueror") &&
+            character.getSetting("paladin-invincible-conquerer", false))
+            critical_limit = 19;
         if (character.hasClassFeature("Superior Critical"))
             critical_limit = 18;
 
@@ -469,6 +472,9 @@ function rollAction(paneClass) {
                 character.getSetting("paladin-legendary-strike", false))
                 critical_limit = 19;
             if (character.hasClassFeature("Improved Critical"))
+                critical_limit = 19;
+            if (character.hasClassFeature("Invincible Conqueror") &&
+                character.getSetting("paladin-invincible-conquerer", false))
                 critical_limit = 19;
             if (character.hasClassFeature("Superior Critical"))
                 critical_limit = 18;

--- a/src/extension/popup.js
+++ b/src/extension/popup.js
@@ -179,6 +179,10 @@ function populateCharacter(response) {
             e = createHTMLOption("protector-aasimar-radiant-soul", false, character_settings);
             options.append(e);
         }
+        if (response["class-features"].includes("Invincible Conqueror")) {
+            e = createHTMLOption("paladin-invincible-conquerer", false, character_settings);
+            options.append(e);
+        }
 
         loadSettings(response.settings, character_settings);
     }


### PR DESCRIPTION
https://www.dndbeyond.com/classes/paladin#OathofConquest

Invincible Conqueror
At 20th level, you gain the ability to harness extraordinary martial prowess. As an action, you can magically become an avatar of conquest, gaining the following benefits for 1 minute:

You have resistance to all damage.
When you take the Attack action on your turn, you can make one additional attack as part of that action.
Your melee weapon attacks score a critical hit on a roll of 19 or 20 on the d20.