### PR TITLE
Do not query for Colossus Slayer Critical Hit

### DIFF
--- a/dist/astral_script.js
+++ b/dist/astral_script.js
@@ -2619,33 +2619,6 @@ class Beyond20RollRenderer {
                 damages[0] = damages[0].replace("d8", ttd_dice);
             }
 
-            // Ranger Ability Support;
-            // let dmg_dice = "0";
-            // for (let [dmgIndex, dmgType] of damage_types.entries()) {
-            //     if (dmgType == "Colossus Slayer") {
-            //         const dmg = damages[dmgIndex].toString();
-            //         if (dmg) {
-            //             dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
-            //             if (dmg_dice == "0") {
-            //                 damages.splice(dmgIndex, 1);
-            //                 damage_types.splice(dmgIndex, 1);
-            //             }
-            //         }
-            //     }
-            // }
-
-            // for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
-            //     if (dmgType == "Colossus Slayer") {
-            //         const dmg = critical_damages[dmgIndex].toString();
-            //         if (dmg) {
-            //             if (dmg_dice == "0") {
-            //                 critical_damages.splice(dmgIndex, 1);
-            //                 critical_damage_types.splice(dmgIndex, 1);
-            //             }
-            //         }
-            //     }
-            // }
-
             const has_versatile = damage_types.length > 1 && damage_types[1].includes("Two-Handed");
             for (let i = 0; i < (damages.length); i++) {
                 const roll = this._roller.roll(damages[i]);

--- a/dist/astral_script.js
+++ b/dist/astral_script.js
@@ -2620,14 +2620,26 @@ class Beyond20RollRenderer {
             }
 
             // Ranger Ability Support;
+            let dmg_dice = "0";
             for (let [dmgIndex, dmgType] of damage_types.entries()) {
                 if (dmgType == "Colossus Slayer") {
                     const dmg = damages[dmgIndex].toString();
                     if (dmg) {
-                        const dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
+                        dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
                         if (dmg_dice == "0") {
                             damages.splice(dmgIndex, 1);
                             damage_types.splice(dmgIndex, 1);
+                        }
+                    }
+                }
+            }
+
+            for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
+                if (dmgType == "Colossus Slayer") {
+                    const dmg = critical_damages[dmgIndex].toString();
+                    if (dmg) {
+                        // dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
+                        if (dmg_dice == "0") {
                             critical_damages.splice(dmgIndex, 1);
                             critical_damage_types.splice(dmgIndex, 1);
                         }

--- a/dist/astral_script.js
+++ b/dist/astral_script.js
@@ -2628,6 +2628,8 @@ class Beyond20RollRenderer {
                         if (dmg_dice == "0") {
                             damages.splice(dmgIndex, 1);
                             damage_types.splice(dmgIndex, 1);
+                            critical_damages.splice(dmgIndex, 1);
+                            critical_damage_types.splice(dmgIndex, 1);
                         }
                     }
                 }

--- a/dist/astral_script.js
+++ b/dist/astral_script.js
@@ -2638,7 +2638,6 @@ class Beyond20RollRenderer {
                 if (dmgType == "Colossus Slayer") {
                     const dmg = critical_damages[dmgIndex].toString();
                     if (dmg) {
-                        // dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
                         if (dmg_dice == "0") {
                             critical_damages.splice(dmgIndex, 1);
                             critical_damage_types.splice(dmgIndex, 1);

--- a/dist/astral_script.js
+++ b/dist/astral_script.js
@@ -2620,31 +2620,31 @@ class Beyond20RollRenderer {
             }
 
             // Ranger Ability Support;
-            let dmg_dice = "0";
-            for (let [dmgIndex, dmgType] of damage_types.entries()) {
-                if (dmgType == "Colossus Slayer") {
-                    const dmg = damages[dmgIndex].toString();
-                    if (dmg) {
-                        dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
-                        if (dmg_dice == "0") {
-                            damages.splice(dmgIndex, 1);
-                            damage_types.splice(dmgIndex, 1);
-                        }
-                    }
-                }
-            }
+            // let dmg_dice = "0";
+            // for (let [dmgIndex, dmgType] of damage_types.entries()) {
+            //     if (dmgType == "Colossus Slayer") {
+            //         const dmg = damages[dmgIndex].toString();
+            //         if (dmg) {
+            //             dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
+            //             if (dmg_dice == "0") {
+            //                 damages.splice(dmgIndex, 1);
+            //                 damage_types.splice(dmgIndex, 1);
+            //             }
+            //         }
+            //     }
+            // }
 
-            for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
-                if (dmgType == "Colossus Slayer") {
-                    const dmg = critical_damages[dmgIndex].toString();
-                    if (dmg) {
-                        if (dmg_dice == "0") {
-                            critical_damages.splice(dmgIndex, 1);
-                            critical_damage_types.splice(dmgIndex, 1);
-                        }
-                    }
-                }
-            }
+            // for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
+            //     if (dmgType == "Colossus Slayer") {
+            //         const dmg = critical_damages[dmgIndex].toString();
+            //         if (dmg) {
+            //             if (dmg_dice == "0") {
+            //                 critical_damages.splice(dmgIndex, 1);
+            //                 critical_damage_types.splice(dmgIndex, 1);
+            //             }
+            //         }
+            //     }
+            // }
 
             const has_versatile = damage_types.length > 1 && damage_types[1].includes("Two-Handed");
             for (let i = 0; i < (damages.length); i++) {

--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -5072,7 +5072,7 @@ function rollHitDie(multiclass, index) {
     });
 }
 
-async function rollItem(force_display = false, force_to_hit_only = false, force_damages_only = false) {
+function rollItem(force_display = false, force_to_hit_only = false, force_damages_only = false, spell_group = null) {
     const prop_list = $(".ct-item-pane .ct-property-list .ct-property-list__property,.ct-item-pane .ddbc-property-list .ddbc-property-list__property");
     const properties = propertyListToDict(prop_list);
     properties["Properties"] = properties["Properties"] || "";

--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -5268,12 +5268,8 @@ async function rollItem(force_display = false, force_to_hit_only = false, force_
                 character.mergeCharacterSettings({ "ranger-dread-ambusher": false });
             }
             if (character.hasClassFeature("Hunter’s Prey: Colossus Slayer")) {
-                let use_colossus_slayer = "0";
-                use_colossus_slayer = await dndbeyondDiceRoller.queryGeneric("Colossus Slayer: Hunter's Prey", "Is the enemy you're targeting below its Hit Point Maximum?", { "0": "No", "1": "Yes" }, "use_colossus_slayer", ["0", "1"]);
-                if (use_colossus_slayer === "1") {
-                    damages.push("1d8");
-                    damage_types.push("Colossus Slayer");
-                }
+                damages.push("1d8");
+                damage_types.push("Colossus Slayer");
             }
             if (character.hasClassFeature("Slayer’s Prey") &&
                 character.getSetting("ranger-slayers-prey", false)) {

--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -2620,14 +2620,26 @@ class Beyond20RollRenderer {
             }
 
             // Ranger Ability Support;
+            let dmg_dice = "0";
             for (let [dmgIndex, dmgType] of damage_types.entries()) {
                 if (dmgType == "Colossus Slayer") {
                     const dmg = damages[dmgIndex].toString();
                     if (dmg) {
-                        const dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
+                        dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
                         if (dmg_dice == "0") {
                             damages.splice(dmgIndex, 1);
                             damage_types.splice(dmgIndex, 1);
+                        }
+                    }
+                }
+            }
+
+            for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
+                if (dmgType == "Colossus Slayer") {
+                    const dmg = critical_damages[dmgIndex].toString();
+                    if (dmg) {
+                        // dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
+                        if (dmg_dice == "0") {
                             critical_damages.splice(dmgIndex, 1);
                             critical_damage_types.splice(dmgIndex, 1);
                         }

--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -2628,6 +2628,8 @@ class Beyond20RollRenderer {
                         if (dmg_dice == "0") {
                             damages.splice(dmgIndex, 1);
                             damage_types.splice(dmgIndex, 1);
+                            critical_damages.splice(dmgIndex, 1);
+                            critical_damage_types.splice(dmgIndex, 1);
                         }
                     }
                 }

--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -2638,7 +2638,6 @@ class Beyond20RollRenderer {
                 if (dmgType == "Colossus Slayer") {
                     const dmg = critical_damages[dmgIndex].toString();
                     if (dmg) {
-                        // dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
                         if (dmg_dice == "0") {
                             critical_damages.splice(dmgIndex, 1);
                             critical_damage_types.splice(dmgIndex, 1);

--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -2619,33 +2619,6 @@ class Beyond20RollRenderer {
                 damages[0] = damages[0].replace("d8", ttd_dice);
             }
 
-            // Ranger Ability Support;
-            // let dmg_dice = "0";
-            // for (let [dmgIndex, dmgType] of damage_types.entries()) {
-            //     if (dmgType == "Colossus Slayer") {
-            //         const dmg = damages[dmgIndex].toString();
-            //         if (dmg) {
-            //             dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
-            //             if (dmg_dice == "0") {
-            //                 damages.splice(dmgIndex, 1);
-            //                 damage_types.splice(dmgIndex, 1);
-            //             }
-            //         }
-            //     }
-            // }
-
-            // for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
-            //     if (dmgType == "Colossus Slayer") {
-            //         const dmg = critical_damages[dmgIndex].toString();
-            //         if (dmg) {
-            //             if (dmg_dice == "0") {
-            //                 critical_damages.splice(dmgIndex, 1);
-            //                 critical_damage_types.splice(dmgIndex, 1);
-            //             }
-            //         }
-            //     }
-            // }
-
             const has_versatile = damage_types.length > 1 && damage_types[1].includes("Two-Handed");
             for (let i = 0; i < (damages.length); i++) {
                 const roll = this._roller.roll(damages[i]);
@@ -5099,7 +5072,7 @@ function rollHitDie(multiclass, index) {
     });
 }
 
-function rollItem(force_display = false, force_to_hit_only = false, force_damages_only = false, spell_group = null) {
+async function rollItem(force_display = false, force_to_hit_only = false, force_damages_only = false) {
     const prop_list = $(".ct-item-pane .ct-property-list .ct-property-list__property,.ct-item-pane .ddbc-property-list .ddbc-property-list__property");
     const properties = propertyListToDict(prop_list);
     properties["Properties"] = properties["Properties"] || "";
@@ -5295,9 +5268,9 @@ function rollItem(force_display = false, force_to_hit_only = false, force_damage
                 character.mergeCharacterSettings({ "ranger-dread-ambusher": false });
             }
             if (character.hasClassFeature("Hunter’s Prey: Colossus Slayer")) {
-                // alertify.confirm("Colossus Slayer: Hunter's Prey", "Is the enemy you're targeting below its Hit Point Maximum?", function(){ alertify.success('Yes')}
-                    // , function(){ alertify.error('No')})
-                if (confirm("Colossus Slayer: Is the enemy you're targeting missing health?")) {
+                let use_colossus_slayer = "0";
+                use_colossus_slayer = await dndbeyondDiceRoller.queryGeneric("Colossus Slayer: Hunter's Prey", "Is the enemy you're targeting below its Hit Point Maximum?", { "0": "No", "1": "Yes" }, "use_colossus_slayer", ["0", "1"]);
+                if (use_colossus_slayer === "1") {
                     damages.push("1d8");
                     damage_types.push("Colossus Slayer");
                 }

--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -2620,31 +2620,31 @@ class Beyond20RollRenderer {
             }
 
             // Ranger Ability Support;
-            let dmg_dice = "0";
-            for (let [dmgIndex, dmgType] of damage_types.entries()) {
-                if (dmgType == "Colossus Slayer") {
-                    const dmg = damages[dmgIndex].toString();
-                    if (dmg) {
-                        dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
-                        if (dmg_dice == "0") {
-                            damages.splice(dmgIndex, 1);
-                            damage_types.splice(dmgIndex, 1);
-                        }
-                    }
-                }
-            }
+            // let dmg_dice = "0";
+            // for (let [dmgIndex, dmgType] of damage_types.entries()) {
+            //     if (dmgType == "Colossus Slayer") {
+            //         const dmg = damages[dmgIndex].toString();
+            //         if (dmg) {
+            //             dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
+            //             if (dmg_dice == "0") {
+            //                 damages.splice(dmgIndex, 1);
+            //                 damage_types.splice(dmgIndex, 1);
+            //             }
+            //         }
+            //     }
+            // }
 
-            for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
-                if (dmgType == "Colossus Slayer") {
-                    const dmg = critical_damages[dmgIndex].toString();
-                    if (dmg) {
-                        if (dmg_dice == "0") {
-                            critical_damages.splice(dmgIndex, 1);
-                            critical_damage_types.splice(dmgIndex, 1);
-                        }
-                    }
-                }
-            }
+            // for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
+            //     if (dmgType == "Colossus Slayer") {
+            //         const dmg = critical_damages[dmgIndex].toString();
+            //         if (dmg) {
+            //             if (dmg_dice == "0") {
+            //                 critical_damages.splice(dmgIndex, 1);
+            //                 critical_damage_types.splice(dmgIndex, 1);
+            //             }
+            //         }
+            //     }
+            // }
 
             const has_versatile = damage_types.length > 1 && damage_types[1].includes("Two-Handed");
             for (let i = 0; i < (damages.length); i++) {
@@ -5295,8 +5295,12 @@ function rollItem(force_display = false, force_to_hit_only = false, force_damage
                 character.mergeCharacterSettings({ "ranger-dread-ambusher": false });
             }
             if (character.hasClassFeature("Hunter’s Prey: Colossus Slayer")) {
-                damages.push("1d8");
-                damage_types.push("Colossus Slayer");
+                // alertify.confirm("Colossus Slayer: Hunter's Prey", "Is the enemy you're targeting below its Hit Point Maximum?", function(){ alertify.success('Yes')}
+                    // , function(){ alertify.error('No')})
+                if (confirm("Colossus Slayer: Is the enemy you're targeting missing health?")) {
+                    damages.push("1d8");
+                    damage_types.push("Colossus Slayer");
+                }
             }
             if (character.hasClassFeature("Slayer’s Prey") &&
                 character.getSetting("ranger-slayers-prey", false)) {

--- a/dist/dndbeyond_encounter.js
+++ b/dist/dndbeyond_encounter.js
@@ -2619,33 +2619,6 @@ class Beyond20RollRenderer {
                 damages[0] = damages[0].replace("d8", ttd_dice);
             }
 
-            // Ranger Ability Support;
-            // let dmg_dice = "0";
-            // for (let [dmgIndex, dmgType] of damage_types.entries()) {
-            //     if (dmgType == "Colossus Slayer") {
-            //         const dmg = damages[dmgIndex].toString();
-            //         if (dmg) {
-            //             dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
-            //             if (dmg_dice == "0") {
-            //                 damages.splice(dmgIndex, 1);
-            //                 damage_types.splice(dmgIndex, 1);
-            //             }
-            //         }
-            //     }
-            // }
-
-            // for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
-            //     if (dmgType == "Colossus Slayer") {
-            //         const dmg = critical_damages[dmgIndex].toString();
-            //         if (dmg) {
-            //             if (dmg_dice == "0") {
-            //                 critical_damages.splice(dmgIndex, 1);
-            //                 critical_damage_types.splice(dmgIndex, 1);
-            //             }
-            //         }
-            //     }
-            // }
-
             const has_versatile = damage_types.length > 1 && damage_types[1].includes("Two-Handed");
             for (let i = 0; i < (damages.length); i++) {
                 const roll = this._roller.roll(damages[i]);

--- a/dist/dndbeyond_encounter.js
+++ b/dist/dndbeyond_encounter.js
@@ -2620,14 +2620,26 @@ class Beyond20RollRenderer {
             }
 
             // Ranger Ability Support;
+            let dmg_dice = "0";
             for (let [dmgIndex, dmgType] of damage_types.entries()) {
                 if (dmgType == "Colossus Slayer") {
                     const dmg = damages[dmgIndex].toString();
                     if (dmg) {
-                        const dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
+                        dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
                         if (dmg_dice == "0") {
                             damages.splice(dmgIndex, 1);
                             damage_types.splice(dmgIndex, 1);
+                        }
+                    }
+                }
+            }
+
+            for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
+                if (dmgType == "Colossus Slayer") {
+                    const dmg = critical_damages[dmgIndex].toString();
+                    if (dmg) {
+                        // dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
+                        if (dmg_dice == "0") {
                             critical_damages.splice(dmgIndex, 1);
                             critical_damage_types.splice(dmgIndex, 1);
                         }

--- a/dist/dndbeyond_encounter.js
+++ b/dist/dndbeyond_encounter.js
@@ -2628,6 +2628,8 @@ class Beyond20RollRenderer {
                         if (dmg_dice == "0") {
                             damages.splice(dmgIndex, 1);
                             damage_types.splice(dmgIndex, 1);
+                            critical_damages.splice(dmgIndex, 1);
+                            critical_damage_types.splice(dmgIndex, 1);
                         }
                     }
                 }

--- a/dist/dndbeyond_encounter.js
+++ b/dist/dndbeyond_encounter.js
@@ -2638,7 +2638,6 @@ class Beyond20RollRenderer {
                 if (dmgType == "Colossus Slayer") {
                     const dmg = critical_damages[dmgIndex].toString();
                     if (dmg) {
-                        // dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
                         if (dmg_dice == "0") {
                             critical_damages.splice(dmgIndex, 1);
                             critical_damage_types.splice(dmgIndex, 1);

--- a/dist/dndbeyond_encounter.js
+++ b/dist/dndbeyond_encounter.js
@@ -2620,31 +2620,31 @@ class Beyond20RollRenderer {
             }
 
             // Ranger Ability Support;
-            let dmg_dice = "0";
-            for (let [dmgIndex, dmgType] of damage_types.entries()) {
-                if (dmgType == "Colossus Slayer") {
-                    const dmg = damages[dmgIndex].toString();
-                    if (dmg) {
-                        dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
-                        if (dmg_dice == "0") {
-                            damages.splice(dmgIndex, 1);
-                            damage_types.splice(dmgIndex, 1);
-                        }
-                    }
-                }
-            }
+            // let dmg_dice = "0";
+            // for (let [dmgIndex, dmgType] of damage_types.entries()) {
+            //     if (dmgType == "Colossus Slayer") {
+            //         const dmg = damages[dmgIndex].toString();
+            //         if (dmg) {
+            //             dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
+            //             if (dmg_dice == "0") {
+            //                 damages.splice(dmgIndex, 1);
+            //                 damage_types.splice(dmgIndex, 1);
+            //             }
+            //         }
+            //     }
+            // }
 
-            for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
-                if (dmgType == "Colossus Slayer") {
-                    const dmg = critical_damages[dmgIndex].toString();
-                    if (dmg) {
-                        if (dmg_dice == "0") {
-                            critical_damages.splice(dmgIndex, 1);
-                            critical_damage_types.splice(dmgIndex, 1);
-                        }
-                    }
-                }
-            }
+            // for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
+            //     if (dmgType == "Colossus Slayer") {
+            //         const dmg = critical_damages[dmgIndex].toString();
+            //         if (dmg) {
+            //             if (dmg_dice == "0") {
+            //                 critical_damages.splice(dmgIndex, 1);
+            //                 critical_damage_types.splice(dmgIndex, 1);
+            //             }
+            //         }
+            //     }
+            // }
 
             const has_versatile = damage_types.length > 1 && damage_types[1].includes("Two-Handed");
             for (let i = 0; i < (damages.length); i++) {

--- a/dist/dndbeyond_item.js
+++ b/dist/dndbeyond_item.js
@@ -2619,33 +2619,6 @@ class Beyond20RollRenderer {
                 damages[0] = damages[0].replace("d8", ttd_dice);
             }
 
-            // Ranger Ability Support;
-            // let dmg_dice = "0";
-            // for (let [dmgIndex, dmgType] of damage_types.entries()) {
-            //     if (dmgType == "Colossus Slayer") {
-            //         const dmg = damages[dmgIndex].toString();
-            //         if (dmg) {
-            //             dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
-            //             if (dmg_dice == "0") {
-            //                 damages.splice(dmgIndex, 1);
-            //                 damage_types.splice(dmgIndex, 1);
-            //             }
-            //         }
-            //     }
-            // }
-
-            // for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
-            //     if (dmgType == "Colossus Slayer") {
-            //         const dmg = critical_damages[dmgIndex].toString();
-            //         if (dmg) {
-            //             if (dmg_dice == "0") {
-            //                 critical_damages.splice(dmgIndex, 1);
-            //                 critical_damage_types.splice(dmgIndex, 1);
-            //             }
-            //         }
-            //     }
-            // }
-
             const has_versatile = damage_types.length > 1 && damage_types[1].includes("Two-Handed");
             for (let i = 0; i < (damages.length); i++) {
                 const roll = this._roller.roll(damages[i]);

--- a/dist/dndbeyond_item.js
+++ b/dist/dndbeyond_item.js
@@ -2620,14 +2620,26 @@ class Beyond20RollRenderer {
             }
 
             // Ranger Ability Support;
+            let dmg_dice = "0";
             for (let [dmgIndex, dmgType] of damage_types.entries()) {
                 if (dmgType == "Colossus Slayer") {
                     const dmg = damages[dmgIndex].toString();
                     if (dmg) {
-                        const dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
+                        dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
                         if (dmg_dice == "0") {
                             damages.splice(dmgIndex, 1);
                             damage_types.splice(dmgIndex, 1);
+                        }
+                    }
+                }
+            }
+
+            for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
+                if (dmgType == "Colossus Slayer") {
+                    const dmg = critical_damages[dmgIndex].toString();
+                    if (dmg) {
+                        // dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
+                        if (dmg_dice == "0") {
                             critical_damages.splice(dmgIndex, 1);
                             critical_damage_types.splice(dmgIndex, 1);
                         }

--- a/dist/dndbeyond_item.js
+++ b/dist/dndbeyond_item.js
@@ -2628,6 +2628,8 @@ class Beyond20RollRenderer {
                         if (dmg_dice == "0") {
                             damages.splice(dmgIndex, 1);
                             damage_types.splice(dmgIndex, 1);
+                            critical_damages.splice(dmgIndex, 1);
+                            critical_damage_types.splice(dmgIndex, 1);
                         }
                     }
                 }

--- a/dist/dndbeyond_item.js
+++ b/dist/dndbeyond_item.js
@@ -2638,7 +2638,6 @@ class Beyond20RollRenderer {
                 if (dmgType == "Colossus Slayer") {
                     const dmg = critical_damages[dmgIndex].toString();
                     if (dmg) {
-                        // dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
                         if (dmg_dice == "0") {
                             critical_damages.splice(dmgIndex, 1);
                             critical_damage_types.splice(dmgIndex, 1);

--- a/dist/dndbeyond_item.js
+++ b/dist/dndbeyond_item.js
@@ -2620,31 +2620,31 @@ class Beyond20RollRenderer {
             }
 
             // Ranger Ability Support;
-            let dmg_dice = "0";
-            for (let [dmgIndex, dmgType] of damage_types.entries()) {
-                if (dmgType == "Colossus Slayer") {
-                    const dmg = damages[dmgIndex].toString();
-                    if (dmg) {
-                        dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
-                        if (dmg_dice == "0") {
-                            damages.splice(dmgIndex, 1);
-                            damage_types.splice(dmgIndex, 1);
-                        }
-                    }
-                }
-            }
+            // let dmg_dice = "0";
+            // for (let [dmgIndex, dmgType] of damage_types.entries()) {
+            //     if (dmgType == "Colossus Slayer") {
+            //         const dmg = damages[dmgIndex].toString();
+            //         if (dmg) {
+            //             dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
+            //             if (dmg_dice == "0") {
+            //                 damages.splice(dmgIndex, 1);
+            //                 damage_types.splice(dmgIndex, 1);
+            //             }
+            //         }
+            //     }
+            // }
 
-            for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
-                if (dmgType == "Colossus Slayer") {
-                    const dmg = critical_damages[dmgIndex].toString();
-                    if (dmg) {
-                        if (dmg_dice == "0") {
-                            critical_damages.splice(dmgIndex, 1);
-                            critical_damage_types.splice(dmgIndex, 1);
-                        }
-                    }
-                }
-            }
+            // for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
+            //     if (dmgType == "Colossus Slayer") {
+            //         const dmg = critical_damages[dmgIndex].toString();
+            //         if (dmg) {
+            //             if (dmg_dice == "0") {
+            //                 critical_damages.splice(dmgIndex, 1);
+            //                 critical_damage_types.splice(dmgIndex, 1);
+            //             }
+            //         }
+            //     }
+            // }
 
             const has_versatile = damage_types.length > 1 && damage_types[1].includes("Two-Handed");
             for (let i = 0; i < (damages.length); i++) {

--- a/dist/dndbeyond_monster.js
+++ b/dist/dndbeyond_monster.js
@@ -2619,33 +2619,6 @@ class Beyond20RollRenderer {
                 damages[0] = damages[0].replace("d8", ttd_dice);
             }
 
-            // Ranger Ability Support;
-            // let dmg_dice = "0";
-            // for (let [dmgIndex, dmgType] of damage_types.entries()) {
-            //     if (dmgType == "Colossus Slayer") {
-            //         const dmg = damages[dmgIndex].toString();
-            //         if (dmg) {
-            //             dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
-            //             if (dmg_dice == "0") {
-            //                 damages.splice(dmgIndex, 1);
-            //                 damage_types.splice(dmgIndex, 1);
-            //             }
-            //         }
-            //     }
-            // }
-
-            // for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
-            //     if (dmgType == "Colossus Slayer") {
-            //         const dmg = critical_damages[dmgIndex].toString();
-            //         if (dmg) {
-            //             if (dmg_dice == "0") {
-            //                 critical_damages.splice(dmgIndex, 1);
-            //                 critical_damage_types.splice(dmgIndex, 1);
-            //             }
-            //         }
-            //     }
-            // }
-
             const has_versatile = damage_types.length > 1 && damage_types[1].includes("Two-Handed");
             for (let i = 0; i < (damages.length); i++) {
                 const roll = this._roller.roll(damages[i]);

--- a/dist/dndbeyond_monster.js
+++ b/dist/dndbeyond_monster.js
@@ -2620,14 +2620,26 @@ class Beyond20RollRenderer {
             }
 
             // Ranger Ability Support;
+            let dmg_dice = "0";
             for (let [dmgIndex, dmgType] of damage_types.entries()) {
                 if (dmgType == "Colossus Slayer") {
                     const dmg = damages[dmgIndex].toString();
                     if (dmg) {
-                        const dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
+                        dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
                         if (dmg_dice == "0") {
                             damages.splice(dmgIndex, 1);
                             damage_types.splice(dmgIndex, 1);
+                        }
+                    }
+                }
+            }
+
+            for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
+                if (dmgType == "Colossus Slayer") {
+                    const dmg = critical_damages[dmgIndex].toString();
+                    if (dmg) {
+                        // dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
+                        if (dmg_dice == "0") {
                             critical_damages.splice(dmgIndex, 1);
                             critical_damage_types.splice(dmgIndex, 1);
                         }

--- a/dist/dndbeyond_monster.js
+++ b/dist/dndbeyond_monster.js
@@ -2628,6 +2628,8 @@ class Beyond20RollRenderer {
                         if (dmg_dice == "0") {
                             damages.splice(dmgIndex, 1);
                             damage_types.splice(dmgIndex, 1);
+                            critical_damages.splice(dmgIndex, 1);
+                            critical_damage_types.splice(dmgIndex, 1);
                         }
                     }
                 }

--- a/dist/dndbeyond_monster.js
+++ b/dist/dndbeyond_monster.js
@@ -2638,7 +2638,6 @@ class Beyond20RollRenderer {
                 if (dmgType == "Colossus Slayer") {
                     const dmg = critical_damages[dmgIndex].toString();
                     if (dmg) {
-                        // dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
                         if (dmg_dice == "0") {
                             critical_damages.splice(dmgIndex, 1);
                             critical_damage_types.splice(dmgIndex, 1);

--- a/dist/dndbeyond_monster.js
+++ b/dist/dndbeyond_monster.js
@@ -2620,31 +2620,31 @@ class Beyond20RollRenderer {
             }
 
             // Ranger Ability Support;
-            let dmg_dice = "0";
-            for (let [dmgIndex, dmgType] of damage_types.entries()) {
-                if (dmgType == "Colossus Slayer") {
-                    const dmg = damages[dmgIndex].toString();
-                    if (dmg) {
-                        dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
-                        if (dmg_dice == "0") {
-                            damages.splice(dmgIndex, 1);
-                            damage_types.splice(dmgIndex, 1);
-                        }
-                    }
-                }
-            }
+            // let dmg_dice = "0";
+            // for (let [dmgIndex, dmgType] of damage_types.entries()) {
+            //     if (dmgType == "Colossus Slayer") {
+            //         const dmg = damages[dmgIndex].toString();
+            //         if (dmg) {
+            //             dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
+            //             if (dmg_dice == "0") {
+            //                 damages.splice(dmgIndex, 1);
+            //                 damage_types.splice(dmgIndex, 1);
+            //             }
+            //         }
+            //     }
+            // }
 
-            for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
-                if (dmgType == "Colossus Slayer") {
-                    const dmg = critical_damages[dmgIndex].toString();
-                    if (dmg) {
-                        if (dmg_dice == "0") {
-                            critical_damages.splice(dmgIndex, 1);
-                            critical_damage_types.splice(dmgIndex, 1);
-                        }
-                    }
-                }
-            }
+            // for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
+            //     if (dmgType == "Colossus Slayer") {
+            //         const dmg = critical_damages[dmgIndex].toString();
+            //         if (dmg) {
+            //             if (dmg_dice == "0") {
+            //                 critical_damages.splice(dmgIndex, 1);
+            //                 critical_damage_types.splice(dmgIndex, 1);
+            //             }
+            //         }
+            //     }
+            // }
 
             const has_versatile = damage_types.length > 1 && damage_types[1].includes("Two-Handed");
             for (let i = 0; i < (damages.length); i++) {

--- a/dist/dndbeyond_spell.js
+++ b/dist/dndbeyond_spell.js
@@ -2619,33 +2619,6 @@ class Beyond20RollRenderer {
                 damages[0] = damages[0].replace("d8", ttd_dice);
             }
 
-            // Ranger Ability Support;
-            // let dmg_dice = "0";
-            // for (let [dmgIndex, dmgType] of damage_types.entries()) {
-            //     if (dmgType == "Colossus Slayer") {
-            //         const dmg = damages[dmgIndex].toString();
-            //         if (dmg) {
-            //             dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
-            //             if (dmg_dice == "0") {
-            //                 damages.splice(dmgIndex, 1);
-            //                 damage_types.splice(dmgIndex, 1);
-            //             }
-            //         }
-            //     }
-            // }
-
-            // for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
-            //     if (dmgType == "Colossus Slayer") {
-            //         const dmg = critical_damages[dmgIndex].toString();
-            //         if (dmg) {
-            //             if (dmg_dice == "0") {
-            //                 critical_damages.splice(dmgIndex, 1);
-            //                 critical_damage_types.splice(dmgIndex, 1);
-            //             }
-            //         }
-            //     }
-            // }
-
             const has_versatile = damage_types.length > 1 && damage_types[1].includes("Two-Handed");
             for (let i = 0; i < (damages.length); i++) {
                 const roll = this._roller.roll(damages[i]);

--- a/dist/dndbeyond_spell.js
+++ b/dist/dndbeyond_spell.js
@@ -2620,14 +2620,26 @@ class Beyond20RollRenderer {
             }
 
             // Ranger Ability Support;
+            let dmg_dice = "0";
             for (let [dmgIndex, dmgType] of damage_types.entries()) {
                 if (dmgType == "Colossus Slayer") {
                     const dmg = damages[dmgIndex].toString();
                     if (dmg) {
-                        const dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
+                        dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
                         if (dmg_dice == "0") {
                             damages.splice(dmgIndex, 1);
                             damage_types.splice(dmgIndex, 1);
+                        }
+                    }
+                }
+            }
+
+            for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
+                if (dmgType == "Colossus Slayer") {
+                    const dmg = critical_damages[dmgIndex].toString();
+                    if (dmg) {
+                        // dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
+                        if (dmg_dice == "0") {
                             critical_damages.splice(dmgIndex, 1);
                             critical_damage_types.splice(dmgIndex, 1);
                         }

--- a/dist/dndbeyond_spell.js
+++ b/dist/dndbeyond_spell.js
@@ -2628,6 +2628,8 @@ class Beyond20RollRenderer {
                         if (dmg_dice == "0") {
                             damages.splice(dmgIndex, 1);
                             damage_types.splice(dmgIndex, 1);
+                            critical_damages.splice(dmgIndex, 1);
+                            critical_damage_types.splice(dmgIndex, 1);
                         }
                     }
                 }

--- a/dist/dndbeyond_spell.js
+++ b/dist/dndbeyond_spell.js
@@ -2638,7 +2638,6 @@ class Beyond20RollRenderer {
                 if (dmgType == "Colossus Slayer") {
                     const dmg = critical_damages[dmgIndex].toString();
                     if (dmg) {
-                        // dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
                         if (dmg_dice == "0") {
                             critical_damages.splice(dmgIndex, 1);
                             critical_damage_types.splice(dmgIndex, 1);

--- a/dist/dndbeyond_spell.js
+++ b/dist/dndbeyond_spell.js
@@ -2620,31 +2620,31 @@ class Beyond20RollRenderer {
             }
 
             // Ranger Ability Support;
-            let dmg_dice = "0";
-            for (let [dmgIndex, dmgType] of damage_types.entries()) {
-                if (dmgType == "Colossus Slayer") {
-                    const dmg = damages[dmgIndex].toString();
-                    if (dmg) {
-                        dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
-                        if (dmg_dice == "0") {
-                            damages.splice(dmgIndex, 1);
-                            damage_types.splice(dmgIndex, 1);
-                        }
-                    }
-                }
-            }
+            // let dmg_dice = "0";
+            // for (let [dmgIndex, dmgType] of damage_types.entries()) {
+            //     if (dmgType == "Colossus Slayer") {
+            //         const dmg = damages[dmgIndex].toString();
+            //         if (dmg) {
+            //             dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
+            //             if (dmg_dice == "0") {
+            //                 damages.splice(dmgIndex, 1);
+            //                 damage_types.splice(dmgIndex, 1);
+            //             }
+            //         }
+            //     }
+            // }
 
-            for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
-                if (dmgType == "Colossus Slayer") {
-                    const dmg = critical_damages[dmgIndex].toString();
-                    if (dmg) {
-                        if (dmg_dice == "0") {
-                            critical_damages.splice(dmgIndex, 1);
-                            critical_damage_types.splice(dmgIndex, 1);
-                        }
-                    }
-                }
-            }
+            // for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
+            //     if (dmgType == "Colossus Slayer") {
+            //         const dmg = critical_damages[dmgIndex].toString();
+            //         if (dmg) {
+            //             if (dmg_dice == "0") {
+            //                 critical_damages.splice(dmgIndex, 1);
+            //                 critical_damage_types.splice(dmgIndex, 1);
+            //             }
+            //         }
+            //     }
+            // }
 
             const has_versatile = damage_types.length > 1 && damage_types[1].includes("Two-Handed");
             for (let i = 0; i < (damages.length); i++) {

--- a/dist/dndbeyond_vehicle.js
+++ b/dist/dndbeyond_vehicle.js
@@ -2619,33 +2619,6 @@ class Beyond20RollRenderer {
                 damages[0] = damages[0].replace("d8", ttd_dice);
             }
 
-            // Ranger Ability Support;
-            // let dmg_dice = "0";
-            // for (let [dmgIndex, dmgType] of damage_types.entries()) {
-            //     if (dmgType == "Colossus Slayer") {
-            //         const dmg = damages[dmgIndex].toString();
-            //         if (dmg) {
-            //             dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
-            //             if (dmg_dice == "0") {
-            //                 damages.splice(dmgIndex, 1);
-            //                 damage_types.splice(dmgIndex, 1);
-            //             }
-            //         }
-            //     }
-            // }
-
-            // for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
-            //     if (dmgType == "Colossus Slayer") {
-            //         const dmg = critical_damages[dmgIndex].toString();
-            //         if (dmg) {
-            //             if (dmg_dice == "0") {
-            //                 critical_damages.splice(dmgIndex, 1);
-            //                 critical_damage_types.splice(dmgIndex, 1);
-            //             }
-            //         }
-            //     }
-            // }
-
             const has_versatile = damage_types.length > 1 && damage_types[1].includes("Two-Handed");
             for (let i = 0; i < (damages.length); i++) {
                 const roll = this._roller.roll(damages[i]);

--- a/dist/dndbeyond_vehicle.js
+++ b/dist/dndbeyond_vehicle.js
@@ -2620,14 +2620,26 @@ class Beyond20RollRenderer {
             }
 
             // Ranger Ability Support;
+            let dmg_dice = "0";
             for (let [dmgIndex, dmgType] of damage_types.entries()) {
                 if (dmgType == "Colossus Slayer") {
                     const dmg = damages[dmgIndex].toString();
                     if (dmg) {
-                        const dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
+                        dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
                         if (dmg_dice == "0") {
                             damages.splice(dmgIndex, 1);
                             damage_types.splice(dmgIndex, 1);
+                        }
+                    }
+                }
+            }
+
+            for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
+                if (dmgType == "Colossus Slayer") {
+                    const dmg = critical_damages[dmgIndex].toString();
+                    if (dmg) {
+                        // dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
+                        if (dmg_dice == "0") {
                             critical_damages.splice(dmgIndex, 1);
                             critical_damage_types.splice(dmgIndex, 1);
                         }

--- a/dist/dndbeyond_vehicle.js
+++ b/dist/dndbeyond_vehicle.js
@@ -2628,6 +2628,8 @@ class Beyond20RollRenderer {
                         if (dmg_dice == "0") {
                             damages.splice(dmgIndex, 1);
                             damage_types.splice(dmgIndex, 1);
+                            critical_damages.splice(dmgIndex, 1);
+                            critical_damage_types.splice(dmgIndex, 1);
                         }
                     }
                 }

--- a/dist/dndbeyond_vehicle.js
+++ b/dist/dndbeyond_vehicle.js
@@ -2638,7 +2638,6 @@ class Beyond20RollRenderer {
                 if (dmgType == "Colossus Slayer") {
                     const dmg = critical_damages[dmgIndex].toString();
                     if (dmg) {
-                        // dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
                         if (dmg_dice == "0") {
                             critical_damages.splice(dmgIndex, 1);
                             critical_damage_types.splice(dmgIndex, 1);

--- a/dist/dndbeyond_vehicle.js
+++ b/dist/dndbeyond_vehicle.js
@@ -2620,31 +2620,31 @@ class Beyond20RollRenderer {
             }
 
             // Ranger Ability Support;
-            let dmg_dice = "0";
-            for (let [dmgIndex, dmgType] of damage_types.entries()) {
-                if (dmgType == "Colossus Slayer") {
-                    const dmg = damages[dmgIndex].toString();
-                    if (dmg) {
-                        dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
-                        if (dmg_dice == "0") {
-                            damages.splice(dmgIndex, 1);
-                            damage_types.splice(dmgIndex, 1);
-                        }
-                    }
-                }
-            }
+            // let dmg_dice = "0";
+            // for (let [dmgIndex, dmgType] of damage_types.entries()) {
+            //     if (dmgType == "Colossus Slayer") {
+            //         const dmg = damages[dmgIndex].toString();
+            //         if (dmg) {
+            //             dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
+            //             if (dmg_dice == "0") {
+            //                 damages.splice(dmgIndex, 1);
+            //                 damage_types.splice(dmgIndex, 1);
+            //             }
+            //         }
+            //     }
+            // }
 
-            for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
-                if (dmgType == "Colossus Slayer") {
-                    const dmg = critical_damages[dmgIndex].toString();
-                    if (dmg) {
-                        if (dmg_dice == "0") {
-                            critical_damages.splice(dmgIndex, 1);
-                            critical_damage_types.splice(dmgIndex, 1);
-                        }
-                    }
-                }
-            }
+            // for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
+            //     if (dmgType == "Colossus Slayer") {
+            //         const dmg = critical_damages[dmgIndex].toString();
+            //         if (dmg) {
+            //             if (dmg_dice == "0") {
+            //                 critical_damages.splice(dmgIndex, 1);
+            //                 critical_damage_types.splice(dmgIndex, 1);
+            //             }
+            //         }
+            //     }
+            // }
 
             const has_versatile = damage_types.length > 1 && damage_types[1].includes("Two-Handed");
             for (let i = 0; i < (damages.length); i++) {

--- a/dist/fvtt_script.js
+++ b/dist/fvtt_script.js
@@ -2621,14 +2621,26 @@ class Beyond20RollRenderer {
             }
 
             // Ranger Ability Support;
+            let dmg_dice = "0";
             for (let [dmgIndex, dmgType] of damage_types.entries()) {
                 if (dmgType == "Colossus Slayer") {
                     const dmg = damages[dmgIndex].toString();
                     if (dmg) {
-                        const dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
+                        dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
                         if (dmg_dice == "0") {
                             damages.splice(dmgIndex, 1);
                             damage_types.splice(dmgIndex, 1);
+                        }
+                    }
+                }
+            }
+
+            for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
+                if (dmgType == "Colossus Slayer") {
+                    const dmg = critical_damages[dmgIndex].toString();
+                    if (dmg) {
+                        // dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
+                        if (dmg_dice == "0") {
                             critical_damages.splice(dmgIndex, 1);
                             critical_damage_types.splice(dmgIndex, 1);
                         }

--- a/dist/fvtt_script.js
+++ b/dist/fvtt_script.js
@@ -2639,7 +2639,6 @@ class Beyond20RollRenderer {
                 if (dmgType == "Colossus Slayer") {
                     const dmg = critical_damages[dmgIndex].toString();
                     if (dmg) {
-                        // dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
                         if (dmg_dice == "0") {
                             critical_damages.splice(dmgIndex, 1);
                             critical_damage_types.splice(dmgIndex, 1);

--- a/dist/fvtt_script.js
+++ b/dist/fvtt_script.js
@@ -2620,33 +2620,6 @@ class Beyond20RollRenderer {
                 damages[0] = damages[0].replace("d8", ttd_dice);
             }
 
-            // Ranger Ability Support;
-            // let dmg_dice = "0";
-            // for (let [dmgIndex, dmgType] of damage_types.entries()) {
-            //     if (dmgType == "Colossus Slayer") {
-            //         const dmg = damages[dmgIndex].toString();
-            //         if (dmg) {
-            //             dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
-            //             if (dmg_dice == "0") {
-            //                 damages.splice(dmgIndex, 1);
-            //                 damage_types.splice(dmgIndex, 1);
-            //             }
-            //         }
-            //     }
-            // }
-
-            // for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
-            //     if (dmgType == "Colossus Slayer") {
-            //         const dmg = critical_damages[dmgIndex].toString();
-            //         if (dmg) {
-            //             if (dmg_dice == "0") {
-            //                 critical_damages.splice(dmgIndex, 1);
-            //                 critical_damage_types.splice(dmgIndex, 1);
-            //             }
-            //         }
-            //     }
-            // }
-
             const has_versatile = damage_types.length > 1 && damage_types[1].includes("Two-Handed");
             for (let i = 0; i < (damages.length); i++) {
                 const roll = this._roller.roll(damages[i]);

--- a/dist/fvtt_script.js
+++ b/dist/fvtt_script.js
@@ -2629,6 +2629,8 @@ class Beyond20RollRenderer {
                         if (dmg_dice == "0") {
                             damages.splice(dmgIndex, 1);
                             damage_types.splice(dmgIndex, 1);
+                            critical_damages.splice(dmgIndex, 1);
+                            critical_damage_types.splice(dmgIndex, 1);
                         }
                     }
                 }

--- a/dist/fvtt_script.js
+++ b/dist/fvtt_script.js
@@ -2621,31 +2621,31 @@ class Beyond20RollRenderer {
             }
 
             // Ranger Ability Support;
-            let dmg_dice = "0";
-            for (let [dmgIndex, dmgType] of damage_types.entries()) {
-                if (dmgType == "Colossus Slayer") {
-                    const dmg = damages[dmgIndex].toString();
-                    if (dmg) {
-                        dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
-                        if (dmg_dice == "0") {
-                            damages.splice(dmgIndex, 1);
-                            damage_types.splice(dmgIndex, 1);
-                        }
-                    }
-                }
-            }
+            // let dmg_dice = "0";
+            // for (let [dmgIndex, dmgType] of damage_types.entries()) {
+            //     if (dmgType == "Colossus Slayer") {
+            //         const dmg = damages[dmgIndex].toString();
+            //         if (dmg) {
+            //             dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
+            //             if (dmg_dice == "0") {
+            //                 damages.splice(dmgIndex, 1);
+            //                 damage_types.splice(dmgIndex, 1);
+            //             }
+            //         }
+            //     }
+            // }
 
-            for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
-                if (dmgType == "Colossus Slayer") {
-                    const dmg = critical_damages[dmgIndex].toString();
-                    if (dmg) {
-                        if (dmg_dice == "0") {
-                            critical_damages.splice(dmgIndex, 1);
-                            critical_damage_types.splice(dmgIndex, 1);
-                        }
-                    }
-                }
-            }
+            // for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
+            //     if (dmgType == "Colossus Slayer") {
+            //         const dmg = critical_damages[dmgIndex].toString();
+            //         if (dmg) {
+            //             if (dmg_dice == "0") {
+            //                 critical_damages.splice(dmgIndex, 1);
+            //                 critical_damage_types.splice(dmgIndex, 1);
+            //             }
+            //         }
+            //     }
+            // }
 
             const has_versatile = damage_types.length > 1 && damage_types[1].includes("Two-Handed");
             for (let i = 0; i < (damages.length); i++) {

--- a/dist/roll20.js
+++ b/dist/roll20.js
@@ -2619,33 +2619,6 @@ class Beyond20RollRenderer {
                 damages[0] = damages[0].replace("d8", ttd_dice);
             }
 
-            // Ranger Ability Support;
-            // let dmg_dice = "0";
-            // for (let [dmgIndex, dmgType] of damage_types.entries()) {
-            //     if (dmgType == "Colossus Slayer") {
-            //         const dmg = damages[dmgIndex].toString();
-            //         if (dmg) {
-            //             dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
-            //             if (dmg_dice == "0") {
-            //                 damages.splice(dmgIndex, 1);
-            //                 damage_types.splice(dmgIndex, 1);
-            //             }
-            //         }
-            //     }
-            // }
-
-            // for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
-            //     if (dmgType == "Colossus Slayer") {
-            //         const dmg = critical_damages[dmgIndex].toString();
-            //         if (dmg) {
-            //             if (dmg_dice == "0") {
-            //                 critical_damages.splice(dmgIndex, 1);
-            //                 critical_damage_types.splice(dmgIndex, 1);
-            //             }
-            //         }
-            //     }
-            // }
-
             const has_versatile = damage_types.length > 1 && damage_types[1].includes("Two-Handed");
             for (let i = 0; i < (damages.length); i++) {
                 const roll = this._roller.roll(damages[i]);
@@ -3354,12 +3327,6 @@ function rollAttack(request, custom_roll_dice = "") {
         const damage_types = request["damage-types"];
         const crit_damages = request["critical-damages"];
         const crit_damage_types = request["critical-damage-types"];
-
-        // Ranger Ability Support;
-        for (let [dmgIndex, dmgType] of damage_types.entries()) {
-            if (damage_types[dmgIndex] == "Colossus Slayer")
-                damages[dmgIndex] = ROLL20_ADD_GENERIC_DAMAGE_DMG_QUERY.replace(/%dmgType%/, damage_types[dmgIndex]).replace(/%dmg%/, damages[dmgIndex]);
-        }
 
         dmg_props = damagesToRollProperties(damages, damage_types, crit_damages, crit_damage_types);
     }

--- a/dist/roll20.js
+++ b/dist/roll20.js
@@ -2620,14 +2620,26 @@ class Beyond20RollRenderer {
             }
 
             // Ranger Ability Support;
+            let dmg_dice = "0";
             for (let [dmgIndex, dmgType] of damage_types.entries()) {
                 if (dmgType == "Colossus Slayer") {
                     const dmg = damages[dmgIndex].toString();
                     if (dmg) {
-                        const dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
+                        dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
                         if (dmg_dice == "0") {
                             damages.splice(dmgIndex, 1);
                             damage_types.splice(dmgIndex, 1);
+                        }
+                    }
+                }
+            }
+
+            for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
+                if (dmgType == "Colossus Slayer") {
+                    const dmg = critical_damages[dmgIndex].toString();
+                    if (dmg) {
+                        // dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
+                        if (dmg_dice == "0") {
                             critical_damages.splice(dmgIndex, 1);
                             critical_damage_types.splice(dmgIndex, 1);
                         }

--- a/dist/roll20.js
+++ b/dist/roll20.js
@@ -2628,6 +2628,8 @@ class Beyond20RollRenderer {
                         if (dmg_dice == "0") {
                             damages.splice(dmgIndex, 1);
                             damage_types.splice(dmgIndex, 1);
+                            critical_damages.splice(dmgIndex, 1);
+                            critical_damage_types.splice(dmgIndex, 1);
                         }
                     }
                 }

--- a/dist/roll20.js
+++ b/dist/roll20.js
@@ -2638,7 +2638,6 @@ class Beyond20RollRenderer {
                 if (dmgType == "Colossus Slayer") {
                     const dmg = critical_damages[dmgIndex].toString();
                     if (dmg) {
-                        // dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
                         if (dmg_dice == "0") {
                             critical_damages.splice(dmgIndex, 1);
                             critical_damage_types.splice(dmgIndex, 1);

--- a/dist/roll20.js
+++ b/dist/roll20.js
@@ -2620,31 +2620,31 @@ class Beyond20RollRenderer {
             }
 
             // Ranger Ability Support;
-            let dmg_dice = "0";
-            for (let [dmgIndex, dmgType] of damage_types.entries()) {
-                if (dmgType == "Colossus Slayer") {
-                    const dmg = damages[dmgIndex].toString();
-                    if (dmg) {
-                        dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
-                        if (dmg_dice == "0") {
-                            damages.splice(dmgIndex, 1);
-                            damage_types.splice(dmgIndex, 1);
-                        }
-                    }
-                }
-            }
+            // let dmg_dice = "0";
+            // for (let [dmgIndex, dmgType] of damage_types.entries()) {
+            //     if (dmgType == "Colossus Slayer") {
+            //         const dmg = damages[dmgIndex].toString();
+            //         if (dmg) {
+            //             dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
+            //             if (dmg_dice == "0") {
+            //                 damages.splice(dmgIndex, 1);
+            //                 damage_types.splice(dmgIndex, 1);
+            //             }
+            //         }
+            //     }
+            // }
 
-            for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
-                if (dmgType == "Colossus Slayer") {
-                    const dmg = critical_damages[dmgIndex].toString();
-                    if (dmg) {
-                        if (dmg_dice == "0") {
-                            critical_damages.splice(dmgIndex, 1);
-                            critical_damage_types.splice(dmgIndex, 1);
-                        }
-                    }
-                }
-            }
+            // for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
+            //     if (dmgType == "Colossus Slayer") {
+            //         const dmg = critical_damages[dmgIndex].toString();
+            //         if (dmg) {
+            //             if (dmg_dice == "0") {
+            //                 critical_damages.splice(dmgIndex, 1);
+            //                 critical_damage_types.splice(dmgIndex, 1);
+            //             }
+            //         }
+            //     }
+            // }
 
             const has_versatile = damage_types.length > 1 && damage_types[1].includes("Two-Handed");
             for (let i = 0; i < (damages.length); i++) {

--- a/src/common/roll_renderer.js
+++ b/src/common/roll_renderer.js
@@ -548,14 +548,26 @@ class Beyond20RollRenderer {
             }
 
             // Ranger Ability Support;
+            let dmg_dice = "0";
             for (let [dmgIndex, dmgType] of damage_types.entries()) {
                 if (dmgType == "Colossus Slayer") {
                     const dmg = damages[dmgIndex].toString();
                     if (dmg) {
-                        const dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
+                        dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
                         if (dmg_dice == "0") {
                             damages.splice(dmgIndex, 1);
                             damage_types.splice(dmgIndex, 1);
+                        }
+                    }
+                }
+            }
+
+            for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
+                if (dmgType == "Colossus Slayer") {
+                    const dmg = critical_damages[dmgIndex].toString();
+                    if (dmg) {
+                        // dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
+                        if (dmg_dice == "0") {
                             critical_damages.splice(dmgIndex, 1);
                             critical_damage_types.splice(dmgIndex, 1);
                         }

--- a/src/common/roll_renderer.js
+++ b/src/common/roll_renderer.js
@@ -556,6 +556,8 @@ class Beyond20RollRenderer {
                         if (dmg_dice == "0") {
                             damages.splice(dmgIndex, 1);
                             damage_types.splice(dmgIndex, 1);
+                            critical_damages.splice(dmgIndex, 1);
+                            critical_damage_types.splice(dmgIndex, 1);
                         }
                     }
                 }

--- a/src/common/roll_renderer.js
+++ b/src/common/roll_renderer.js
@@ -547,33 +547,6 @@ class Beyond20RollRenderer {
                 damages[0] = damages[0].replace("d8", ttd_dice);
             }
 
-            // Ranger Ability Support;
-            // let dmg_dice = "0";
-            // for (let [dmgIndex, dmgType] of damage_types.entries()) {
-            //     if (dmgType == "Colossus Slayer") {
-            //         const dmg = damages[dmgIndex].toString();
-            //         if (dmg) {
-            //             dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
-            //             if (dmg_dice == "0") {
-            //                 damages.splice(dmgIndex, 1);
-            //                 damage_types.splice(dmgIndex, 1);
-            //             }
-            //         }
-            //     }
-            // }
-
-            // for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
-            //     if (dmgType == "Colossus Slayer") {
-            //         const dmg = critical_damages[dmgIndex].toString();
-            //         if (dmg) {
-            //             if (dmg_dice == "0") {
-            //                 critical_damages.splice(dmgIndex, 1);
-            //                 critical_damage_types.splice(dmgIndex, 1);
-            //             }
-            //         }
-            //     }
-            // }
-
             const has_versatile = damage_types.length > 1 && damage_types[1].includes("Two-Handed");
             for (let i = 0; i < (damages.length); i++) {
                 const roll = this._roller.roll(damages[i]);

--- a/src/common/roll_renderer.js
+++ b/src/common/roll_renderer.js
@@ -566,7 +566,6 @@ class Beyond20RollRenderer {
                 if (dmgType == "Colossus Slayer") {
                     const dmg = critical_damages[dmgIndex].toString();
                     if (dmg) {
-                        // dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
                         if (dmg_dice == "0") {
                             critical_damages.splice(dmgIndex, 1);
                             critical_damage_types.splice(dmgIndex, 1);

--- a/src/common/roll_renderer.js
+++ b/src/common/roll_renderer.js
@@ -548,31 +548,31 @@ class Beyond20RollRenderer {
             }
 
             // Ranger Ability Support;
-            let dmg_dice = "0";
-            for (let [dmgIndex, dmgType] of damage_types.entries()) {
-                if (dmgType == "Colossus Slayer") {
-                    const dmg = damages[dmgIndex].toString();
-                    if (dmg) {
-                        dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
-                        if (dmg_dice == "0") {
-                            damages.splice(dmgIndex, 1);
-                            damage_types.splice(dmgIndex, 1);
-                        }
-                    }
-                }
-            }
+            // let dmg_dice = "0";
+            // for (let [dmgIndex, dmgType] of damage_types.entries()) {
+            //     if (dmgType == "Colossus Slayer") {
+            //         const dmg = damages[dmgIndex].toString();
+            //         if (dmg) {
+            //             dmg_dice = await this.queryGeneric(request.name, `Add ${dmgType} damage ?`, { "0": "No", [dmg]: "Yes" }, "dmg_dice", ["0", dmg]);
+            //             if (dmg_dice == "0") {
+            //                 damages.splice(dmgIndex, 1);
+            //                 damage_types.splice(dmgIndex, 1);
+            //             }
+            //         }
+            //     }
+            // }
 
-            for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
-                if (dmgType == "Colossus Slayer") {
-                    const dmg = critical_damages[dmgIndex].toString();
-                    if (dmg) {
-                        if (dmg_dice == "0") {
-                            critical_damages.splice(dmgIndex, 1);
-                            critical_damage_types.splice(dmgIndex, 1);
-                        }
-                    }
-                }
-            }
+            // for (let [dmgIndex, dmgType] of critical_damage_types.entries()) {
+            //     if (dmgType == "Colossus Slayer") {
+            //         const dmg = critical_damages[dmgIndex].toString();
+            //         if (dmg) {
+            //             if (dmg_dice == "0") {
+            //                 critical_damages.splice(dmgIndex, 1);
+            //                 critical_damage_types.splice(dmgIndex, 1);
+            //             }
+            //         }
+            //     }
+            // }
 
             const has_versatile = damage_types.length > 1 && damage_types[1].includes("Two-Handed");
             for (let i = 0; i < (damages.length); i++) {

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -224,7 +224,7 @@ function rollHitDie(multiclass, index) {
     });
 }
 
-function rollItem(force_display = false, force_to_hit_only = false, force_damages_only = false, spell_group = null) {
+async function rollItem(force_display = false, force_to_hit_only = false, force_damages_only = false) {
     const prop_list = $(".ct-item-pane .ct-property-list .ct-property-list__property,.ct-item-pane .ddbc-property-list .ddbc-property-list__property");
     const properties = propertyListToDict(prop_list);
     properties["Properties"] = properties["Properties"] || "";
@@ -420,9 +420,9 @@ function rollItem(force_display = false, force_to_hit_only = false, force_damage
                 character.mergeCharacterSettings({ "ranger-dread-ambusher": false });
             }
             if (character.hasClassFeature("Hunter’s Prey: Colossus Slayer")) {
-                // alertify.confirm("Colossus Slayer: Hunter's Prey", "Is the enemy you're targeting below its Hit Point Maximum?", function(){ alertify.success('Yes')}
-                    // , function(){ alertify.error('No')})
-                if (confirm("Colossus Slayer: Is the enemy you're targeting missing health?")) {
+                let use_colossus_slayer = "0";
+                use_colossus_slayer = await dndbeyondDiceRoller.queryGeneric("Colossus Slayer: Hunter's Prey", "Is the enemy you're targeting below its Hit Point Maximum?", { "0": "No", "1": "Yes" }, "use_colossus_slayer", ["0", "1"]);
+                if (use_colossus_slayer === "1") {
                     damages.push("1d8");
                     damage_types.push("Colossus Slayer");
                 }

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -420,12 +420,8 @@ async function rollItem(force_display = false, force_to_hit_only = false, force_
                 character.mergeCharacterSettings({ "ranger-dread-ambusher": false });
             }
             if (character.hasClassFeature("Hunter’s Prey: Colossus Slayer")) {
-                let use_colossus_slayer = "0";
-                use_colossus_slayer = await dndbeyondDiceRoller.queryGeneric("Colossus Slayer: Hunter's Prey", "Is the enemy you're targeting below its Hit Point Maximum?", { "0": "No", "1": "Yes" }, "use_colossus_slayer", ["0", "1"]);
-                if (use_colossus_slayer === "1") {
-                    damages.push("1d8");
-                    damage_types.push("Colossus Slayer");
-                }
+                damages.push("1d8");
+                damage_types.push("Colossus Slayer");
             }
             if (character.hasClassFeature("Slayer’s Prey") &&
                 character.getSetting("ranger-slayers-prey", false)) {

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -224,7 +224,7 @@ function rollHitDie(multiclass, index) {
     });
 }
 
-async function rollItem(force_display = false, force_to_hit_only = false, force_damages_only = false) {
+function rollItem(force_display = false, force_to_hit_only = false, force_damages_only = false, spell_group = null) {
     const prop_list = $(".ct-item-pane .ct-property-list .ct-property-list__property,.ct-item-pane .ddbc-property-list .ddbc-property-list__property");
     const properties = propertyListToDict(prop_list);
     properties["Properties"] = properties["Properties"] || "";

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -420,8 +420,12 @@ function rollItem(force_display = false, force_to_hit_only = false, force_damage
                 character.mergeCharacterSettings({ "ranger-dread-ambusher": false });
             }
             if (character.hasClassFeature("Hunter’s Prey: Colossus Slayer")) {
-                damages.push("1d8");
-                damage_types.push("Colossus Slayer");
+                // alertify.confirm("Colossus Slayer: Hunter's Prey", "Is the enemy you're targeting below its Hit Point Maximum?", function(){ alertify.success('Yes')}
+                    // , function(){ alertify.error('No')})
+                if (confirm("Colossus Slayer: Is the enemy you're targeting missing health?")) {
+                    damages.push("1d8");
+                    damage_types.push("Colossus Slayer");
+                }
             }
             if (character.hasClassFeature("Slayer’s Prey") &&
                 character.getSetting("ranger-slayers-prey", false)) {

--- a/src/roll20/content-script.js
+++ b/src/roll20/content-script.js
@@ -352,12 +352,6 @@ function rollAttack(request, custom_roll_dice = "") {
         const crit_damages = request["critical-damages"];
         const crit_damage_types = request["critical-damage-types"];
 
-        // Ranger Ability Support;
-        for (let [dmgIndex, dmgType] of damage_types.entries()) {
-            if (damage_types[dmgIndex] == "Colossus Slayer")
-                damages[dmgIndex] = ROLL20_ADD_GENERIC_DAMAGE_DMG_QUERY.replace(/%dmgType%/, damage_types[dmgIndex]).replace(/%dmg%/, damages[dmgIndex]);
-        }
-
         dmg_props = damagesToRollProperties(damages, damage_types, crit_damages, crit_damage_types);
     }
     if (request.range !== undefined)


### PR DESCRIPTION
Fixes #546
Properly removes Critical Hit Damage and Critical Hit Damage Type (in addition to the already removed Damage/Damage Type).
This is necessary because damagesToCrits has already been called, so the Colossus Slayer Critical Hit Damage and Damage Type are already ready to go.