### PR TITLE
Implement escaping commas in damage bonus

### DIFF
--- a/dist/astral.js
+++ b/dist/astral.js
@@ -554,7 +554,8 @@ const character_settings = {
     },
     "custom-damage-dice": {
         "title": "Custom Damage dice formula bonus",
-        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple independent rolls.",
+        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple " +
+            "independent rolls.\nFor macros including commas inside the formula, preceed each comma with \\",
         "type": "string",
         "default": ""
     },

--- a/dist/astral_script.js
+++ b/dist/astral_script.js
@@ -554,7 +554,8 @@ const character_settings = {
     },
     "custom-damage-dice": {
         "title": "Custom Damage dice formula bonus",
-        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple independent rolls.",
+        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple " +
+            "independent rolls.\nFor macros including commas inside the formula, preceed each comma with \\",
         "type": "string",
         "default": ""
     },

--- a/dist/background.js
+++ b/dist/background.js
@@ -600,7 +600,8 @@ const character_settings = {
     },
     "custom-damage-dice": {
         "title": "Custom Damage dice formula bonus",
-        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple independent rolls.",
+        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple " +
+            "independent rolls.\nFor macros including commas inside the formula, preceed each comma with \\",
         "type": "string",
         "default": ""
     },

--- a/dist/default_popup.js
+++ b/dist/default_popup.js
@@ -555,7 +555,8 @@ const character_settings = {
     },
     "custom-damage-dice": {
         "title": "Custom Damage dice formula bonus",
-        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple independent rolls.",
+        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple " +
+            "independent rolls.\nFor macros including commas inside the formula, preceed each comma with \\",
         "type": "string",
         "default": ""
     },

--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -554,7 +554,8 @@ const character_settings = {
     },
     "custom-damage-dice": {
         "title": "Custom Damage dice formula bonus",
-        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple independent rolls.",
+        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple " +
+            "independent rolls.\nFor macros including commas inside the formula, preceed each comma with \\",
         "type": "string",
         "default": ""
     },
@@ -5202,7 +5203,9 @@ function rollItem(force_display = false, force_to_hit_only = false, force_damage
 
         const custom_damages = character.getSetting("custom-damage-dice", "");
         if (custom_damages.length > 0) {
-            for (let custom_damage of custom_damages.split(",")) {
+            // Split only on not escaped commas, then remove the escape character 
+            for (let custom_damage_delimited of custom_damages.split(/(?<!\\),/)) {
+                const custom_damage = custom_damage_delimited.replace(/\\,/g, ",");
                 if (custom_damage.includes(":")) {
                     const parts = custom_damage.split(":", 2);
                     damages.push(parts[1].trim());
@@ -5576,7 +5579,9 @@ function rollAction(paneClass, force_to_hit_only = false, force_damages_only = f
 
         const custom_damages = character.getSetting("custom-damage-dice", "");
         if (custom_damages.length > 0) {
-            for (let custom_damage of custom_damages.split(",")) {
+            // Split only on not escaped commas, then remove the escape character 
+            for (let custom_damage_delimited of custom_damages.split(/(?<!\\),/)) {
+                const custom_damage = custom_damage_delimited.replace(/\\,/g, ",");
                 if (custom_damage.includes(":")) {
                     const parts = custom_damage.split(":", 2);
                     damages.push(parts[1].trim());
@@ -5970,7 +5975,9 @@ function rollSpell(force_display = false, force_to_hit_only = false, force_damag
 
         const custom_damages = character.getSetting("custom-damage-dice", "");
         if (custom_damages.length > 0) {
-            for (let custom_damage of custom_damages.split(",")) {
+            // Split only on not escaped commas, then remove the escape character 
+            for (let custom_damage_delimited of custom_damages.split(/(?<!\\),/)) {
+                const custom_damage = custom_damage_delimited.replace(/\\,/g, ",");
                 if (custom_damage.includes(":")) {
                     const parts = custom_damage.split(":", 2);
                     damages.push(parts[1].trim());

--- a/dist/dndbeyond_encounter.js
+++ b/dist/dndbeyond_encounter.js
@@ -554,7 +554,8 @@ const character_settings = {
     },
     "custom-damage-dice": {
         "title": "Custom Damage dice formula bonus",
-        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple independent rolls.",
+        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple " +
+            "independent rolls.\nFor macros including commas inside the formula, preceed each comma with \\",
         "type": "string",
         "default": ""
     },

--- a/dist/dndbeyond_item.js
+++ b/dist/dndbeyond_item.js
@@ -554,7 +554,8 @@ const character_settings = {
     },
     "custom-damage-dice": {
         "title": "Custom Damage dice formula bonus",
-        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple independent rolls.",
+        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple " +
+            "independent rolls.\nFor macros including commas inside the formula, preceed each comma with \\",
         "type": "string",
         "default": ""
     },

--- a/dist/dndbeyond_monster.js
+++ b/dist/dndbeyond_monster.js
@@ -554,7 +554,8 @@ const character_settings = {
     },
     "custom-damage-dice": {
         "title": "Custom Damage dice formula bonus",
-        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple independent rolls.",
+        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple " +
+            "independent rolls.\nFor macros including commas inside the formula, preceed each comma with \\",
         "type": "string",
         "default": ""
     },

--- a/dist/dndbeyond_spell.js
+++ b/dist/dndbeyond_spell.js
@@ -554,7 +554,8 @@ const character_settings = {
     },
     "custom-damage-dice": {
         "title": "Custom Damage dice formula bonus",
-        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple independent rolls.",
+        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple " +
+            "independent rolls.\nFor macros including commas inside the formula, preceed each comma with \\",
         "type": "string",
         "default": ""
     },

--- a/dist/dndbeyond_vehicle.js
+++ b/dist/dndbeyond_vehicle.js
@@ -554,7 +554,8 @@ const character_settings = {
     },
     "custom-damage-dice": {
         "title": "Custom Damage dice formula bonus",
-        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple independent rolls.",
+        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple " +
+            "independent rolls.\nFor macros including commas inside the formula, preceed each comma with \\",
         "type": "string",
         "default": ""
     },

--- a/dist/fvtt.js
+++ b/dist/fvtt.js
@@ -554,7 +554,8 @@ const character_settings = {
     },
     "custom-damage-dice": {
         "title": "Custom Damage dice formula bonus",
-        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple independent rolls.",
+        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple " +
+            "independent rolls.\nFor macros including commas inside the formula, preceed each comma with \\",
         "type": "string",
         "default": ""
     },

--- a/dist/fvtt_script.js
+++ b/dist/fvtt_script.js
@@ -555,7 +555,8 @@ const character_settings = {
     },
     "custom-damage-dice": {
         "title": "Custom Damage dice formula bonus",
-        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple independent rolls.",
+        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple " +
+            "independent rolls.\nFor macros including commas inside the formula, preceed each comma with \\",
         "type": "string",
         "default": ""
     },

--- a/dist/options.js
+++ b/dist/options.js
@@ -554,7 +554,8 @@ const character_settings = {
     },
     "custom-damage-dice": {
         "title": "Custom Damage dice formula bonus",
-        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple independent rolls.",
+        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple " +
+            "independent rolls.\nFor macros including commas inside the formula, preceed each comma with \\",
         "type": "string",
         "default": ""
     },

--- a/dist/popup.js
+++ b/dist/popup.js
@@ -600,7 +600,8 @@ const character_settings = {
     },
     "custom-damage-dice": {
         "title": "Custom Damage dice formula bonus",
-        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple independent rolls.",
+        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple " +
+            "independent rolls.\nFor macros including commas inside the formula, preceed each comma with \\",
         "type": "string",
         "default": ""
     },

--- a/dist/roll20.js
+++ b/dist/roll20.js
@@ -554,7 +554,8 @@ const character_settings = {
     },
     "custom-damage-dice": {
         "title": "Custom Damage dice formula bonus",
-        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple independent rolls.",
+        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple " +
+            "independent rolls.\nFor macros including commas inside the formula, preceed each comma with \\",
         "type": "string",
         "default": ""
     },

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -102,6 +102,8 @@ Be aware that the roll bonus is applied to all rolls (ability checks, skill chec
 
 For example, if you want it to ask you if you want to apply the Bless bonus on every roll, you could set it to : `+?{Use Bless|Yes,1d4|No,0}`
 
+To use such macro in a damage bonus, preceed commas with `\`. For example: `?{Use Hex|Yes\,1d6|No\,0}`
+
 Of course, the use of such macros will only work on Roll 20, not on Foundry VTT or other.
 
 ### How can I use this non-standard spell or feature? 

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -386,7 +386,8 @@ const character_settings = {
     },
     "custom-damage-dice": {
         "title": "Custom Damage dice formula bonus",
-        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple independent rolls.",
+        "description": "Add custom dice to damage rolls (Magic Weapon, Elemental Weapon, Green-flame Blade, etc..). Use a comma to separate multiple " +
+            "independent rolls.\nFor macros including commas inside the formula, preceed each comma with \\",
         "type": "string",
         "default": ""
     },

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -329,7 +329,9 @@ function rollItem(force_display = false, force_to_hit_only = false, force_damage
 
         const custom_damages = character.getSetting("custom-damage-dice", "");
         if (custom_damages.length > 0) {
-            for (let custom_damage of custom_damages.split(",")) {
+            // Split only on not escaped commas, then remove the escape character 
+            for (let custom_damage_delimited of custom_damages.split(/(?<!\\),/)) {
+                const custom_damage = custom_damage_delimited.replace(/\\,/g, ",");
                 if (custom_damage.includes(":")) {
                     const parts = custom_damage.split(":", 2);
                     damages.push(parts[1].trim());
@@ -703,7 +705,9 @@ function rollAction(paneClass, force_to_hit_only = false, force_damages_only = f
 
         const custom_damages = character.getSetting("custom-damage-dice", "");
         if (custom_damages.length > 0) {
-            for (let custom_damage of custom_damages.split(",")) {
+            // Split only on not escaped commas, then remove the escape character 
+            for (let custom_damage_delimited of custom_damages.split(/(?<!\\),/)) {
+                const custom_damage = custom_damage_delimited.replace(/\\,/g, ",");
                 if (custom_damage.includes(":")) {
                     const parts = custom_damage.split(":", 2);
                     damages.push(parts[1].trim());
@@ -1097,7 +1101,9 @@ function rollSpell(force_display = false, force_to_hit_only = false, force_damag
 
         const custom_damages = character.getSetting("custom-damage-dice", "");
         if (custom_damages.length > 0) {
-            for (let custom_damage of custom_damages.split(",")) {
+            // Split only on not escaped commas, then remove the escape character 
+            for (let custom_damage_delimited of custom_damages.split(/(?<!\\),/)) {
+                const custom_damage = custom_damage_delimited.replace(/\\,/g, ",");
                 if (custom_damage.includes(":")) {
                     const parts = custom_damage.split(":", 2);
                     damages.push(parts[1].trim());


### PR DESCRIPTION
Implemented the option to escape commas in damage dice formula bonus field using `\`.

Wasn't sure if it is wanted there, but I included mentions of the possibility in option and on the FAQ page.