### PR TITLE
Fix ajs-content overlapping with ajs-header in "Beyond20 Quick Settings"

### DIFF
--- a/libs/css/alertify-themes/beyond20.css
+++ b/libs/css/alertify-themes/beyond20.css
@@ -27,3 +27,9 @@
   -webkit-animation-duration: 100ms;
           animation-duration: 100ms;
 }
+
+/* Prevent ajs-content from overlapping with ajs-header in "Beyond20 Quick Settings" */
+.alertify.ajs-resizable .ajs-body .ajs-content,
+.alertify.ajs-maximized .ajs-body .ajs-content {
+  top: 64px;
+}

--- a/libs/css/alertify.css
+++ b/libs/css/alertify.css
@@ -193,7 +193,7 @@
 .alertify.ajs-resizable .ajs-body .ajs-content,
 .alertify.ajs-maximized .ajs-body .ajs-content {
   position: absolute;
-  top: 64px;
+  top: 50px;
   right: 24px;
   bottom: 50px;
   left: 24px;

--- a/libs/css/alertify.css
+++ b/libs/css/alertify.css
@@ -193,7 +193,7 @@
 .alertify.ajs-resizable .ajs-body .ajs-content,
 .alertify.ajs-maximized .ajs-body .ajs-content {
   position: absolute;
-  top: 50px;
+  top: 64px;
   right: 24px;
   bottom: 50px;
   left: 24px;


### PR DESCRIPTION
'Tis but a small visual fix to the "Beyond20 Quick Settings." (Tested on Chrome version 83.0.4103.116 (64 bit) on Windows 10)

## Before
![Before](https://imgur.com/Y2HsVkz.png)
## After
![After](https://imgur.com/MMaUp5z.png)