### PR TITLE
Add toggle for Colossus Slayer

### DIFF
--- a/dist/astral.js
+++ b/dist/astral.js
@@ -696,6 +696,12 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+    "ranger-colossus-slayer": {
+        "title": "Ranger: Hunter's Prey: Colossus Slayer (Apply to next roll only)",
+        "description": "Use your Colossus Slayer ability and add 1d8 damage to your target",
+        "type": "bool",
+        "default": false
+    },
     "ranger-slayers-prey": {
         "title": "Ranger: Monster Slayer: Slayer's Prey",
         "description": "Use your Slayer's Prey ability and add 1d6 damage to your target",

--- a/dist/astral_script.js
+++ b/dist/astral_script.js
@@ -696,6 +696,12 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+    "ranger-colossus-slayer": {
+        "title": "Ranger: Hunter's Prey: Colossus Slayer (Apply to next roll only)",
+        "description": "Use your Colossus Slayer ability and add 1d8 damage to your target",
+        "type": "bool",
+        "default": false
+    },
     "ranger-slayers-prey": {
         "title": "Ranger: Monster Slayer: Slayer's Prey",
         "description": "Use your Slayer's Prey ability and add 1d6 damage to your target",

--- a/dist/background.js
+++ b/dist/background.js
@@ -742,6 +742,12 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+    "ranger-colossus-slayer": {
+        "title": "Ranger: Hunter's Prey: Colossus Slayer (Apply to next roll only)",
+        "description": "Use your Colossus Slayer ability and add 1d8 damage to your target",
+        "type": "bool",
+        "default": false
+    },
     "ranger-slayers-prey": {
         "title": "Ranger: Monster Slayer: Slayer's Prey",
         "description": "Use your Slayer's Prey ability and add 1d6 damage to your target",

--- a/dist/default_popup.js
+++ b/dist/default_popup.js
@@ -697,6 +697,12 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+    "ranger-colossus-slayer": {
+        "title": "Ranger: Hunter's Prey: Colossus Slayer (Apply to next roll only)",
+        "description": "Use your Colossus Slayer ability and add 1d8 damage to your target",
+        "type": "bool",
+        "default": false
+    },
     "ranger-slayers-prey": {
         "title": "Ranger: Monster Slayer: Slayer's Prey",
         "description": "Use your Slayer's Prey ability and add 1d6 damage to your target",

--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -696,6 +696,12 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+    "ranger-colossus-slayer": {
+        "title": "Ranger: Hunter's Prey: Colossus Slayer (Apply to next roll only)",
+        "description": "Use your Colossus Slayer ability and add 1d8 damage to your target",
+        "type": "bool",
+        "default": false
+    },
     "ranger-slayers-prey": {
         "title": "Ranger: Monster Slayer: Slayer's Prey",
         "description": "Use your Slayer's Prey ability and add 1d6 damage to your target",
@@ -5113,6 +5119,7 @@ function rollItem(force_display = false, force_to_hit_only = false, force_damage
     if (!force_display && Object.keys(properties).includes("Damage")) {
         const item_full_name = $(".ct-item-pane .ct-sidebar__heading .ct-item-name,.ct-item-pane .ct-sidebar__heading .ddbc-item-name").text();
         let to_hit = properties["To Hit"] !== undefined && properties["To Hit"] !== "--" ? properties["To Hit"] : null;
+        let settings_to_change = {}
 
         if (to_hit === null)
             to_hit = findToHit(item_full_name, ".ct-combat-attack--item,.ddbc-combat-attack--item", ".ct-item-name,.ddbc-item-name", ".ct-combat-attack__tohit,.ddbc-combat-attack__tohit");
@@ -5244,7 +5251,7 @@ function rollItem(force_display = false, force_to_hit_only = false, force_damage
             to_hit += " - 5";
             damages.push("10");
             damage_types.push("Sharpshooter");
-            character.mergeCharacterSettings({ "sharpshooter": false });
+            settings_to_change["sharpshooter"] = false;
         }
         if (to_hit !== null && 
             character.getSetting("great-weapon-master", false) &&
@@ -5255,7 +5262,7 @@ function rollItem(force_display = false, force_to_hit_only = false, force_damage
             to_hit += " - 5";
             damages.push("10");
             damage_types.push("Weapon Master");
-            character.mergeCharacterSettings({ "great-weapon-master": false });
+            settings_to_change["great-weapon-master"] = false;
         }
         if (to_hit !== null && 
             character.getSetting("paladin-sacred-weapon", false)) {
@@ -5292,11 +5299,13 @@ function rollItem(force_display = false, force_to_hit_only = false, force_damage
             if (character.getSetting("ranger-dread-ambusher", false)) {
                 damages.push("1d8");
                 damage_types.push("Ambush");
-                character.mergeCharacterSettings({ "ranger-dread-ambusher": false });
+                settings_to_change["ranger-dread-ambusher"] = false;
             }
-            if (character.hasClassFeature("Hunter’s Prey: Colossus Slayer")) {
+            if (character.hasClassFeature("Hunter’s Prey: Colossus Slayer") &&
+                character.getSetting("ranger-colossus-slayer", false)) {
                 damages.push("1d8");
                 damage_types.push("Colossus Slayer");
+                settings_to_change["ranger-colossus-slayer"] = false; // Reset to off since CS only applies once per turn
             }
             if (character.hasClassFeature("Slayer’s Prey") &&
                 character.getSetting("ranger-slayers-prey", false)) {
@@ -5372,7 +5381,7 @@ function rollItem(force_display = false, force_to_hit_only = false, force_damage
                 blades_dmg = "8d6"
             damages.push(blades_dmg);
             damage_types.push("Psychic");
-            character.mergeCharacterSettings({ "bard-psychic-blades": false });
+            settings_to_change["bard-psychic-blades"] = false;
         }
         //Protector Aasimar: Radiant Soul Damage
         if (character.hasRacialTrait("Radiant Soul") &&
@@ -5461,16 +5470,20 @@ function rollItem(force_display = false, force_to_hit_only = false, force_damage
                 roll_properties["name"] += ` (CRIT${custom_critical_limit})`;
         }
 
-        // Asssassinate: consider all rolls as critical;
+        // Assassinate: consider all rolls as critical;
         if (character.hasClassFeature("Assassinate") &&
             character.getSetting("rogue-assassinate", false)) {
             roll_properties["critical-limit"] = 1;
             roll_properties["advantage"] = RollType.OVERRIDE_ADVANTAGE;
-            character.mergeCharacterSettings({ "rogue-assassinate": false });
+            settings_to_change["rogue-assassinate"] = false;
         }
         // Sorcerer: Clockwork Soul - Trance of Order
         if (character.hasClassFeature("Trance of Order") && character.getSetting("sorcerer-trance-of-order", false))
             roll_properties.d20 = "1d20min10";
+
+        // Apply batched updates to settings, if any:
+        if (Object.keys(settings_to_change).length > 0)
+            character.mergeCharacterSettings(settings_to_change);
 
         return sendRollWithCharacter("attack", damages[0], roll_properties);
     } else if (!force_display && (is_tool || is_instrument) && character._abilities.length > 0) {

--- a/dist/dndbeyond_encounter.js
+++ b/dist/dndbeyond_encounter.js
@@ -696,6 +696,12 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+    "ranger-colossus-slayer": {
+        "title": "Ranger: Hunter's Prey: Colossus Slayer (Apply to next roll only)",
+        "description": "Use your Colossus Slayer ability and add 1d8 damage to your target",
+        "type": "bool",
+        "default": false
+    },
     "ranger-slayers-prey": {
         "title": "Ranger: Monster Slayer: Slayer's Prey",
         "description": "Use your Slayer's Prey ability and add 1d6 damage to your target",

--- a/dist/dndbeyond_item.js
+++ b/dist/dndbeyond_item.js
@@ -696,6 +696,12 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+    "ranger-colossus-slayer": {
+        "title": "Ranger: Hunter's Prey: Colossus Slayer (Apply to next roll only)",
+        "description": "Use your Colossus Slayer ability and add 1d8 damage to your target",
+        "type": "bool",
+        "default": false
+    },
     "ranger-slayers-prey": {
         "title": "Ranger: Monster Slayer: Slayer's Prey",
         "description": "Use your Slayer's Prey ability and add 1d6 damage to your target",

--- a/dist/dndbeyond_monster.js
+++ b/dist/dndbeyond_monster.js
@@ -696,6 +696,12 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+    "ranger-colossus-slayer": {
+        "title": "Ranger: Hunter's Prey: Colossus Slayer (Apply to next roll only)",
+        "description": "Use your Colossus Slayer ability and add 1d8 damage to your target",
+        "type": "bool",
+        "default": false
+    },
     "ranger-slayers-prey": {
         "title": "Ranger: Monster Slayer: Slayer's Prey",
         "description": "Use your Slayer's Prey ability and add 1d6 damage to your target",

--- a/dist/dndbeyond_spell.js
+++ b/dist/dndbeyond_spell.js
@@ -696,6 +696,12 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+    "ranger-colossus-slayer": {
+        "title": "Ranger: Hunter's Prey: Colossus Slayer (Apply to next roll only)",
+        "description": "Use your Colossus Slayer ability and add 1d8 damage to your target",
+        "type": "bool",
+        "default": false
+    },
     "ranger-slayers-prey": {
         "title": "Ranger: Monster Slayer: Slayer's Prey",
         "description": "Use your Slayer's Prey ability and add 1d6 damage to your target",

--- a/dist/dndbeyond_vehicle.js
+++ b/dist/dndbeyond_vehicle.js
@@ -696,6 +696,12 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+    "ranger-colossus-slayer": {
+        "title": "Ranger: Hunter's Prey: Colossus Slayer (Apply to next roll only)",
+        "description": "Use your Colossus Slayer ability and add 1d8 damage to your target",
+        "type": "bool",
+        "default": false
+    },
     "ranger-slayers-prey": {
         "title": "Ranger: Monster Slayer: Slayer's Prey",
         "description": "Use your Slayer's Prey ability and add 1d6 damage to your target",

--- a/dist/fvtt.js
+++ b/dist/fvtt.js
@@ -696,6 +696,12 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+    "ranger-colossus-slayer": {
+        "title": "Ranger: Hunter's Prey: Colossus Slayer (Apply to next roll only)",
+        "description": "Use your Colossus Slayer ability and add 1d8 damage to your target",
+        "type": "bool",
+        "default": false
+    },
     "ranger-slayers-prey": {
         "title": "Ranger: Monster Slayer: Slayer's Prey",
         "description": "Use your Slayer's Prey ability and add 1d6 damage to your target",

--- a/dist/fvtt_script.js
+++ b/dist/fvtt_script.js
@@ -697,6 +697,12 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+    "ranger-colossus-slayer": {
+        "title": "Ranger: Hunter's Prey: Colossus Slayer (Apply to next roll only)",
+        "description": "Use your Colossus Slayer ability and add 1d8 damage to your target",
+        "type": "bool",
+        "default": false
+    },
     "ranger-slayers-prey": {
         "title": "Ranger: Monster Slayer: Slayer's Prey",
         "description": "Use your Slayer's Prey ability and add 1d6 damage to your target",

--- a/dist/options.js
+++ b/dist/options.js
@@ -696,6 +696,12 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+    "ranger-colossus-slayer": {
+        "title": "Ranger: Hunter's Prey: Colossus Slayer (Apply to next roll only)",
+        "description": "Use your Colossus Slayer ability and add 1d8 damage to your target",
+        "type": "bool",
+        "default": false
+    },
     "ranger-slayers-prey": {
         "title": "Ranger: Monster Slayer: Slayer's Prey",
         "description": "Use your Slayer's Prey ability and add 1d6 damage to your target",

--- a/dist/popup.js
+++ b/dist/popup.js
@@ -742,6 +742,12 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+    "ranger-colossus-slayer": {
+        "title": "Ranger: Hunter's Prey: Colossus Slayer (Apply to next roll only)",
+        "description": "Use your Colossus Slayer ability and add 1d8 damage to your target",
+        "type": "bool",
+        "default": false
+    },
     "ranger-slayers-prey": {
         "title": "Ranger: Monster Slayer: Slayer's Prey",
         "description": "Use your Slayer's Prey ability and add 1d6 damage to your target",
@@ -1790,6 +1796,11 @@ function populateCharacter(response) {
         }
         if (response["class-features"].includes("Planar Warrior")) {
             e = createHTMLOption("ranger-planar-warrior", false, character_settings);
+            options.append(e);
+        }
+        if (response["class-features"].includes("Hunter’s Prey: Colossus Slayer")) {
+            console.log('CS Class feature detected.');
+            e = createHTMLOption("ranger-colossus-slayer", false, character_settings);
             options.append(e);
         }
         if (response["class-features"].includes("Slayer’s Prey")) {

--- a/dist/roll20.js
+++ b/dist/roll20.js
@@ -696,6 +696,12 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+    "ranger-colossus-slayer": {
+        "title": "Ranger: Hunter's Prey: Colossus Slayer (Apply to next roll only)",
+        "description": "Use your Colossus Slayer ability and add 1d8 damage to your target",
+        "type": "bool",
+        "default": false
+    },
     "ranger-slayers-prey": {
         "title": "Ranger: Monster Slayer: Slayer's Prey",
         "description": "Use your Slayer's Prey ability and add 1d6 damage to your target",

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,3 +1,8 @@
+Unreleased
+====
+* **Feature**: Add a toggle option for the Ranger's Colossus Slayer ability, rather than always rolling it
+* **Bugfix**: Fixed an issue where only one setting could be changed during damage rolls, even if multiple settings should have been changed
+
 v2.3.0
 ===
 
@@ -11,7 +16,7 @@ v2.3.0
 * **Feature**: Allow queuing up of rolls when the Digital Dice are enabled so all rolls are executed
 * **Feature**: Add support for capturing and transferring digital dice rolled manually through D&D Beyond's interface
 * **Feature**: Add support for parsing the item customization options (Hex Weapon, Pact Weapon)
-* **Feature**: Display a class feature's choices (such as selected profiency or the Monastic Tradition) when displaying a feature to the VTT
+* **Feature**: Display a class feature's choices (such as selected proficiency or the Monastic Tradition) when displaying a feature to the VTT
 * **Feature**: Add option to hide from the player the results of a whispered roll that is sent to Discord (by [@rispig](https://github.com/rispig))
 * **Feature**: Add a notification when the class features are parsed so the user gets visual feedback when it's done
 * **Feature**: Wizard Bladesong: Support concentration constitution saves and adds the intelligence modifier (by [@Aeristoka](https://github.com/Aeristoka))
@@ -47,7 +52,7 @@ v2.3.0
 * **Bugfix**: Fix critical damages not being rolled with digital dice disabled and using Beyond20 roll renderer
 * **Bugfix**: Display the full spell card information from a monster page when using the "hide monster name" whisper name
 * **Bugfix**: Fix custom messages not working properly if the whisper or roll type setting is set to "always ask"
-* **Bugfix**: Fix unreliable support of Collossus slayer feat. Does not query anymore and is handled like Sneak Attack (by [@Aeristoka](https://github.com/Aeristoka))
+* **Bugfix**: Fix unreliable support of Colossus slayer feat. Does not query anymore and is handled like Sneak Attack (by [@Aeristoka](https://github.com/Aeristoka))
 * **Bugfix**: *Roll20*: Fix rolls not being sent with the correct character "speaking as"
 * **Bugfix**: *Roll20*: Fix detection of some character names to speak rolls as by trimming leading and trailing spaces
 * **Bugfix**: *Roll20*: Fix custom chat messages not displaying correctly when using the Beyond20 roll renderer
@@ -58,7 +63,7 @@ v2.3.0
 * **Bugfix**: *Astral*: Changed rendered roll formulas in Astral using the syntax recommended by @Redmega. (by [@adriangaro](https://github.com/adriangaro))
 * **Bugfix**: *Astral*: Fixed some errors related to speak as character functionality. (by [@adriangaro](https://github.com/adriangaro))
 * **Misc**: Clarify the text for the "click the features and traits" alert on new character sheets (by [@Aeristoka](https://github.com/Aeristoka))
-* **Misc**: Remove the mention from the "send custom notes" feature information that falsly stated being supported on Roll20 only
+* **Misc**: Remove the mention from the "send custom notes" feature information that falsely stated being supported on Roll20 only
 * **Misc**: Rename the "Fighter: Sharpshooter" option to "Feat: Sharpshooter" to be more accurate
 * **Misc**: Rename the "Rage: You are raging" option to "Barbarian: Rage!" to be more in line with other options formatting
 * **Misc**: Add an information banner in the extension popup on non D&D Beyond and VTT pages to decrease confusion on how to use the extension
@@ -70,7 +75,7 @@ v2.2.1
 
 * **Feature**: Make the quick roll tooltip stay longer after hover to more easily interact with it
 * **Bugfix**: *Roll20*: Fix issue preventing rolls from appearing on Roll20 when the character sheet template isn't OGL
-* **Bugfix**: Fix missing "Roll Damages" button when auto-roll-damages is disabeld
+* **Bugfix**: Fix missing "Roll Damages" button when auto-roll-damages is disabled
 * **Bugfix**: Fix issue preventing damage-only rolls from working if auto-roll-damages was disabled
 * **Bugfix**: Fix a possible crash when rolling an attack that has no damage
 * **Bugfix**: Fix the roll formula being incorrect when having both Reliable Talent/Silver Tongue class feature and Halfling Luck
@@ -101,7 +106,7 @@ v2.2
 * **Feature**: Move the user query for rolling tools and instruments to the D&D Beyond page
 * **Feature**: Add a "Use Tool" and "Use Instrument" button for tools and instrument items
 * **Feature**: Save the last choice made by the user in the whisper/advantage query dialogs
-* **Feature**: Add abilility to send custom chat messages/macros to VTT when doing a roll (by [@John-Paul-R](https://github.com/John-Paul-R))
+* **Feature**: Add ability to send custom chat messages/macros to VTT when doing a roll (by [@John-Paul-R](https://github.com/John-Paul-R))
 * **Feature**: Roll the Spell Attack as a full attack instead of a custom d20 modifier. Allows use of the advantage settings
 * **Feature**: Add the ability to switch the D&D Beyond sidebar to the selected spell's level when clicking on a spell which is the same as the one already displayed, but at a different level
 * **Feature**: Add support for Halfling Luck feature
@@ -212,7 +217,7 @@ v2.0
 ===
 * **Feature**: Add integration with the D&D Beyond Digital Dice
 * **Feature**: Update the Beyond20 icon sets to make them more beautiful and usable at low resolutions. Icons provided by [Jerry Escandon](https://github.com/Jerryescandon)
-* **Feature**: *Discord*: Add a channel manager for Discord secret keys to allow easily switching channel destinationse](https://github.com/Brunhine))
+* **Feature**: *Discord*: Add a channel manager for Discord secret keys to allow easily switching channel destinations](https://github.com/Brunhine))
 * **Feature**: *Discord*: Add support for whispered rolls in the Discord integration
 * **Feature**: *Roll20*: Automatically check for character sheet template and display the roll according to the campaign setting
 * **Feature**: Add quick roll button to Initiative
@@ -241,7 +246,7 @@ v2.0
 * **Bugfix**: Fix some edge cases in roll formula formatting in ability descriptions (By [@Brunhine](https://github.com/Brunhine))
 * **Bugfix**: Fix Fighter's Giant Might class feature not scaling its dice properly at level 11 (By [@Aeristoka](https://github.com/Aeristoka))
 * **Bugfix**: Fix Cleric's Divine Strike to work for non melee weapons as well (By [@Aeristoka](https://github.com/Aeristoka))
-* **Bugfix**: Fix handling of Great Weapon Fighting for the Polarm Master bonus action (By [@Aeristoka](https://github.com/Aeristoka))
+* **Bugfix**: Fix handling of Great Weapon Fighting for the Polearm Master bonus action (By [@Aeristoka](https://github.com/Aeristoka))
 * **Bugfix**: Roll Sneak Attack damages on Psychic Blades action (By [@Aeristoka](https://github.com/Aeristoka))
 * **Bugfix**: Fix saving throws quick roll not working anymore (By [@kbuzsaki](https://github.com/kbuzsaki))
 * **Bugfix**: Do not display duplicate custom dice icons in the class features list
@@ -250,7 +255,7 @@ v2.0
 * **Bugfix**: Fix Cleric's Life Transference damage being wrongly calculated
 * **Bugfix**: Fix custom damage labels being ignored for spells and actions
 * **Bugfix**: Fix class feature descriptions not being properly displayed
-* **Bugfix**: Fix rolling tools from Equipement due to change in equipment type
+* **Bugfix**: Fix rolling tools from Equipment due to change in equipment type
 * **Bugfix**: *Roll20*: Prevent multiple dice rolls in a single formula from appearing as separate formulas
 * **Bugfix**: *Foundry VTT*: Fix add to initiative breaking with 0.6.0 release (By [@Aeristoka](https://github.com/Aeristoka))
 * **Bugfix**: *Foundry VTT*: Fix applying damage or healing to a token from a custom roll
@@ -320,7 +325,7 @@ v0.9
 
 * **Feature**: Add indicator on roll buttons to identify the roll type (advantage, disadvantage, roll twice, etc...)
 * **Feature**: Add synchronization of Temporary HP to tokens and character sheets in Roll20 and FVTT
-* **Feature**: Add support for HP and Temp HP synchornization for character sheet creatures from the Extra section
+* **Feature**: Add support for HP and Temp HP synchronization for character sheet creatures from the Extra section
 * **Feature**: Add a "Display to VTT" button on Equipment and Magic Items pages of D&D Beyond
 * **Feature**: Support rolling with Advantage when clicking with the Shift button pressed
 * **Feature**: Support rolling with Disadvantage when clicking with the Ctrl button pressed
@@ -369,7 +374,7 @@ v0.8
 * **Bugfix**: Fix inability to roll when opening the character sheet for the first time with a mobile or tablet layout
 * **Bugfix**: Fix duplication of the "Roll initiative" lines in stat blocks when switching monsters in the My Encounters page
 * **Bugfix**: Fix the spell name for concentration or ritual spells since the recent change to D&D Beyond content
-* **Bugfix**: Fix Great Weapong Fighting dice reroll being mistakenly applied on some two-handed non-melee weapons
+* **Bugfix**: Fix Great Weapon Fighting dice reroll being mistakenly applied on some two-handed non-melee weapons
 * **Bugfix**: Fix the spell level/school display missing spaces introduced in the recent code refactor of v0.7
 * **Bugfix**: Fix character action list not being properly cached which may lead to loss of character options on mobile
 * **Bugfix**: Fix parsing of stat block attacks for Clay Gladiator and Scout which had typos in the official D&D Beyond pages
@@ -438,7 +443,7 @@ v0.5
 - **Bugfix**: Roll damages even without a "To-Hit" for Custom Actions
 - **Bugfix**: *FVTT*: Clicking 'Roll Damages' when auto-roll damage is disabled will now re-roll the damage dice.
 - **Misc**: Decrease Chrome extension permissions and require manual activation for FVTT installations (See [Release Notes](release_notes#v05) for more information)
-- **Misc**: Replace all remaining occurences of "Roll20" with "VTT"
+- **Misc**: Replace all remaining occurrences of "Roll20" with "VTT"
 
 v0.4
 ===
@@ -449,7 +454,7 @@ v0.4
 - **Feature**: *FVTT*: Add support for the auto-roll damage option
 - **Feature**: *FVTT*: Nicer display output for rolls
 - **Feature**: Add "Roll20 Template" option in the Roll20 popup menu
-- **Bugfix**: Fix non-visible messages on Roll20 when using other tempaltes even if template is set to 'Other templates'
+- **Bugfix**: Fix non-visible messages on Roll20 when using other templates even if template is set to 'Other templates'
 - **Bugfix**: No need to roll critical damages for spells that have no 'to-hit'. Fixes 3d Dice rolls doubled on healing spells.
 - **Bugfix**: Fix spell attack dice disappearing
 - **Misc**: Remove the green/red on death saving throws above/below 10 as it was apparently confusing to players (might re-add as an option).
@@ -551,7 +556,7 @@ v0.0.4
 ===
 
 - **Feature:** Add support for other roll20 character sheet templates
-- **Bugfix:** Fix custom dice formulas gettings messed up if we change spell level casting
+- **Bugfix:** Fix custom dice formulas getting messed up if we change spell level casting
 
 v0.0.3
 ===

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -528,6 +528,12 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+    "ranger-colossus-slayer": {
+        "title": "Ranger: Hunter's Prey: Colossus Slayer (Apply to next roll only)",
+        "description": "Use your Colossus Slayer ability and add 1d8 damage to your target",
+        "type": "bool",
+        "default": false
+    },
     "ranger-slayers-prey": {
         "title": "Ranger: Monster Slayer: Slayer's Prey",
         "description": "Use your Slayer's Prey ability and add 1d6 damage to your target",

--- a/src/extension/popup.js
+++ b/src/extension/popup.js
@@ -145,6 +145,11 @@ function populateCharacter(response) {
             e = createHTMLOption("ranger-planar-warrior", false, character_settings);
             options.append(e);
         }
+        if (response["class-features"].includes("Hunter’s Prey: Colossus Slayer")) {
+            console.log('CS Class feature detected.');
+            e = createHTMLOption("ranger-colossus-slayer", false, character_settings);
+            options.append(e);
+        }
         if (response["class-features"].includes("Slayer’s Prey")) {
             e = createHTMLOption("ranger-slayers-prey", false, character_settings);
             options.append(e);


### PR DESCRIPTION
- Added a settings toggle for the next role to add the ranger's Colossus Slayer damage die.
- Also fixed a bug where multiple settings changed during a damage role were not being applied properly.
- Fixed some typos.