### PR TITLE
Fix RegEx for monster attack when attack default damage is missing

### DIFF
--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -3835,7 +3835,7 @@ class Monster extends CharacterBase {
         if (hit_idx > 0)
             hit = description.slice(hit_idx);
         // Using match with global modifier then map to regular match because RegExp.matchAll isn't available on every browser
-        const damage_regexp = new RegExp(/([\w]* )(?:([0-9]+))?(?: *\(?([0-9]*d[0-9]+(?:\s*[-+]\s*[0-9]+)?(?: plus [^\)]+)?)\)?)? ([\w ]+?) damage/)
+        const damage_regexp = new RegExp(/([\w]* )(?:([0-9]+)[^d])?(?: *\(?([0-9]*d[0-9]+(?:\s*[-+]\s*[0-9]+)?(?: plus [^\)]+)?)\)?)? ([\w ]+?) damage/)
         const damage_matches = reMatchAll(damage_regexp, hit) || [];
         const damages = [];
         const damage_types = [];

--- a/dist/dndbeyond_encounter.js
+++ b/dist/dndbeyond_encounter.js
@@ -3835,7 +3835,7 @@ class Monster extends CharacterBase {
         if (hit_idx > 0)
             hit = description.slice(hit_idx);
         // Using match with global modifier then map to regular match because RegExp.matchAll isn't available on every browser
-        const damage_regexp = new RegExp(/([\w]* )(?:([0-9]+))?(?: *\(?([0-9]*d[0-9]+(?:\s*[-+]\s*[0-9]+)?(?: plus [^\)]+)?)\)?)? ([\w ]+?) damage/)
+        const damage_regexp = new RegExp(/([\w]* )(?:([0-9]+)[^d])?(?: *\(?([0-9]*d[0-9]+(?:\s*[-+]\s*[0-9]+)?(?: plus [^\)]+)?)\)?)? ([\w ]+?) damage/)
         const damage_matches = reMatchAll(damage_regexp, hit) || [];
         const damages = [];
         const damage_types = [];

--- a/dist/dndbeyond_monster.js
+++ b/dist/dndbeyond_monster.js
@@ -3835,7 +3835,7 @@ class Monster extends CharacterBase {
         if (hit_idx > 0)
             hit = description.slice(hit_idx);
         // Using match with global modifier then map to regular match because RegExp.matchAll isn't available on every browser
-        const damage_regexp = new RegExp(/([\w]* )(?:([0-9]+))?(?: *\(?([0-9]*d[0-9]+(?:\s*[-+]\s*[0-9]+)?(?: plus [^\)]+)?)\)?)? ([\w ]+?) damage/)
+        const damage_regexp = new RegExp(/([\w]* )(?:([0-9]+)[^d])?(?: *\(?([0-9]*d[0-9]+(?:\s*[-+]\s*[0-9]+)?(?: plus [^\)]+)?)\)?)? ([\w ]+?) damage/)
         const damage_matches = reMatchAll(damage_regexp, hit) || [];
         const damages = [];
         const damage_types = [];

--- a/dist/dndbeyond_vehicle.js
+++ b/dist/dndbeyond_vehicle.js
@@ -3835,7 +3835,7 @@ class Monster extends CharacterBase {
         if (hit_idx > 0)
             hit = description.slice(hit_idx);
         // Using match with global modifier then map to regular match because RegExp.matchAll isn't available on every browser
-        const damage_regexp = new RegExp(/([\w]* )(?:([0-9]+))?(?: *\(?([0-9]*d[0-9]+(?:\s*[-+]\s*[0-9]+)?(?: plus [^\)]+)?)\)?)? ([\w ]+?) damage/)
+        const damage_regexp = new RegExp(/([\w]* )(?:([0-9]+)[^d])?(?: *\(?([0-9]*d[0-9]+(?:\s*[-+]\s*[0-9]+)?(?: plus [^\)]+)?)\)?)? ([\w ]+?) damage/)
         const damage_matches = reMatchAll(damage_regexp, hit) || [];
         const damages = [];
         const damage_types = [];

--- a/src/dndbeyond/base/monster.js
+++ b/src/dndbeyond/base/monster.js
@@ -281,7 +281,7 @@ class Monster extends CharacterBase {
         if (hit_idx > 0)
             hit = description.slice(hit_idx);
         // Using match with global modifier then map to regular match because RegExp.matchAll isn't available on every browser
-        const damage_regexp = new RegExp(/([\w]* )(?:([0-9]+))?(?: *\(?([0-9]*d[0-9]+(?:\s*[-+]\s*[0-9]+)?(?: plus [^\)]+)?)\)?)? ([\w ]+?) damage/)
+        const damage_regexp = new RegExp(/([\w]* )(?:([0-9]+)[^d])?(?: *\(?([0-9]*d[0-9]+(?:\s*[-+]\s*[0-9]+)?(?: plus [^\)]+)?)\)?)? ([\w ]+?) damage/)
         const damage_matches = reMatchAll(damage_regexp, hit) || [];
         const damages = [];
         const damage_types = [];


### PR DESCRIPTION
I hate adding commit with no values in the log, so I made the changes of PR #596
I will close the other PR.

This is related to the bug seen on discord, a homebrew monster with an attack text without the default damage was giving a bad roll. Eg:
`...Hit: 2d4 + 2 ...` would be interpret as `d4+2`
because the regex took the first number as the default damage.
