### PR TITLE
Notify about features & traits instead of blocking the user with a modal dialog.

### DIFF
--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -1840,7 +1840,7 @@ function documentModified(mutations, observer) {
     activateQuickRolls();
     if (character._features_needs_refresh && !character._features_refresh_warning_displayed) {
         character._features_refresh_warning_displayed = true;
-        alertify.alert("This is a new or recently leveled-up character sheet and Beyond20 needs to parse its information. <br/>Please select the <strong>'Features &amp; Traits'</strong> panel on your DnDBeyond Character Sheet for Beyond20 to parse this character's features and populate the character-specific options.");
+        alertify.notify("This is a new or recently leveled-up character sheet and Beyond20 needs to parse its information. <br/>Please select the <strong>'Features &amp; Traits'</strong> panel on your DnDBeyond Character Sheet for Beyond20 to parse this character's features and populate the character-specific options.");
     }
 
     const pane = $(".ct-sidebar__pane-content > div");


### PR DESCRIPTION
Modal dialogs create a frustrating UX and should only be used to control what a user *must* do, not what they *should* do. 

This modal dialog interrupts players from just using DNDBeyond regardless of whether or not they're actively playing with a VTT. A user just viewing a character sheet for a recently created/copied/leveled character doesn't necessarily care that Beyond20 can't parse all its information; and shouldn't be interrupted for that.

Caveat: I'm not a JS coder, I just took a cursory look at the alertify docs to see what else it can do and offered this change for the sake of putting my money where my mouth is, so to speak.