### PR TITLE
Fix double character names in roll20 condition display

### DIFF
--- a/dist/roll20.js
+++ b/dist/roll20.js
@@ -3509,12 +3509,12 @@ function handleMessage(request, sender, sendResponse) {
 
             // We can't use window.is_gm because it's  !available to the content script;
             const is_gm = $("#textchat .message.system").text().includes("The player link for this campaign is");
-            const em_command = is_gm ? "/emas " : "/em ";
+            const em_command = is_gm ? "/emas \"" + character_name + "\" " : "/em ";
             let message = "";
             if (conditions.length == 0) {
-                message = em_command + character_name + " has no active condition";
+                message = em_command + "has no active conditions";
             } else {
-                message = em_command + character_name + " is : " + conditions.join(", ");
+                message = em_command + "is: " + conditions.join(", ");
             }
             postChatMessage(message, character_name);
         }

--- a/src/roll20/content-script.js
+++ b/src/roll20/content-script.js
@@ -934,12 +934,12 @@ function handleMessage(request, sender, sendResponse) {
 
             // We can't use window.is_gm because it's  !available to the content script;
             const is_gm = $("#textchat .message.system").text().includes("The player link for this campaign is");
-            const em_command = is_gm ? "/emas " : "/em ";
+            const em_command = is_gm ? "/emas \"" + character_name + "\" " : "/em ";
             let message = "";
             if (conditions.length == 0) {
-                message = em_command + character_name + " has no active condition";
+                message = em_command + "has no active conditions";
             } else {
-                message = em_command + character_name + " is : " + conditions.join(", ");
+                message = em_command + "is: " + conditions.join(", ");
             }
             postChatMessage(message, character_name);
         }


### PR DESCRIPTION
Right now, when a character condition changes for a player in a Roll20 campaign their character's name is displayed twice in the chat log. Was going to log this as an issue; but then decided to just track it down and fix it. Thanks for the great plugin; LMK if you'd prefer a different process / want me to log an issue as well.

As per Roll20 Text Chat, /em does not require a character name, only /emas for GMs wants a character name (surrounded in quotes). Update the roll20 javascript to match this (and also clean up some spacing/grammar since I happened to be there).

Tested this as both a player and GM in Roll20 Chrome; looks good to me.

As per the discussion in #499; _not_ including the other dist change due to a past src change that did not include a matching dist update to scope this PR just to my change. 