### PR TITLE
Fix double character names in roll20 condition display

### DIFF
--- a/dist/dndbeyond_item.js
+++ b/dist/dndbeyond_item.js
@@ -3280,7 +3280,7 @@ function addDisplayButton() {
     const item_name = $(".page-title").text().trim();
     const item_type = descriptionToString(".item-details .item-info .details, .details-container-equipment .details-container-content-description > div > .details-container-content-description-text");
     const description = descriptionToString(".item-details .more-info-content, .details-container-equipment .marginBottom20 + .details-container-content-description-text");
-    const item_tags = $(".details-container-content-footer .tags").find(".tag").toArray().map(elem => elem.textContent);
+    const item_tags = $(".details-container-content-footer .tags .tag").toArray().map(elem => elem.textContent);
     $(".page-heading__content").after(button);
 
     $(".ct-beyond20-roll").css({

--- a/dist/roll20.js
+++ b/dist/roll20.js
@@ -3509,12 +3509,12 @@ function handleMessage(request, sender, sendResponse) {
 
             // We can't use window.is_gm because it's  !available to the content script;
             const is_gm = $("#textchat .message.system").text().includes("The player link for this campaign is");
-            const em_command = is_gm ? "/emas " : "/em ";
+            const em_command = is_gm ? "/emas \"" + character_name + "\" " : "/em ";
             let message = "";
             if (conditions.length == 0) {
-                message = em_command + character_name + " has no active condition";
+                message = em_command + "has no active conditions";
             } else {
-                message = em_command + character_name + " is : " + conditions.join(", ");
+                message = em_command + "is: " + conditions.join(", ");
             }
             postChatMessage(message, character_name);
         }

--- a/dist/roll20.js
+++ b/dist/roll20.js
@@ -3509,12 +3509,12 @@ function handleMessage(request, sender, sendResponse) {
 
             // We can't use window.is_gm because it's  !available to the content script;
             const is_gm = $("#textchat .message.system").text().includes("The player link for this campaign is");
-            const em_command = is_gm ? "/emas \"" + character_name + "\" " : "/em ";
+            const em_command = is_gm ? "/emas " : "/em ";
             let message = "";
             if (conditions.length == 0) {
-                message = em_command + " has no active condition";
+                message = em_command + character_name + " has no active condition";
             } else {
-                message = em_command + " is : " + conditions.join(", ");
+                message = em_command + character_name + " is : " + conditions.join(", ");
             }
             postChatMessage(message, character_name);
         }

--- a/dist/roll20.js
+++ b/dist/roll20.js
@@ -3509,12 +3509,12 @@ function handleMessage(request, sender, sendResponse) {
 
             // We can't use window.is_gm because it's  !available to the content script;
             const is_gm = $("#textchat .message.system").text().includes("The player link for this campaign is");
-            const em_command = is_gm ? "/emas " : "/em ";
+            const em_command = is_gm ? "/emas \"" + character_name + "\" " : "/em ";
             let message = "";
             if (conditions.length == 0) {
-                message = em_command + character_name + " has no active condition";
+                message = em_command + " has no active condition";
             } else {
-                message = em_command + character_name + " is : " + conditions.join(", ");
+                message = em_command + " is : " + conditions.join(", ");
             }
             postChatMessage(message, character_name);
         }

--- a/src/roll20/content-script.js
+++ b/src/roll20/content-script.js
@@ -934,12 +934,12 @@ function handleMessage(request, sender, sendResponse) {
 
             // We can't use window.is_gm because it's  !available to the content script;
             const is_gm = $("#textchat .message.system").text().includes("The player link for this campaign is");
-            const em_command = is_gm ? "/emas " : "/em ";
+            const em_command = is_gm ? "/emas \"" + character_name + "\" " : "/em ";
             let message = "";
             if (conditions.length == 0) {
-                message = em_command + character_name + " has no active condition";
+                message = em_command + "has no active conditions";
             } else {
-                message = em_command + character_name + " is : " + conditions.join(", ");
+                message = em_command + "is: " + conditions.join(", ");
             }
             postChatMessage(message, character_name);
         }


### PR DESCRIPTION
Right now, when a character condition changes for a player in a Roll20 campaign their character's name is displayed twice in the chat log. Was going to log this as an issue; but then decided to just track it down and fix it. Thanks for the great plugin; LMK if you'd prefer a different process / want me to log an issue as well. 

As per [Roll20 Text Chat](https://roll20.zendesk.com/hc/en-us/articles/360039675093-Text-Chat), /em does not require a character name, only /emas for GMs wants a character name (surrounded in quotes). Update the roll20 javascript to match this (and also clean up some spacing/grammar since I happened to be there). 

Tested this as both a player and GM in Roll20 Chrome; looks good to me. 

Also, because the build was updating the built dndbeyond_item.js based on one of the earlier commits (a4d09d0), check in that update as well. 