### PR TITLE
#409 First mostly working implementation of turn tracker.

### DIFF
--- a/dist/background.js
+++ b/dist/background.js
@@ -487,6 +487,13 @@ const options_list = {
         "default": ""
     },
 
+    "sync-combat-tracker": {
+        "title": "Sync D&D Beyond Encounter with VTT turn tracker",
+        "description": "Currently only supports roll 20.",
+        "type": "bool",
+        "default": false
+    },
+
     "donate": {
         "short": "Buy rations (1 day) to feed my familiar",
         "title": "Become a patron of the art of software development!",
@@ -1131,7 +1138,7 @@ function setDiscordChannelsSetting(name, settings) {
     if (!dropdowns.find(d => d.active)) dropdowns[0].active = true;
     if (dropdowns.find(d => d.secret)) dropdowns.push({ name: "Delete selected channel", action: "delete" })
     dropdowns.push({ name: "Add new channel", action: "add" })
-    
+
     console.log("Added new options", dropdowns);
     fillDisordChannelsDropdown(name, dropdowns);
 }
@@ -1149,7 +1156,7 @@ function fillDisordChannelsDropdown(name, dropdowns, triggerChange=false) {
     const active = dropdowns.find(d => d.active);
     input.text(active.name);
     input.attr("data-secret", active.secret.slice(0, 12));
-    
+
     $("#beyond20-option-discord-channels li").off('click').click(ev => {
         ev.stopPropagation();
         ev.preventDefault()
@@ -1169,7 +1176,7 @@ function fillDisordChannelsDropdown(name, dropdowns, triggerChange=false) {
     $("#beyond20-option-discord-channels li[data-action=add]").off('click').click(ev => {
         ev.stopPropagation();
         ev.preventDefault()
-        
+
         dropdown_menu.removeClass('open');
         button_group.removeClass('open');
         m.set('triangle').size(10);
@@ -1385,10 +1392,19 @@ function onRollFailure(request, sendResponse) {
     });
 }
 
+
+const acceptedActions = [
+    "roll",
+    "rendered-roll",
+    "hp-update",
+    "conditions-update",
+    "combat-tracker",
+];
+
 function onMessage(request, sender, sendResponse) {
     console.log("Received message: ", request)
-    if (["roll", "rendered-roll", "hp-update", "conditions-update"].includes(request.action)) {
-        makeFailureCB = (trackFailure, vtt, sendResponse) => {
+    if (acceptedActions.includes(request.action)) {
+        const makeFailureCB = (trackFailure, vtt, sendResponse) => {
             return (result) => {
                 trackFailure[vtt] = result
                 console.log("Result of sending to VTT ", vtt, ": ", result)

--- a/dist/background.js
+++ b/dist/background.js
@@ -488,10 +488,10 @@ const options_list = {
     },
 
     "sync-combat-tracker": {
-        "title": "Sync D&D Beyond Encounter with VTT turn tracker",
-        "description": "Currently only supports roll 20.",
+        "title": "Synchronize the Combat Tracker with the VTT",
+        "description": "Overwrites the VTT's combat tracker with the details from D&D Beyond's Encounter tool (Roll20 only)",
         "type": "bool",
-        "default": false
+        "default": true
     },
 
     "donate": {
@@ -1393,17 +1393,17 @@ function onRollFailure(request, sendResponse) {
 }
 
 
-const acceptedActions = [
+const forwardedActions = [
     "roll",
     "rendered-roll",
     "hp-update",
     "conditions-update",
-    "combat-tracker",
+    "update-combat",
 ];
 
 function onMessage(request, sender, sendResponse) {
     console.log("Received message: ", request)
-    if (acceptedActions.includes(request.action)) {
+    if (forwardedActions.includes(request.action)) {
         const makeFailureCB = (trackFailure, vtt, sendResponse) => {
             return (result) => {
                 trackFailure[vtt] = result

--- a/dist/default_popup.js
+++ b/dist/default_popup.js
@@ -444,10 +444,10 @@ const options_list = {
     },
 
     "sync-combat-tracker": {
-        "title": "Sync D&D Beyond Encounter with VTT turn tracker",
-        "description": "Currently only supports roll 20.",
+        "title": "Synchronize the Combat Tracker with the VTT",
+        "description": "Overwrites the VTT's combat tracker with the details from D&D Beyond's Encounter tool (Roll20 only)",
         "type": "bool",
-        "default": false
+        "default": true
     },
 
     "donate": {

--- a/dist/default_popup.js
+++ b/dist/default_popup.js
@@ -443,6 +443,13 @@ const options_list = {
         "default": ""
     },
 
+    "sync-combat-tracker": {
+        "title": "Sync D&D Beyond Encounter with VTT turn tracker",
+        "description": "Currently only supports roll 20.",
+        "type": "bool",
+        "default": false
+    },
+
     "donate": {
         "short": "Buy rations (1 day) to feed my familiar",
         "title": "Become a patron of the art of software development!",
@@ -1087,7 +1094,7 @@ function setDiscordChannelsSetting(name, settings) {
     if (!dropdowns.find(d => d.active)) dropdowns[0].active = true;
     if (dropdowns.find(d => d.secret)) dropdowns.push({ name: "Delete selected channel", action: "delete" })
     dropdowns.push({ name: "Add new channel", action: "add" })
-    
+
     console.log("Added new options", dropdowns);
     fillDisordChannelsDropdown(name, dropdowns);
 }
@@ -1105,7 +1112,7 @@ function fillDisordChannelsDropdown(name, dropdowns, triggerChange=false) {
     const active = dropdowns.find(d => d.active);
     input.text(active.name);
     input.attr("data-secret", active.secret.slice(0, 12));
-    
+
     $("#beyond20-option-discord-channels li").off('click').click(ev => {
         ev.stopPropagation();
         ev.preventDefault()
@@ -1125,7 +1132,7 @@ function fillDisordChannelsDropdown(name, dropdowns, triggerChange=false) {
     $("#beyond20-option-discord-channels li[data-action=add]").off('click').click(ev => {
         ev.stopPropagation();
         ev.preventDefault()
-        
+
         dropdown_menu.removeClass('open');
         button_group.removeClass('open');
         m.set('triangle').size(10);

--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -442,6 +442,13 @@ const options_list = {
         "default": ""
     },
 
+    "sync-combat-tracker": {
+        "title": "Sync D&D Beyond Encounter with VTT turn tracker",
+        "description": "Currently only supports roll 20.",
+        "type": "bool",
+        "default": false
+    },
+
     "donate": {
         "short": "Buy rations (1 day) to feed my familiar",
         "title": "Become a patron of the art of software development!",
@@ -1086,7 +1093,7 @@ function setDiscordChannelsSetting(name, settings) {
     if (!dropdowns.find(d => d.active)) dropdowns[0].active = true;
     if (dropdowns.find(d => d.secret)) dropdowns.push({ name: "Delete selected channel", action: "delete" })
     dropdowns.push({ name: "Add new channel", action: "add" })
-    
+
     console.log("Added new options", dropdowns);
     fillDisordChannelsDropdown(name, dropdowns);
 }
@@ -1104,7 +1111,7 @@ function fillDisordChannelsDropdown(name, dropdowns, triggerChange=false) {
     const active = dropdowns.find(d => d.active);
     input.text(active.name);
     input.attr("data-secret", active.secret.slice(0, 12));
-    
+
     $("#beyond20-option-discord-channels li").off('click').click(ev => {
         ev.stopPropagation();
         ev.preventDefault()
@@ -1124,7 +1131,7 @@ function fillDisordChannelsDropdown(name, dropdowns, triggerChange=false) {
     $("#beyond20-option-discord-channels li[data-action=add]").off('click').click(ev => {
         ev.stopPropagation();
         ev.preventDefault()
-        
+
         dropdown_menu.removeClass('open');
         button_group.removeClass('open');
         m.set('triangle').size(10);

--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -443,10 +443,10 @@ const options_list = {
     },
 
     "sync-combat-tracker": {
-        "title": "Sync D&D Beyond Encounter with VTT turn tracker",
-        "description": "Currently only supports roll 20.",
+        "title": "Synchronize the Combat Tracker with the VTT",
+        "description": "Overwrites the VTT's combat tracker with the details from D&D Beyond's Encounter tool (Roll20 only)",
         "type": "bool",
-        "default": false
+        "default": true
     },
 
     "donate": {
@@ -2977,7 +2977,7 @@ function buildAttackRoll(character, attack_source, name, description, properties
                     }
                 }
                 const isBrutal = character.hasClassFeature("Brutal Critical");
-                const isSavage = character.hasRacialTrait("Savage Attacks");   
+                const isSavage = character.hasRacialTrait("Savage Attacks");
                 if (highest_dice != 0) {
                     crit_damages.push(`${brutal}d${highest_dice}`);
                     crit_damage_types.push(isBrutal && isSavage ? "Savage Attacks & Brutal" : (isBrutal ? "Brutal" : "Savage Attacks"));
@@ -2985,7 +2985,7 @@ function buildAttackRoll(character, attack_source, name, description, properties
                     crit_damages.push(`${homebrew_max_damage}`);
                     crit_damage_types.push(isBrutal && isSavage ? "Savage Attacks & Brutal" : (isBrutal ? "Brutal" : "Savage Attacks"));
                 }
-                
+
             }
             roll_properties["critical-damages"] = crit_damages;
             roll_properties["critical-damage-types"] = crit_damage_types;
@@ -3245,7 +3245,7 @@ function injectDiceToRolls(selector, character, name = "") {
 }
 
 function beyond20SendMessageFailure(character, response) {
-    if (!response)
+    if (!response || (response.request && response.request.action === "update-combat"))
         return;
     console.log("Received response : ", response);
     if (["roll", "rendered-roll"].includes(response.request.action)  && (response.vtt == "dndbeyond" || response.error)) {

--- a/dist/dndbeyond_item.js
+++ b/dist/dndbeyond_item.js
@@ -442,6 +442,13 @@ const options_list = {
         "default": ""
     },
 
+    "sync-combat-tracker": {
+        "title": "Sync D&D Beyond Encounter with VTT turn tracker",
+        "description": "Currently only supports roll 20.",
+        "type": "bool",
+        "default": false
+    },
+
     "donate": {
         "short": "Buy rations (1 day) to feed my familiar",
         "title": "Become a patron of the art of software development!",
@@ -1086,7 +1093,7 @@ function setDiscordChannelsSetting(name, settings) {
     if (!dropdowns.find(d => d.active)) dropdowns[0].active = true;
     if (dropdowns.find(d => d.secret)) dropdowns.push({ name: "Delete selected channel", action: "delete" })
     dropdowns.push({ name: "Add new channel", action: "add" })
-    
+
     console.log("Added new options", dropdowns);
     fillDisordChannelsDropdown(name, dropdowns);
 }
@@ -1104,7 +1111,7 @@ function fillDisordChannelsDropdown(name, dropdowns, triggerChange=false) {
     const active = dropdowns.find(d => d.active);
     input.text(active.name);
     input.attr("data-secret", active.secret.slice(0, 12));
-    
+
     $("#beyond20-option-discord-channels li").off('click').click(ev => {
         ev.stopPropagation();
         ev.preventDefault()
@@ -1124,7 +1131,7 @@ function fillDisordChannelsDropdown(name, dropdowns, triggerChange=false) {
     $("#beyond20-option-discord-channels li[data-action=add]").off('click').click(ev => {
         ev.stopPropagation();
         ev.preventDefault()
-        
+
         dropdown_menu.removeClass('open');
         button_group.removeClass('open');
         m.set('triangle').size(10);

--- a/dist/dndbeyond_item.js
+++ b/dist/dndbeyond_item.js
@@ -443,10 +443,10 @@ const options_list = {
     },
 
     "sync-combat-tracker": {
-        "title": "Sync D&D Beyond Encounter with VTT turn tracker",
-        "description": "Currently only supports roll 20.",
+        "title": "Synchronize the Combat Tracker with the VTT",
+        "description": "Overwrites the VTT's combat tracker with the details from D&D Beyond's Encounter tool (Roll20 only)",
         "type": "bool",
-        "default": false
+        "default": true
     },
 
     "donate": {
@@ -2977,7 +2977,7 @@ function buildAttackRoll(character, attack_source, name, description, properties
                     }
                 }
                 const isBrutal = character.hasClassFeature("Brutal Critical");
-                const isSavage = character.hasRacialTrait("Savage Attacks");   
+                const isSavage = character.hasRacialTrait("Savage Attacks");
                 if (highest_dice != 0) {
                     crit_damages.push(`${brutal}d${highest_dice}`);
                     crit_damage_types.push(isBrutal && isSavage ? "Savage Attacks & Brutal" : (isBrutal ? "Brutal" : "Savage Attacks"));
@@ -2985,7 +2985,7 @@ function buildAttackRoll(character, attack_source, name, description, properties
                     crit_damages.push(`${homebrew_max_damage}`);
                     crit_damage_types.push(isBrutal && isSavage ? "Savage Attacks & Brutal" : (isBrutal ? "Brutal" : "Savage Attacks"));
                 }
-                
+
             }
             roll_properties["critical-damages"] = crit_damages;
             roll_properties["critical-damage-types"] = crit_damage_types;
@@ -3245,7 +3245,7 @@ function injectDiceToRolls(selector, character, name = "") {
 }
 
 function beyond20SendMessageFailure(character, response) {
-    if (!response)
+    if (!response || (response.request && response.request.action === "update-combat"))
         return;
     console.log("Received response : ", response);
     if (["roll", "rendered-roll"].includes(response.request.action)  && (response.vtt == "dndbeyond" || response.error)) {

--- a/dist/dndbeyond_monster.js
+++ b/dist/dndbeyond_monster.js
@@ -442,6 +442,13 @@ const options_list = {
         "default": ""
     },
 
+    "sync-combat-tracker": {
+        "title": "Sync D&D Beyond Encounter with VTT turn tracker",
+        "description": "Currently only supports roll 20.",
+        "type": "bool",
+        "default": false
+    },
+
     "donate": {
         "short": "Buy rations (1 day) to feed my familiar",
         "title": "Become a patron of the art of software development!",
@@ -1086,7 +1093,7 @@ function setDiscordChannelsSetting(name, settings) {
     if (!dropdowns.find(d => d.active)) dropdowns[0].active = true;
     if (dropdowns.find(d => d.secret)) dropdowns.push({ name: "Delete selected channel", action: "delete" })
     dropdowns.push({ name: "Add new channel", action: "add" })
-    
+
     console.log("Added new options", dropdowns);
     fillDisordChannelsDropdown(name, dropdowns);
 }
@@ -1104,7 +1111,7 @@ function fillDisordChannelsDropdown(name, dropdowns, triggerChange=false) {
     const active = dropdowns.find(d => d.active);
     input.text(active.name);
     input.attr("data-secret", active.secret.slice(0, 12));
-    
+
     $("#beyond20-option-discord-channels li").off('click').click(ev => {
         ev.stopPropagation();
         ev.preventDefault()
@@ -1124,7 +1131,7 @@ function fillDisordChannelsDropdown(name, dropdowns, triggerChange=false) {
     $("#beyond20-option-discord-channels li[data-action=add]").off('click').click(ev => {
         ev.stopPropagation();
         ev.preventDefault()
-        
+
         dropdown_menu.removeClass('open');
         button_group.removeClass('open');
         m.set('triangle').size(10);

--- a/dist/dndbeyond_monster.js
+++ b/dist/dndbeyond_monster.js
@@ -443,10 +443,10 @@ const options_list = {
     },
 
     "sync-combat-tracker": {
-        "title": "Sync D&D Beyond Encounter with VTT turn tracker",
-        "description": "Currently only supports roll 20.",
+        "title": "Synchronize the Combat Tracker with the VTT",
+        "description": "Overwrites the VTT's combat tracker with the details from D&D Beyond's Encounter tool (Roll20 only)",
         "type": "bool",
-        "default": false
+        "default": true
     },
 
     "donate": {
@@ -2977,7 +2977,7 @@ function buildAttackRoll(character, attack_source, name, description, properties
                     }
                 }
                 const isBrutal = character.hasClassFeature("Brutal Critical");
-                const isSavage = character.hasRacialTrait("Savage Attacks");   
+                const isSavage = character.hasRacialTrait("Savage Attacks");
                 if (highest_dice != 0) {
                     crit_damages.push(`${brutal}d${highest_dice}`);
                     crit_damage_types.push(isBrutal && isSavage ? "Savage Attacks & Brutal" : (isBrutal ? "Brutal" : "Savage Attacks"));
@@ -2985,7 +2985,7 @@ function buildAttackRoll(character, attack_source, name, description, properties
                     crit_damages.push(`${homebrew_max_damage}`);
                     crit_damage_types.push(isBrutal && isSavage ? "Savage Attacks & Brutal" : (isBrutal ? "Brutal" : "Savage Attacks"));
                 }
-                
+
             }
             roll_properties["critical-damages"] = crit_damages;
             roll_properties["critical-damage-types"] = crit_damage_types;
@@ -3245,7 +3245,7 @@ function injectDiceToRolls(selector, character, name = "") {
 }
 
 function beyond20SendMessageFailure(character, response) {
-    if (!response)
+    if (!response || (response.request && response.request.action === "update-combat"))
         return;
     console.log("Received response : ", response);
     if (["roll", "rendered-roll"].includes(response.request.action)  && (response.vtt == "dndbeyond" || response.error)) {

--- a/dist/dndbeyond_spell.js
+++ b/dist/dndbeyond_spell.js
@@ -442,6 +442,13 @@ const options_list = {
         "default": ""
     },
 
+    "sync-combat-tracker": {
+        "title": "Sync D&D Beyond Encounter with VTT turn tracker",
+        "description": "Currently only supports roll 20.",
+        "type": "bool",
+        "default": false
+    },
+
     "donate": {
         "short": "Buy rations (1 day) to feed my familiar",
         "title": "Become a patron of the art of software development!",
@@ -1086,7 +1093,7 @@ function setDiscordChannelsSetting(name, settings) {
     if (!dropdowns.find(d => d.active)) dropdowns[0].active = true;
     if (dropdowns.find(d => d.secret)) dropdowns.push({ name: "Delete selected channel", action: "delete" })
     dropdowns.push({ name: "Add new channel", action: "add" })
-    
+
     console.log("Added new options", dropdowns);
     fillDisordChannelsDropdown(name, dropdowns);
 }
@@ -1104,7 +1111,7 @@ function fillDisordChannelsDropdown(name, dropdowns, triggerChange=false) {
     const active = dropdowns.find(d => d.active);
     input.text(active.name);
     input.attr("data-secret", active.secret.slice(0, 12));
-    
+
     $("#beyond20-option-discord-channels li").off('click').click(ev => {
         ev.stopPropagation();
         ev.preventDefault()
@@ -1124,7 +1131,7 @@ function fillDisordChannelsDropdown(name, dropdowns, triggerChange=false) {
     $("#beyond20-option-discord-channels li[data-action=add]").off('click').click(ev => {
         ev.stopPropagation();
         ev.preventDefault()
-        
+
         dropdown_menu.removeClass('open');
         button_group.removeClass('open');
         m.set('triangle').size(10);

--- a/dist/dndbeyond_spell.js
+++ b/dist/dndbeyond_spell.js
@@ -443,10 +443,10 @@ const options_list = {
     },
 
     "sync-combat-tracker": {
-        "title": "Sync D&D Beyond Encounter with VTT turn tracker",
-        "description": "Currently only supports roll 20.",
+        "title": "Synchronize the Combat Tracker with the VTT",
+        "description": "Overwrites the VTT's combat tracker with the details from D&D Beyond's Encounter tool (Roll20 only)",
         "type": "bool",
-        "default": false
+        "default": true
     },
 
     "donate": {
@@ -2977,7 +2977,7 @@ function buildAttackRoll(character, attack_source, name, description, properties
                     }
                 }
                 const isBrutal = character.hasClassFeature("Brutal Critical");
-                const isSavage = character.hasRacialTrait("Savage Attacks");   
+                const isSavage = character.hasRacialTrait("Savage Attacks");
                 if (highest_dice != 0) {
                     crit_damages.push(`${brutal}d${highest_dice}`);
                     crit_damage_types.push(isBrutal && isSavage ? "Savage Attacks & Brutal" : (isBrutal ? "Brutal" : "Savage Attacks"));
@@ -2985,7 +2985,7 @@ function buildAttackRoll(character, attack_source, name, description, properties
                     crit_damages.push(`${homebrew_max_damage}`);
                     crit_damage_types.push(isBrutal && isSavage ? "Savage Attacks & Brutal" : (isBrutal ? "Brutal" : "Savage Attacks"));
                 }
-                
+
             }
             roll_properties["critical-damages"] = crit_damages;
             roll_properties["critical-damage-types"] = crit_damage_types;
@@ -3245,7 +3245,7 @@ function injectDiceToRolls(selector, character, name = "") {
 }
 
 function beyond20SendMessageFailure(character, response) {
-    if (!response)
+    if (!response || (response.request && response.request.action === "update-combat"))
         return;
     console.log("Received response : ", response);
     if (["roll", "rendered-roll"].includes(response.request.action)  && (response.vtt == "dndbeyond" || response.error)) {

--- a/dist/dndbeyond_vehicle.js
+++ b/dist/dndbeyond_vehicle.js
@@ -442,6 +442,13 @@ const options_list = {
         "default": ""
     },
 
+    "sync-combat-tracker": {
+        "title": "Sync D&D Beyond Encounter with VTT turn tracker",
+        "description": "Currently only supports roll 20.",
+        "type": "bool",
+        "default": false
+    },
+
     "donate": {
         "short": "Buy rations (1 day) to feed my familiar",
         "title": "Become a patron of the art of software development!",
@@ -1086,7 +1093,7 @@ function setDiscordChannelsSetting(name, settings) {
     if (!dropdowns.find(d => d.active)) dropdowns[0].active = true;
     if (dropdowns.find(d => d.secret)) dropdowns.push({ name: "Delete selected channel", action: "delete" })
     dropdowns.push({ name: "Add new channel", action: "add" })
-    
+
     console.log("Added new options", dropdowns);
     fillDisordChannelsDropdown(name, dropdowns);
 }
@@ -1104,7 +1111,7 @@ function fillDisordChannelsDropdown(name, dropdowns, triggerChange=false) {
     const active = dropdowns.find(d => d.active);
     input.text(active.name);
     input.attr("data-secret", active.secret.slice(0, 12));
-    
+
     $("#beyond20-option-discord-channels li").off('click').click(ev => {
         ev.stopPropagation();
         ev.preventDefault()
@@ -1124,7 +1131,7 @@ function fillDisordChannelsDropdown(name, dropdowns, triggerChange=false) {
     $("#beyond20-option-discord-channels li[data-action=add]").off('click').click(ev => {
         ev.stopPropagation();
         ev.preventDefault()
-        
+
         dropdown_menu.removeClass('open');
         button_group.removeClass('open');
         m.set('triangle').size(10);

--- a/dist/dndbeyond_vehicle.js
+++ b/dist/dndbeyond_vehicle.js
@@ -443,10 +443,10 @@ const options_list = {
     },
 
     "sync-combat-tracker": {
-        "title": "Sync D&D Beyond Encounter with VTT turn tracker",
-        "description": "Currently only supports roll 20.",
+        "title": "Synchronize the Combat Tracker with the VTT",
+        "description": "Overwrites the VTT's combat tracker with the details from D&D Beyond's Encounter tool (Roll20 only)",
         "type": "bool",
-        "default": false
+        "default": true
     },
 
     "donate": {
@@ -2977,7 +2977,7 @@ function buildAttackRoll(character, attack_source, name, description, properties
                     }
                 }
                 const isBrutal = character.hasClassFeature("Brutal Critical");
-                const isSavage = character.hasRacialTrait("Savage Attacks");   
+                const isSavage = character.hasRacialTrait("Savage Attacks");
                 if (highest_dice != 0) {
                     crit_damages.push(`${brutal}d${highest_dice}`);
                     crit_damage_types.push(isBrutal && isSavage ? "Savage Attacks & Brutal" : (isBrutal ? "Brutal" : "Savage Attacks"));
@@ -2985,7 +2985,7 @@ function buildAttackRoll(character, attack_source, name, description, properties
                     crit_damages.push(`${homebrew_max_damage}`);
                     crit_damage_types.push(isBrutal && isSavage ? "Savage Attacks & Brutal" : (isBrutal ? "Brutal" : "Savage Attacks"));
                 }
-                
+
             }
             roll_properties["critical-damages"] = crit_damages;
             roll_properties["critical-damage-types"] = crit_damage_types;
@@ -3245,7 +3245,7 @@ function injectDiceToRolls(selector, character, name = "") {
 }
 
 function beyond20SendMessageFailure(character, response) {
-    if (!response)
+    if (!response || (response.request && response.request.action === "update-combat"))
         return;
     console.log("Received response : ", response);
     if (["roll", "rendered-roll"].includes(response.request.action)  && (response.vtt == "dndbeyond" || response.error)) {

--- a/dist/fvtt.js
+++ b/dist/fvtt.js
@@ -442,6 +442,13 @@ const options_list = {
         "default": ""
     },
 
+    "sync-combat-tracker": {
+        "title": "Sync D&D Beyond Encounter with VTT turn tracker",
+        "description": "Currently only supports roll 20.",
+        "type": "bool",
+        "default": false
+    },
+
     "donate": {
         "short": "Buy rations (1 day) to feed my familiar",
         "title": "Become a patron of the art of software development!",
@@ -1086,7 +1093,7 @@ function setDiscordChannelsSetting(name, settings) {
     if (!dropdowns.find(d => d.active)) dropdowns[0].active = true;
     if (dropdowns.find(d => d.secret)) dropdowns.push({ name: "Delete selected channel", action: "delete" })
     dropdowns.push({ name: "Add new channel", action: "add" })
-    
+
     console.log("Added new options", dropdowns);
     fillDisordChannelsDropdown(name, dropdowns);
 }
@@ -1104,7 +1111,7 @@ function fillDisordChannelsDropdown(name, dropdowns, triggerChange=false) {
     const active = dropdowns.find(d => d.active);
     input.text(active.name);
     input.attr("data-secret", active.secret.slice(0, 12));
-    
+
     $("#beyond20-option-discord-channels li").off('click').click(ev => {
         ev.stopPropagation();
         ev.preventDefault()
@@ -1124,7 +1131,7 @@ function fillDisordChannelsDropdown(name, dropdowns, triggerChange=false) {
     $("#beyond20-option-discord-channels li[data-action=add]").off('click').click(ev => {
         ev.stopPropagation();
         ev.preventDefault()
-        
+
         dropdown_menu.removeClass('open');
         button_group.removeClass('open');
         m.set('triangle').size(10);

--- a/dist/fvtt.js
+++ b/dist/fvtt.js
@@ -443,10 +443,10 @@ const options_list = {
     },
 
     "sync-combat-tracker": {
-        "title": "Sync D&D Beyond Encounter with VTT turn tracker",
-        "description": "Currently only supports roll 20.",
+        "title": "Synchronize the Combat Tracker with the VTT",
+        "description": "Overwrites the VTT's combat tracker with the details from D&D Beyond's Encounter tool (Roll20 only)",
         "type": "bool",
-        "default": false
+        "default": true
     },
 
     "donate": {

--- a/dist/fvtt_script.js
+++ b/dist/fvtt_script.js
@@ -444,10 +444,10 @@ const options_list = {
     },
 
     "sync-combat-tracker": {
-        "title": "Sync D&D Beyond Encounter with VTT turn tracker",
-        "description": "Currently only supports roll 20.",
+        "title": "Synchronize the Combat Tracker with the VTT",
+        "description": "Overwrites the VTT's combat tracker with the details from D&D Beyond's Encounter tool (Roll20 only)",
         "type": "bool",
-        "default": false
+        "default": true
     },
 
     "donate": {

--- a/dist/fvtt_script.js
+++ b/dist/fvtt_script.js
@@ -443,6 +443,13 @@ const options_list = {
         "default": ""
     },
 
+    "sync-combat-tracker": {
+        "title": "Sync D&D Beyond Encounter with VTT turn tracker",
+        "description": "Currently only supports roll 20.",
+        "type": "bool",
+        "default": false
+    },
+
     "donate": {
         "short": "Buy rations (1 day) to feed my familiar",
         "title": "Become a patron of the art of software development!",
@@ -1087,7 +1094,7 @@ function setDiscordChannelsSetting(name, settings) {
     if (!dropdowns.find(d => d.active)) dropdowns[0].active = true;
     if (dropdowns.find(d => d.secret)) dropdowns.push({ name: "Delete selected channel", action: "delete" })
     dropdowns.push({ name: "Add new channel", action: "add" })
-    
+
     console.log("Added new options", dropdowns);
     fillDisordChannelsDropdown(name, dropdowns);
 }
@@ -1105,7 +1112,7 @@ function fillDisordChannelsDropdown(name, dropdowns, triggerChange=false) {
     const active = dropdowns.find(d => d.active);
     input.text(active.name);
     input.attr("data-secret", active.secret.slice(0, 12));
-    
+
     $("#beyond20-option-discord-channels li").off('click').click(ev => {
         ev.stopPropagation();
         ev.preventDefault()
@@ -1125,7 +1132,7 @@ function fillDisordChannelsDropdown(name, dropdowns, triggerChange=false) {
     $("#beyond20-option-discord-channels li[data-action=add]").off('click').click(ev => {
         ev.stopPropagation();
         ev.preventDefault()
-        
+
         dropdown_menu.removeClass('open');
         button_group.removeClass('open');
         m.set('triangle').size(10);

--- a/dist/options.js
+++ b/dist/options.js
@@ -442,6 +442,13 @@ const options_list = {
         "default": ""
     },
 
+    "sync-combat-tracker": {
+        "title": "Sync D&D Beyond Encounter with VTT turn tracker",
+        "description": "Currently only supports roll 20.",
+        "type": "bool",
+        "default": false
+    },
+
     "donate": {
         "short": "Buy rations (1 day) to feed my familiar",
         "title": "Become a patron of the art of software development!",
@@ -1086,7 +1093,7 @@ function setDiscordChannelsSetting(name, settings) {
     if (!dropdowns.find(d => d.active)) dropdowns[0].active = true;
     if (dropdowns.find(d => d.secret)) dropdowns.push({ name: "Delete selected channel", action: "delete" })
     dropdowns.push({ name: "Add new channel", action: "add" })
-    
+
     console.log("Added new options", dropdowns);
     fillDisordChannelsDropdown(name, dropdowns);
 }
@@ -1104,7 +1111,7 @@ function fillDisordChannelsDropdown(name, dropdowns, triggerChange=false) {
     const active = dropdowns.find(d => d.active);
     input.text(active.name);
     input.attr("data-secret", active.secret.slice(0, 12));
-    
+
     $("#beyond20-option-discord-channels li").off('click').click(ev => {
         ev.stopPropagation();
         ev.preventDefault()
@@ -1124,7 +1131,7 @@ function fillDisordChannelsDropdown(name, dropdowns, triggerChange=false) {
     $("#beyond20-option-discord-channels li[data-action=add]").off('click').click(ev => {
         ev.stopPropagation();
         ev.preventDefault()
-        
+
         dropdown_menu.removeClass('open');
         button_group.removeClass('open');
         m.set('triangle').size(10);

--- a/dist/options.js
+++ b/dist/options.js
@@ -443,10 +443,10 @@ const options_list = {
     },
 
     "sync-combat-tracker": {
-        "title": "Sync D&D Beyond Encounter with VTT turn tracker",
-        "description": "Currently only supports roll 20.",
+        "title": "Synchronize the Combat Tracker with the VTT",
+        "description": "Overwrites the VTT's combat tracker with the details from D&D Beyond's Encounter tool (Roll20 only)",
         "type": "bool",
-        "default": false
+        "default": true
     },
 
     "donate": {

--- a/dist/popup.js
+++ b/dist/popup.js
@@ -488,10 +488,10 @@ const options_list = {
     },
 
     "sync-combat-tracker": {
-        "title": "Sync D&D Beyond Encounter with VTT turn tracker",
-        "description": "Currently only supports roll 20.",
+        "title": "Synchronize the Combat Tracker with the VTT",
+        "description": "Overwrites the VTT's combat tracker with the details from D&D Beyond's Encounter tool (Roll20 only)",
         "type": "bool",
-        "default": false
+        "default": true
     },
 
     "donate": {
@@ -1452,6 +1452,11 @@ function addMonsterOptions() {
     initializeSettings(gotSettings);
 }
 
+function addEncounterOptions() {
+    const options = $(".beyond20-options");
+    options.append(createHTMLOption("sync-combat-tracker", false));
+}
+
 function tabMatches(tab, url) {
     return tab.url.match(url.replace(/\*/g, "[^]*")) != null;
 }
@@ -1480,11 +1485,10 @@ function actOnCurrentTab(tab) {
         initializeSettings(gotSettings);
     } else if (urlMatches(tab.url, DNDBEYOND_CHARACTER_URL)) {
         sendMessageToTab(tab.id, { "action": "get-character" }, populateCharacter);
-    } else if (urlMatches(tab.url, DNDBEYOND_MONSTER_URL) ||
-        urlMatches(tab.url, DNDBEYOND_VEHICLE_URL) ||
-        urlMatches(tab.url, DNDBEYOND_ENCOUNTERS_URL) ||
-        urlMatches(tab.url, DNDBEYOND_ENCOUNTER_URL) ||
-        urlMatches(tab.url, DNDBEYOND_COMBAT_URL)) {
+    } else if (urlMatches(tab.url, DNDBEYOND_MONSTER_URL) || urlMatches(tab.url, DNDBEYOND_VEHICLE_URL)) {
+        addMonsterOptions();
+    } else if (urlMatches(tab.url, DNDBEYOND_COMBAT_URL) || urlMatches(tab.url, DNDBEYOND_ENCOUNTERS_URL) || urlMatches(tab.url, DNDBEYOND_ENCOUNTER_URL)) {
+        addEncounterOptions();
         addMonsterOptions();
     } else {
         initializeSettings(gotSettings);

--- a/dist/popup.js
+++ b/dist/popup.js
@@ -487,6 +487,13 @@ const options_list = {
         "default": ""
     },
 
+    "sync-combat-tracker": {
+        "title": "Sync D&D Beyond Encounter with VTT turn tracker",
+        "description": "Currently only supports roll 20.",
+        "type": "bool",
+        "default": false
+    },
+
     "donate": {
         "short": "Buy rations (1 day) to feed my familiar",
         "title": "Become a patron of the art of software development!",
@@ -1131,7 +1138,7 @@ function setDiscordChannelsSetting(name, settings) {
     if (!dropdowns.find(d => d.active)) dropdowns[0].active = true;
     if (dropdowns.find(d => d.secret)) dropdowns.push({ name: "Delete selected channel", action: "delete" })
     dropdowns.push({ name: "Add new channel", action: "add" })
-    
+
     console.log("Added new options", dropdowns);
     fillDisordChannelsDropdown(name, dropdowns);
 }
@@ -1149,7 +1156,7 @@ function fillDisordChannelsDropdown(name, dropdowns, triggerChange=false) {
     const active = dropdowns.find(d => d.active);
     input.text(active.name);
     input.attr("data-secret", active.secret.slice(0, 12));
-    
+
     $("#beyond20-option-discord-channels li").off('click').click(ev => {
         ev.stopPropagation();
         ev.preventDefault()
@@ -1169,7 +1176,7 @@ function fillDisordChannelsDropdown(name, dropdowns, triggerChange=false) {
     $("#beyond20-option-discord-channels li[data-action=add]").off('click').click(ev => {
         ev.stopPropagation();
         ev.preventDefault()
-        
+
         dropdown_menu.removeClass('open');
         button_group.removeClass('open');
         m.set('triangle').size(10);

--- a/dist/roll20.js
+++ b/dist/roll20.js
@@ -442,6 +442,13 @@ const options_list = {
         "default": ""
     },
 
+    "sync-combat-tracker": {
+        "title": "Sync D&D Beyond Encounter with VTT turn tracker",
+        "description": "Currently only supports roll 20.",
+        "type": "bool",
+        "default": false
+    },
+
     "donate": {
         "short": "Buy rations (1 day) to feed my familiar",
         "title": "Become a patron of the art of software development!",
@@ -1086,7 +1093,7 @@ function setDiscordChannelsSetting(name, settings) {
     if (!dropdowns.find(d => d.active)) dropdowns[0].active = true;
     if (dropdowns.find(d => d.secret)) dropdowns.push({ name: "Delete selected channel", action: "delete" })
     dropdowns.push({ name: "Add new channel", action: "add" })
-    
+
     console.log("Added new options", dropdowns);
     fillDisordChannelsDropdown(name, dropdowns);
 }
@@ -1104,7 +1111,7 @@ function fillDisordChannelsDropdown(name, dropdowns, triggerChange=false) {
     const active = dropdowns.find(d => d.active);
     input.text(active.name);
     input.attr("data-secret", active.secret.slice(0, 12));
-    
+
     $("#beyond20-option-discord-channels li").off('click').click(ev => {
         ev.stopPropagation();
         ev.preventDefault()
@@ -1124,7 +1131,7 @@ function fillDisordChannelsDropdown(name, dropdowns, triggerChange=false) {
     $("#beyond20-option-discord-channels li[data-action=add]").off('click').click(ev => {
         ev.stopPropagation();
         ev.preventDefault()
-        
+
         dropdown_menu.removeClass('open');
         button_group.removeClass('open');
         m.set('triangle').size(10);
@@ -2746,13 +2753,13 @@ function template(request, name, properties) {
     }
 
     result += " &{template:" + name + "}";
-    
+
     if (request.whisper == WhisperType.HIDE_NAMES) {
         if (properties["charname"])
             properties["charname"] = "???"
         // Take into account links for disabled auto-roll-damages option
         if (properties["rname"])
-            properties["rname"] = properties["rname"].includes("](!") ? 
+            properties["rname"] = properties["rname"].includes("](!") ?
                 properties["rname"].replace(/\[[^\]]*\]\(\!/, "[???](!") : "???";
         if (properties["rnamec"])
             properties["rnamec"] = properties["rnamec"].includes("](!") ?
@@ -3381,6 +3388,8 @@ function handleMessage(request, sender, sendResponse) {
         postChatMessage(roll, character_name);
     } else if (request.action == "rendered-roll") {
         handleRenderedRoll(request);
+    } else if (request.action === "combat-tracker") {
+        sendCustomEvent("CombatTracker", [request.combat]);
     }
 }
 

--- a/dist/roll20.js
+++ b/dist/roll20.js
@@ -443,10 +443,10 @@ const options_list = {
     },
 
     "sync-combat-tracker": {
-        "title": "Sync D&D Beyond Encounter with VTT turn tracker",
-        "description": "Currently only supports roll 20.",
+        "title": "Synchronize the Combat Tracker with the VTT",
+        "description": "Overwrites the VTT's combat tracker with the details from D&D Beyond's Encounter tool (Roll20 only)",
         "type": "bool",
-        "default": false
+        "default": true
     },
 
     "donate": {
@@ -3388,7 +3388,7 @@ function handleMessage(request, sender, sendResponse) {
         postChatMessage(roll, character_name);
     } else if (request.action == "rendered-roll") {
         handleRenderedRoll(request);
-    } else if (request.action === "combat-tracker") {
+    } else if (request.action === "update-combat") {
         sendCustomEvent("CombatTracker", [request.combat]);
     }
 }

--- a/dist/roll20_script.js
+++ b/dist/roll20_script.js
@@ -182,6 +182,23 @@ function updateHP(name, current, total, temp) {
     }
 }
 
+function updateCombatTracker(combat) {
+    const index = combat.findIndex(x => x[2]);
+    if (index === -1) {
+        console.warn("It's apparently nobody's turn :/");
+    } else {
+        const c = combat.splice(index, combat.length);
+        combat.splice(0, 0, ...c);
+    }
+    const turnOrder = combat.map(x => ({
+        id: "-1",
+        pr: x[1],
+        custom: x[0],
+    }));
+    Campaign.set("turnorder", JSON.stringify(turnOrder));
+}
+
+
 function checkForOGL() {
     const isOGL = atob(customcharsheet_html).includes(`<rolltemplate class="sheet-rolltemplate-simple">`);
     $("#isOGL").remove();
@@ -195,6 +212,7 @@ function disconnectAllEvents() {
 
 var registered_events = [];
 registered_events.push(addCustomEventListener("UpdateHP", updateHP));
+registered_events.push(addCustomEventListener("CombatTracker", updateCombatTracker));
 registered_events.push(addCustomEventListener("disconnect", disconnectAllEvents));
 
 // Hack for VTT ES making every script load before Roll20 loads

--- a/dist/roll20_script.js
+++ b/dist/roll20_script.js
@@ -183,19 +183,23 @@ function updateHP(name, current, total, temp) {
 }
 
 function updateCombatTracker(combat) {
-    const index = combat.findIndex(x => x[2]);
+    const index = combat.findIndex(x => x.turn);
     if (index === -1) {
         console.warn("It's apparently nobody's turn :/");
     } else {
+        // Roll20 needs the unit whose turn it is at the top of the array.
         const c = combat.splice(index, combat.length);
         combat.splice(0, 0, ...c);
     }
     const turnOrder = combat.map(x => ({
         id: "-1",
-        pr: x[1],
-        custom: x[0],
+        pr: x.initiative,
+        custom: x.name,
     }));
     Campaign.set("turnorder", JSON.stringify(turnOrder));
+    // Make sure the turn tracker window is open
+    // This also forces roll20 to sync the initiative tracker state to other clients.
+    $("#startrounds").click();
 }
 
 

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -290,10 +290,10 @@ const options_list = {
     },
 
     "sync-combat-tracker": {
-        "title": "Sync D&D Beyond Encounter with VTT turn tracker",
-        "description": "Currently only supports roll 20.",
+        "title": "Synchronize the Combat Tracker with the VTT",
+        "description": "Overwrites the VTT's combat tracker with the details from D&D Beyond's Encounter tool (Roll20 only)",
         "type": "bool",
-        "default": false
+        "default": true
     },
 
     "donate": {

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -289,6 +289,13 @@ const options_list = {
         "default": ""
     },
 
+    "sync-combat-tracker": {
+        "title": "Sync D&D Beyond Encounter with VTT turn tracker",
+        "description": "Currently only supports roll 20.",
+        "type": "bool",
+        "default": false
+    },
+
     "donate": {
         "short": "Buy rations (1 day) to feed my familiar",
         "title": "Become a patron of the art of software development!",
@@ -933,7 +940,7 @@ function setDiscordChannelsSetting(name, settings) {
     if (!dropdowns.find(d => d.active)) dropdowns[0].active = true;
     if (dropdowns.find(d => d.secret)) dropdowns.push({ name: "Delete selected channel", action: "delete" })
     dropdowns.push({ name: "Add new channel", action: "add" })
-    
+
     console.log("Added new options", dropdowns);
     fillDisordChannelsDropdown(name, dropdowns);
 }
@@ -951,7 +958,7 @@ function fillDisordChannelsDropdown(name, dropdowns, triggerChange=false) {
     const active = dropdowns.find(d => d.active);
     input.text(active.name);
     input.attr("data-secret", active.secret.slice(0, 12));
-    
+
     $("#beyond20-option-discord-channels li").off('click').click(ev => {
         ev.stopPropagation();
         ev.preventDefault()
@@ -971,7 +978,7 @@ function fillDisordChannelsDropdown(name, dropdowns, triggerChange=false) {
     $("#beyond20-option-discord-channels li[data-action=add]").off('click').click(ev => {
         ev.stopPropagation();
         ev.preventDefault()
-        
+
         dropdown_menu.removeClass('open');
         button_group.removeClass('open');
         m.set('triangle').size(10);

--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -172,7 +172,7 @@ function buildAttackRoll(character, attack_source, name, description, properties
                     }
                 }
                 const isBrutal = character.hasClassFeature("Brutal Critical");
-                const isSavage = character.hasRacialTrait("Savage Attacks");   
+                const isSavage = character.hasRacialTrait("Savage Attacks");
                 if (highest_dice != 0) {
                     crit_damages.push(`${brutal}d${highest_dice}`);
                     crit_damage_types.push(isBrutal && isSavage ? "Savage Attacks & Brutal" : (isBrutal ? "Brutal" : "Savage Attacks"));
@@ -180,7 +180,7 @@ function buildAttackRoll(character, attack_source, name, description, properties
                     crit_damages.push(`${homebrew_max_damage}`);
                     crit_damage_types.push(isBrutal && isSavage ? "Savage Attacks & Brutal" : (isBrutal ? "Brutal" : "Savage Attacks"));
                 }
-                
+
             }
             roll_properties["critical-damages"] = crit_damages;
             roll_properties["critical-damage-types"] = crit_damage_types;
@@ -440,7 +440,7 @@ function injectDiceToRolls(selector, character, name = "") {
 }
 
 function beyond20SendMessageFailure(character, response) {
-    if (!response)
+    if (!response || (response.request && response.request.action === "update-combat"))
         return;
     console.log("Received response : ", response);
     if (["roll", "rendered-roll"].includes(response.request.action)  && (response.vtt == "dndbeyond" || response.error)) {

--- a/src/dndbeyond/content-scripts/encounter.js
+++ b/src/dndbeyond/content-scripts/encounter.js
@@ -13,6 +13,9 @@ function documentModified(mutations, observer) {
 
     const monster = $(".encounter-details-monster-summary-info-panel,.encounter-details__content-section--monster-stat-block,.combat-tracker-page__content-section--monster-stat-block,.monster-details-modal__body");
     const monster_name = monster.find(".mon-stat-block__name").text();
+    if (settings["sync-combat-tracker"]) {
+        updateCombatTracker();
+    }
     console.log("Doc modified, new mon : ", monster_name, " !=? ", last_monster_name);
     if (monster_name == last_monster_name)
         return;
@@ -20,6 +23,23 @@ function documentModified(mutations, observer) {
     removeRollButtons();
     character = new Monster("Monster", null, settings);
     character.parseStatBlock(monster);
+}
+
+function updateCombatTracker() {
+    if ($(".turn-controls__next-turn-button").length) {
+        $(".ui-dialog-buttonpane").hide(); // get rid of turn controls, to make it more obvious to do things from DDB.
+        const combat = Array.from($(".combatant-card.in-combat")).map(x => [
+            $(".combatant-summary__name", x).text(),
+            $(".combatant-card__initiative-value", x).text(),
+            $(x).hasClass("is-turn"),
+        ]);
+        const req = {
+            action: "combat-tracker",
+            combat,
+        };
+        console.log("Sending combat update", combat);
+        chrome.runtime.sendMessage(req, resp => beyond20SendMessageFailure(character, resp));
+    }
 }
 
 function updateSettings(new_settings = null) {
@@ -48,5 +68,5 @@ updateSettings();
 injectCSS(BUTTON_STYLE_CSS);
 chrome.runtime.onMessage.addListener(handleMessage);
 const observer = new window.MutationObserver(documentModified);
-observer.observe(document, { "subtree": true, "childList": true });
+observer.observe(document, { "subtree": true, "childList": true, attributes: true, });
 chrome.runtime.sendMessage({ "action": "activate-icon" });

--- a/src/dndbeyond/content-scripts/encounter.js
+++ b/src/dndbeyond/content-scripts/encounter.js
@@ -25,11 +25,12 @@ function documentModified(mutations, observer) {
     character.parseStatBlock(monster);
 }
 
+let lastCombatUpdate = null;
+
 function updateCombatTracker() {
     if (!$(".turn-controls__next-turn-button").length) {
         return;
     }
-    $(".ui-dialog-buttonpane").hide(); // get rid of turn controls, to make it more obvious to do things from DDB.
     const combat = Array.from($(".combatant-card.in-combat")).map(combatant => {
         const $combatant = $(combatant);
         return {
@@ -38,6 +39,12 @@ function updateCombatTracker() {
             turn: $combatant.hasClass("is-turn"),
         };
     });
+    const json = JSON.stringify(combat);
+    if (lastCombatUpdate === json) {
+        return;
+    }
+    lastCombatUpdate = json;
+
     const req = {
         action: "update-combat",
         combat,
@@ -45,6 +52,7 @@ function updateCombatTracker() {
     console.log("Sending combat update", combat);
     chrome.runtime.sendMessage(req, resp => beyond20SendMessageFailure(character, resp));
 }
+
 
 function updateSettings(new_settings = null) {
     if (new_settings) {

--- a/src/dndbeyond/content-scripts/encounter.js
+++ b/src/dndbeyond/content-scripts/encounter.js
@@ -26,20 +26,24 @@ function documentModified(mutations, observer) {
 }
 
 function updateCombatTracker() {
-    if ($(".turn-controls__next-turn-button").length) {
-        $(".ui-dialog-buttonpane").hide(); // get rid of turn controls, to make it more obvious to do things from DDB.
-        const combat = Array.from($(".combatant-card.in-combat")).map(x => [
-            $(".combatant-summary__name", x).text(),
-            $(".combatant-card__initiative-value", x).text(),
-            $(x).hasClass("is-turn"),
-        ]);
-        const req = {
-            action: "combat-tracker",
-            combat,
-        };
-        console.log("Sending combat update", combat);
-        chrome.runtime.sendMessage(req, resp => beyond20SendMessageFailure(character, resp));
+    if (!$(".turn-controls__next-turn-button").length) {
+        return;
     }
+    $(".ui-dialog-buttonpane").hide(); // get rid of turn controls, to make it more obvious to do things from DDB.
+    const combat = Array.from($(".combatant-card.in-combat")).map(combatant => {
+        const $combatant = $(combatant);
+        return {
+            name: $combatant.find(".combatant-summary__name").text(),
+            initiative: $combatant.find(".combatant-card__initiative-value").text(),
+            turn: $combatant.hasClass("is-turn"),
+        };
+    });
+    const req = {
+        action: "update-combat",
+        combat,
+    };
+    console.log("Sending combat update", combat);
+    chrome.runtime.sendMessage(req, resp => beyond20SendMessageFailure(character, resp));
 }
 
 function updateSettings(new_settings = null) {

--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -148,10 +148,19 @@ function onRollFailure(request, sendResponse) {
     });
 }
 
+
+const acceptedActions = [
+    "roll",
+    "rendered-roll",
+    "hp-update",
+    "conditions-update",
+    "combat-tracker",
+];
+
 function onMessage(request, sender, sendResponse) {
     console.log("Received message: ", request)
-    if (["roll", "rendered-roll", "hp-update", "conditions-update"].includes(request.action)) {
-        makeFailureCB = (trackFailure, vtt, sendResponse) => {
+    if (acceptedActions.includes(request.action)) {
+        const makeFailureCB = (trackFailure, vtt, sendResponse) => {
             return (result) => {
                 trackFailure[vtt] = result
                 console.log("Result of sending to VTT ", vtt, ": ", result)

--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -149,17 +149,17 @@ function onRollFailure(request, sendResponse) {
 }
 
 
-const acceptedActions = [
+const forwardedActions = [
     "roll",
     "rendered-roll",
     "hp-update",
     "conditions-update",
-    "combat-tracker",
+    "update-combat",
 ];
 
 function onMessage(request, sender, sendResponse) {
     console.log("Received message: ", request)
-    if (acceptedActions.includes(request.action)) {
+    if (forwardedActions.includes(request.action)) {
         const makeFailureCB = (trackFailure, vtt, sendResponse) => {
             return (result) => {
                 trackFailure[vtt] = result

--- a/src/extension/popup.js
+++ b/src/extension/popup.js
@@ -208,6 +208,11 @@ function addMonsterOptions() {
     initializeSettings(gotSettings);
 }
 
+function addEncounterOptions() {
+    const options = $(".beyond20-options");
+    options.append(createHTMLOption("sync-combat-tracker", false));
+}
+
 function tabMatches(tab, url) {
     return tab.url.match(url.replace(/\*/g, "[^]*")) != null;
 }
@@ -236,11 +241,10 @@ function actOnCurrentTab(tab) {
         initializeSettings(gotSettings);
     } else if (urlMatches(tab.url, DNDBEYOND_CHARACTER_URL)) {
         sendMessageToTab(tab.id, { "action": "get-character" }, populateCharacter);
-    } else if (urlMatches(tab.url, DNDBEYOND_MONSTER_URL) ||
-        urlMatches(tab.url, DNDBEYOND_VEHICLE_URL) ||
-        urlMatches(tab.url, DNDBEYOND_ENCOUNTERS_URL) ||
-        urlMatches(tab.url, DNDBEYOND_ENCOUNTER_URL) ||
-        urlMatches(tab.url, DNDBEYOND_COMBAT_URL)) {
+    } else if (urlMatches(tab.url, DNDBEYOND_MONSTER_URL) || urlMatches(tab.url, DNDBEYOND_VEHICLE_URL)) {
+        addMonsterOptions();
+    } else if (urlMatches(tab.url, DNDBEYOND_COMBAT_URL) || urlMatches(tab.url, DNDBEYOND_ENCOUNTERS_URL) || urlMatches(tab.url, DNDBEYOND_ENCOUNTER_URL)) {
+        addEncounterOptions();
         addMonsterOptions();
     } else {
         initializeSettings(gotSettings);

--- a/src/roll20/content-script.js
+++ b/src/roll20/content-script.js
@@ -175,13 +175,13 @@ function template(request, name, properties) {
     }
 
     result += " &{template:" + name + "}";
-    
+
     if (request.whisper == WhisperType.HIDE_NAMES) {
         if (properties["charname"])
             properties["charname"] = "???"
         // Take into account links for disabled auto-roll-damages option
         if (properties["rname"])
-            properties["rname"] = properties["rname"].includes("](!") ? 
+            properties["rname"] = properties["rname"].includes("](!") ?
                 properties["rname"].replace(/\[[^\]]*\]\(\!/, "[???](!") : "???";
         if (properties["rnamec"])
             properties["rnamec"] = properties["rnamec"].includes("](!") ?
@@ -810,6 +810,8 @@ function handleMessage(request, sender, sendResponse) {
         postChatMessage(roll, character_name);
     } else if (request.action == "rendered-roll") {
         handleRenderedRoll(request);
+    } else if (request.action === "combat-tracker") {
+        sendCustomEvent("CombatTracker", [request.combat]);
     }
 }
 

--- a/src/roll20/content-script.js
+++ b/src/roll20/content-script.js
@@ -810,7 +810,7 @@ function handleMessage(request, sender, sendResponse) {
         postChatMessage(roll, character_name);
     } else if (request.action == "rendered-roll") {
         handleRenderedRoll(request);
-    } else if (request.action === "combat-tracker") {
+    } else if (request.action === "update-combat") {
         sendCustomEvent("CombatTracker", [request.combat]);
     }
 }

--- a/src/roll20/page-script.js
+++ b/src/roll20/page-script.js
@@ -29,19 +29,23 @@ function updateHP(name, current, total, temp) {
 }
 
 function updateCombatTracker(combat) {
-    const index = combat.findIndex(x => x[2]);
+    const index = combat.findIndex(x => x.turn);
     if (index === -1) {
         console.warn("It's apparently nobody's turn :/");
     } else {
+        // Roll20 needs the unit whose turn it is at the top of the array.
         const c = combat.splice(index, combat.length);
         combat.splice(0, 0, ...c);
     }
     const turnOrder = combat.map(x => ({
         id: "-1",
-        pr: x[1],
-        custom: x[0],
+        pr: x.initiative,
+        custom: x.name,
     }));
     Campaign.set("turnorder", JSON.stringify(turnOrder));
+    // Make sure the turn tracker window is open
+    // This also forces roll20 to sync the initiative tracker state to other clients.
+    $("#startrounds").click();
 }
 
 

--- a/src/roll20/page-script.js
+++ b/src/roll20/page-script.js
@@ -28,6 +28,23 @@ function updateHP(name, current, total, temp) {
     }
 }
 
+function updateCombatTracker(combat) {
+    const index = combat.findIndex(x => x[2]);
+    if (index === -1) {
+        console.warn("It's apparently nobody's turn :/");
+    } else {
+        const c = combat.splice(index, combat.length);
+        combat.splice(0, 0, ...c);
+    }
+    const turnOrder = combat.map(x => ({
+        id: "-1",
+        pr: x[1],
+        custom: x[0],
+    }));
+    Campaign.set("turnorder", JSON.stringify(turnOrder));
+}
+
+
 function checkForOGL() {
     const isOGL = atob(customcharsheet_html).includes(`<rolltemplate class="sheet-rolltemplate-simple">`);
     $("#isOGL").remove();
@@ -41,6 +58,7 @@ function disconnectAllEvents() {
 
 var registered_events = [];
 registered_events.push(addCustomEventListener("UpdateHP", updateHP));
+registered_events.push(addCustomEventListener("CombatTracker", updateCombatTracker));
 registered_events.push(addCustomEventListener("disconnect", disconnectAllEvents));
 
 // Hack for VTT ES making every script load before Roll20 loads


### PR DESCRIPTION
I've added a setting for this, which is off by default. Those interested in trying it out can enable it from the settings menu - but it might be a good idea to move this into the quick settings once it's been tested a bit. Because of this, I'm not too worried if this gets merged in.

Although this solution seems workable, there are some limitations that should be addressed;
* Ideally we shouldn't unlink tokens from the tracker. At the moment the list is replaced with a fresh version built from data in the DDB tracker.
* There's no support for hidden units - I see no such support in DDB's combat tracker anyway.
* Initiative values need to be entered by the person running the encounter. There is a way to do this automatically for monsters, but players will need manual entry.

But it's a start. Also looks like my IDE picked up some superfluous whitespace issues again. I can fix it if I need to, but it's probably going to bite me every single time I contribute, so I'd rather just fix them unless you have any specific reason why they should be trimmed.