### PR TITLE
Spell Description on Spell Attack for Roll20

### DIFF
--- a/dist/astral.js
+++ b/dist/astral.js
@@ -426,7 +426,7 @@ const options_list = {
         "title": "Display Spell Descriptions in spell attacks",
         "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
         "type": "bool",
-        "defult": false
+        "default": false
     },
 
     "component-prefix": {

--- a/dist/astral.js
+++ b/dist/astral.js
@@ -422,6 +422,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "defult": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/dist/astral_script.js
+++ b/dist/astral_script.js
@@ -426,7 +426,7 @@ const options_list = {
         "title": "Display Spell Descriptions in spell attacks",
         "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
         "type": "bool",
-        "defult": false
+        "default": false
     },
 
     "component-prefix": {

--- a/dist/astral_script.js
+++ b/dist/astral_script.js
@@ -422,6 +422,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "defult": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/dist/background.js
+++ b/dist/background.js
@@ -468,6 +468,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "defult": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/dist/background.js
+++ b/dist/background.js
@@ -472,7 +472,7 @@ const options_list = {
         "title": "Display Spell Descriptions in spell attacks",
         "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
         "type": "bool",
-        "defult": false
+        "default": false
     },
 
     "component-prefix": {

--- a/dist/default_popup.js
+++ b/dist/default_popup.js
@@ -423,6 +423,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "defult": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/dist/default_popup.js
+++ b/dist/default_popup.js
@@ -427,7 +427,7 @@ const options_list = {
         "title": "Display Spell Descriptions in spell attacks",
         "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
         "type": "bool",
-        "defult": false
+        "default": false
     },
 
     "component-prefix": {

--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -426,7 +426,7 @@ const options_list = {
         "title": "Display Spell Descriptions in spell attacks",
         "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
         "type": "bool",
-        "defult": false
+        "default": false
     },
 
     "component-prefix": {

--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -422,6 +422,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "defult": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/dist/dndbeyond_encounter.js
+++ b/dist/dndbeyond_encounter.js
@@ -426,7 +426,7 @@ const options_list = {
         "title": "Display Spell Descriptions in spell attacks",
         "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
         "type": "bool",
-        "defult": false
+        "default": false
     },
 
     "component-prefix": {

--- a/dist/dndbeyond_encounter.js
+++ b/dist/dndbeyond_encounter.js
@@ -422,6 +422,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "defult": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/dist/dndbeyond_item.js
+++ b/dist/dndbeyond_item.js
@@ -426,7 +426,7 @@ const options_list = {
         "title": "Display Spell Descriptions in spell attacks",
         "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
         "type": "bool",
-        "defult": false
+        "default": false
     },
 
     "component-prefix": {

--- a/dist/dndbeyond_item.js
+++ b/dist/dndbeyond_item.js
@@ -422,6 +422,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "defult": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/dist/dndbeyond_monster.js
+++ b/dist/dndbeyond_monster.js
@@ -426,7 +426,7 @@ const options_list = {
         "title": "Display Spell Descriptions in spell attacks",
         "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
         "type": "bool",
-        "defult": false
+        "default": false
     },
 
     "component-prefix": {

--- a/dist/dndbeyond_monster.js
+++ b/dist/dndbeyond_monster.js
@@ -422,6 +422,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "defult": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/dist/dndbeyond_spell.js
+++ b/dist/dndbeyond_spell.js
@@ -426,7 +426,7 @@ const options_list = {
         "title": "Display Spell Descriptions in spell attacks",
         "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
         "type": "bool",
-        "defult": false
+        "default": false
     },
 
     "component-prefix": {

--- a/dist/dndbeyond_spell.js
+++ b/dist/dndbeyond_spell.js
@@ -422,6 +422,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "defult": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/dist/dndbeyond_vehicle.js
+++ b/dist/dndbeyond_vehicle.js
@@ -426,7 +426,7 @@ const options_list = {
         "title": "Display Spell Descriptions in spell attacks",
         "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
         "type": "bool",
-        "defult": false
+        "default": false
     },
 
     "component-prefix": {

--- a/dist/dndbeyond_vehicle.js
+++ b/dist/dndbeyond_vehicle.js
@@ -422,6 +422,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "defult": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/dist/fvtt.js
+++ b/dist/fvtt.js
@@ -426,7 +426,7 @@ const options_list = {
         "title": "Display Spell Descriptions in spell attacks",
         "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
         "type": "bool",
-        "defult": false
+        "default": false
     },
 
     "component-prefix": {

--- a/dist/fvtt.js
+++ b/dist/fvtt.js
@@ -422,6 +422,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "defult": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/dist/fvtt_script.js
+++ b/dist/fvtt_script.js
@@ -423,6 +423,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "defult": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/dist/fvtt_script.js
+++ b/dist/fvtt_script.js
@@ -427,7 +427,7 @@ const options_list = {
         "title": "Display Spell Descriptions in spell attacks",
         "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
         "type": "bool",
-        "defult": false
+        "default": false
     },
 
     "component-prefix": {

--- a/dist/options.js
+++ b/dist/options.js
@@ -426,7 +426,7 @@ const options_list = {
         "title": "Display Spell Descriptions in spell attacks",
         "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
         "type": "bool",
-        "defult": false
+        "default": false
     },
 
     "component-prefix": {

--- a/dist/options.js
+++ b/dist/options.js
@@ -422,6 +422,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "defult": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/dist/popup.js
+++ b/dist/popup.js
@@ -468,6 +468,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "defult": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/dist/popup.js
+++ b/dist/popup.js
@@ -472,7 +472,7 @@ const options_list = {
         "title": "Display Spell Descriptions in spell attacks",
         "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
         "type": "bool",
-        "defult": false
+        "default": false
     },
 
     "component-prefix": {

--- a/dist/roll20.js
+++ b/dist/roll20.js
@@ -426,7 +426,7 @@ const options_list = {
         "title": "Display Spell Descriptions in spell attacks",
         "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
         "type": "bool",
-        "defult": false
+        "default": false
     },
 
     "component-prefix": {

--- a/dist/roll20.js
+++ b/dist/roll20.js
@@ -422,6 +422,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "defult": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",
@@ -3534,7 +3541,19 @@ function rollSpellAttack(request, custom_roll_dice) {
             }
         }
     }
-
+    if (settings["roll20-spell-description-display"] === true) {
+        if (settings["components-display"] === "all") {
+            properties["desc"] += "\r\n\r\nDescription: " + request.description;
+        } else if (settings["components-display"] === "material") {
+            if (properties["desc"] != undefined) {
+                properties["desc"] += "\r\n\r\nDescription: " + request.description;
+            } else {
+                properties["desc"] = "Description: " + request.description;
+            }
+        } else {
+            properties["desc"] = "Description: " + request.description;
+        }
+    }
     if (request.rollDamage && !request.rollAttack) {
         template_type = "dmg";
         dmg_props["charname"] = request.character.name;

--- a/dist/roll20.js
+++ b/dist/roll20.js
@@ -3543,10 +3543,10 @@ function rollSpellAttack(request, custom_roll_dice) {
     }
     if (settings["roll20-spell-description-display"] === true) {
         if (settings["components-display"] === "all") {
-            properties["desc"] += "\r\n\r\nDescription: " + request.description;
+            properties["desc"] += "\n\nDescription: " + request.description;
         } else if (settings["components-display"] === "material") {
             if (properties["desc"] != undefined) {
-                properties["desc"] += "\r\n\r\nDescription: " + request.description;
+                properties["desc"] += "\n\nDescription: " + request.description;
             } else {
                 properties["desc"] = "Description: " + request.description;
             }

--- a/dist/roll20.js
+++ b/dist/roll20.js
@@ -3542,17 +3542,8 @@ function rollSpellAttack(request, custom_roll_dice) {
         }
     }
     if (settings["roll20-spell-description-display"] === true) {
-        if (settings["components-display"] === "all") {
-            properties["desc"] += "\n\nDescription: " + request.description;
-        } else if (settings["components-display"] === "material") {
-            if (properties["desc"] != undefined) {
-                properties["desc"] += "\n\nDescription: " + request.description;
-            } else {
-                properties["desc"] = "Description: " + request.description;
-            }
-        } else {
-            properties["desc"] = "Description: " + request.description;
-        }
+		properties["desc"] = properties["desc"] ? properties["desc"] + "\n\n" : "";
+		properties["desc"] += `\n\nDescription: ${request.description}`;
     }
     if (request.rollDamage && !request.rollAttack) {
         template_type = "dmg";

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -254,6 +254,13 @@ const options_list = {
         "choices": { "all": "All components", "material": "Only material components", "none": "Do not display anything" }
     },
 
+    "roll20-spell-description-display": {
+        "title": "Display Spell Descriptions in spell attacks",
+        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "type": "bool",
+        "defult": false
+    },
+
     "component-prefix": {
         "title": "Component Prefix",
         "description": "Prefix to the components display of a spell attack.\nIf displaying material components only, you may want to set it to 'Materials used :' for example",

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -258,7 +258,7 @@ const options_list = {
         "title": "Display Spell Descriptions in spell attacks",
         "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
         "type": "bool",
-        "defult": false
+        "default": false
     },
 
     "component-prefix": {

--- a/src/roll20/content-script.js
+++ b/src/roll20/content-script.js
@@ -544,7 +544,19 @@ function rollSpellAttack(request, custom_roll_dice) {
             }
         }
     }
-
+    if (settings["roll20-spell-description-display"] === true) {
+        if (settings["components-display"] === "all") {
+            properties["desc"] += "\r\n\r\nDescription: " + request.description;
+        } else if (settings["components-display"] === "material") {
+            if (properties["desc"] != undefined) {
+                properties["desc"] += "\r\n\r\nDescription: " + request.description;
+            } else {
+                properties["desc"] = "Description: " + request.description;
+            }
+        } else {
+            properties["desc"] = "Description: " + request.description;
+        }
+    }
     if (request.rollDamage && !request.rollAttack) {
         template_type = "dmg";
         dmg_props["charname"] = request.character.name;

--- a/src/roll20/content-script.js
+++ b/src/roll20/content-script.js
@@ -545,17 +545,8 @@ function rollSpellAttack(request, custom_roll_dice) {
         }
     }
     if (settings["roll20-spell-description-display"] === true) {
-        if (settings["components-display"] === "all") {
-            properties["desc"] += "\n\nDescription: " + request.description;
-        } else if (settings["components-display"] === "material") {
-            if (properties["desc"] != undefined) {
-                properties["desc"] += "\n\nDescription: " + request.description;
-            } else {
-                properties["desc"] = "Description: " + request.description;
-            }
-        } else {
-            properties["desc"] = "Description: " + request.description;
-        }
+		properties["desc"] = properties["desc"] ? properties["desc"] + "\n\n" : "";
+		properties["desc"] += `\n\nDescription: ${request.description}`;
     }
     if (request.rollDamage && !request.rollAttack) {
         template_type = "dmg";

--- a/src/roll20/content-script.js
+++ b/src/roll20/content-script.js
@@ -546,10 +546,10 @@ function rollSpellAttack(request, custom_roll_dice) {
     }
     if (settings["roll20-spell-description-display"] === true) {
         if (settings["components-display"] === "all") {
-            properties["desc"] += "\r\n\r\nDescription: " + request.description;
+            properties["desc"] += "\n\nDescription: " + request.description;
         } else if (settings["components-display"] === "material") {
             if (properties["desc"] != undefined) {
-                properties["desc"] += "\r\n\r\nDescription: " + request.description;
+                properties["desc"] += "\n\nDescription: " + request.description;
             } else {
                 properties["desc"] = "Description: " + request.description;
             }


### PR DESCRIPTION
Adds a toggle to display a Spell Description on a Spell Attack on Roll20
Logic to interact with the different Material Display Options for Roll20

Request from MaxPat on Beyond20 Discord