### PR TITLE
Halfling lucky toggle

### DIFF
--- a/dist/astral.js
+++ b/dist/astral.js
@@ -779,6 +779,12 @@ const character_settings = {
         "description": "You charge into battle, lending weight to your blow!",
         "type": "bool",
         "default": false
+    },
+    "halfling-lucky": {
+        "title": "Halfling Lucky",
+        "description": "The luck of your people guides your steps",
+        "type": "bool",
+        "default": true
     }
 }
 

--- a/dist/astral_script.js
+++ b/dist/astral_script.js
@@ -779,6 +779,12 @@ const character_settings = {
         "description": "You charge into battle, lending weight to your blow!",
         "type": "bool",
         "default": false
+    },
+    "halfling-lucky": {
+        "title": "Halfling Lucky",
+        "description": "The luck of your people guides your steps",
+        "type": "bool",
+        "default": true
     }
 }
 

--- a/dist/background.js
+++ b/dist/background.js
@@ -825,6 +825,12 @@ const character_settings = {
         "description": "You charge into battle, lending weight to your blow!",
         "type": "bool",
         "default": false
+    },
+    "halfling-lucky": {
+        "title": "Halfling Lucky",
+        "description": "The luck of your people guides your steps",
+        "type": "bool",
+        "default": true
     }
 }
 

--- a/dist/default_popup.js
+++ b/dist/default_popup.js
@@ -780,6 +780,12 @@ const character_settings = {
         "description": "You charge into battle, lending weight to your blow!",
         "type": "bool",
         "default": false
+    },
+    "halfling-lucky": {
+        "title": "Halfling Lucky",
+        "description": "The luck of your people guides your steps",
+        "type": "bool",
+        "default": true
     }
 }
 

--- a/dist/dndbeyond_character.js
+++ b/dist/dndbeyond_character.js
@@ -779,6 +779,12 @@ const character_settings = {
         "description": "You charge into battle, lending weight to your blow!",
         "type": "bool",
         "default": false
+    },
+    "halfling-lucky": {
+        "title": "Halfling Lucky",
+        "description": "The luck of your people guides your steps",
+        "type": "bool",
+        "default": true
     }
 }
 
@@ -4890,7 +4896,7 @@ function sendRollWithCharacter(rollType, fallback, args) {
     if (preview && preview.startsWith("url("))
         args.preview = preview.slice(5, -2);
     // Add halfling luck
-    if (character.hasRacialTrait("Lucky") && ["skill", "ability", "saving-throw", "death-save",
+    if (character.hasRacialTrait("Lucky") && character.getSetting("halfling-lucky", false) && ["skill", "ability", "saving-throw", "death-save",
         "initiative", "attack", "spell-attack"].includes(rollType)) {
         args.d20 = args.d20 || "1d20";
         args.d20 += "ro<=1";

--- a/dist/dndbeyond_encounter.js
+++ b/dist/dndbeyond_encounter.js
@@ -779,6 +779,12 @@ const character_settings = {
         "description": "You charge into battle, lending weight to your blow!",
         "type": "bool",
         "default": false
+    },
+    "halfling-lucky": {
+        "title": "Halfling Lucky",
+        "description": "The luck of your people guides your steps",
+        "type": "bool",
+        "default": true
     }
 }
 

--- a/dist/dndbeyond_item.js
+++ b/dist/dndbeyond_item.js
@@ -779,6 +779,12 @@ const character_settings = {
         "description": "You charge into battle, lending weight to your blow!",
         "type": "bool",
         "default": false
+    },
+    "halfling-lucky": {
+        "title": "Halfling Lucky",
+        "description": "The luck of your people guides your steps",
+        "type": "bool",
+        "default": true
     }
 }
 

--- a/dist/dndbeyond_monster.js
+++ b/dist/dndbeyond_monster.js
@@ -779,6 +779,12 @@ const character_settings = {
         "description": "You charge into battle, lending weight to your blow!",
         "type": "bool",
         "default": false
+    },
+    "halfling-lucky": {
+        "title": "Halfling Lucky",
+        "description": "The luck of your people guides your steps",
+        "type": "bool",
+        "default": true
     }
 }
 

--- a/dist/dndbeyond_spell.js
+++ b/dist/dndbeyond_spell.js
@@ -779,6 +779,12 @@ const character_settings = {
         "description": "You charge into battle, lending weight to your blow!",
         "type": "bool",
         "default": false
+    },
+    "halfling-lucky": {
+        "title": "Halfling Lucky",
+        "description": "The luck of your people guides your steps",
+        "type": "bool",
+        "default": true
     }
 }
 

--- a/dist/dndbeyond_vehicle.js
+++ b/dist/dndbeyond_vehicle.js
@@ -779,6 +779,12 @@ const character_settings = {
         "description": "You charge into battle, lending weight to your blow!",
         "type": "bool",
         "default": false
+    },
+    "halfling-lucky": {
+        "title": "Halfling Lucky",
+        "description": "The luck of your people guides your steps",
+        "type": "bool",
+        "default": true
     }
 }
 

--- a/dist/fvtt.js
+++ b/dist/fvtt.js
@@ -779,6 +779,12 @@ const character_settings = {
         "description": "You charge into battle, lending weight to your blow!",
         "type": "bool",
         "default": false
+    },
+    "halfling-lucky": {
+        "title": "Halfling Lucky",
+        "description": "The luck of your people guides your steps",
+        "type": "bool",
+        "default": true
     }
 }
 

--- a/dist/fvtt_script.js
+++ b/dist/fvtt_script.js
@@ -780,6 +780,12 @@ const character_settings = {
         "description": "You charge into battle, lending weight to your blow!",
         "type": "bool",
         "default": false
+    },
+    "halfling-lucky": {
+        "title": "Halfling Lucky",
+        "description": "The luck of your people guides your steps",
+        "type": "bool",
+        "default": true
     }
 }
 

--- a/dist/options.js
+++ b/dist/options.js
@@ -779,6 +779,12 @@ const character_settings = {
         "description": "You charge into battle, lending weight to your blow!",
         "type": "bool",
         "default": false
+    },
+    "halfling-lucky": {
+        "title": "Halfling Lucky",
+        "description": "The luck of your people guides your steps",
+        "type": "bool",
+        "default": true
     }
 }
 

--- a/dist/popup.js
+++ b/dist/popup.js
@@ -825,6 +825,12 @@ const character_settings = {
         "description": "You charge into battle, lending weight to your blow!",
         "type": "bool",
         "default": false
+    },
+    "halfling-lucky": {
+        "title": "Halfling Lucky",
+        "description": "The luck of your people guides your steps",
+        "type": "bool",
+        "default": true
     }
 }
 
@@ -1898,6 +1904,10 @@ function populateCharacter(response) {
         }
         if (response["feats"].includes("Charger")) {
             e = createHTMLOption("charger-feat", false, character_settings);
+            options.append(e);
+        }
+        if (response["racial-traits"].includes("Lucky")) {
+            e = createHTMLOption("halfling-lucky", false, character_settings);
             options.append(e);
         }
 

--- a/dist/popup.js
+++ b/dist/popup.js
@@ -1761,6 +1761,15 @@ function populateCharacter(response) {
         options.append(e);
         e = createHTMLOption("custom-critical-limit", false, character_settings);
         options.append(e);
+        if (response["racial-traits"].includes("Lucky")) {
+            e = createHTMLOption("halfling-lucky", false, character_settings);
+            options.append(e);
+        }
+        if (response["class-features"].includes("Brutal Critical") ||
+            response["racial-traits"].includes("Savage Attacks")) {
+            e = createHTMLOption("brutal-critical", false, character_settings);
+            options.append(e);
+        }
         if (Object.keys(response.classes).includes("Rogue")) {
             e = createHTMLOption("rogue-sneak-attack", false, character_settings);
             options.append(e);
@@ -1783,11 +1792,6 @@ function populateCharacter(response) {
         }
         if (response["feats"].includes("Great Weapon Master")) {
             e = createHTMLOption("great-weapon-master", false, character_settings);
-            options.append(e);
-        }
-        if (response["class-features"].includes("Brutal Critical") ||
-            response["racial-traits"].includes("Savage Attacks")) {
-            e = createHTMLOption("brutal-critical", false, character_settings);
             options.append(e);
         }
         if (response["class-features"].includes("Rage")) {
@@ -1904,10 +1908,6 @@ function populateCharacter(response) {
         }
         if (response["feats"].includes("Charger")) {
             e = createHTMLOption("charger-feat", false, character_settings);
-            options.append(e);
-        }
-        if (response["racial-traits"].includes("Lucky")) {
-            e = createHTMLOption("halfling-lucky", false, character_settings);
             options.append(e);
         }
 

--- a/dist/roll20.js
+++ b/dist/roll20.js
@@ -779,6 +779,12 @@ const character_settings = {
         "description": "You charge into battle, lending weight to your blow!",
         "type": "bool",
         "default": false
+    },
+    "halfling-lucky": {
+        "title": "Halfling Lucky",
+        "description": "The luck of your people guides your steps",
+        "type": "bool",
+        "default": true
     }
 }
 

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -611,6 +611,12 @@ const character_settings = {
         "description": "You charge into battle, lending weight to your blow!",
         "type": "bool",
         "default": false
+    },
+    "halfling-lucky": {
+        "title": "Halfling Lucky",
+        "description": "The luck of your people guides your steps",
+        "type": "bool",
+        "default": true
     }
 }
 

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -5,7 +5,7 @@ function sendRollWithCharacter(rollType, fallback, args) {
     if (preview && preview.startsWith("url("))
         args.preview = preview.slice(5, -2);
     // Add halfling luck
-    if (character.hasRacialTrait("Lucky") && ["skill", "ability", "saving-throw", "death-save",
+    if (character.hasRacialTrait("Lucky") && character.getSetting("halfling-lucky", false) && ["skill", "ability", "saving-throw", "death-save",
         "initiative", "attack", "spell-attack"].includes(rollType)) {
         args.d20 = args.d20 || "1d20";
         args.d20 += "ro<=1";

--- a/src/extension/popup.js
+++ b/src/extension/popup.js
@@ -96,6 +96,10 @@ function populateCharacter(response) {
         options.append(e);
         e = createHTMLOption("custom-critical-limit", false, character_settings);
         options.append(e);
+        if (response["racial-traits"].includes("Lucky")) {
+            e = createHTMLOption("halfling-lucky", false, character_settings);
+            options.append(e);
+        }
         if (Object.keys(response.classes).includes("Rogue")) {
             e = createHTMLOption("rogue-sneak-attack", false, character_settings);
             options.append(e);
@@ -118,11 +122,6 @@ function populateCharacter(response) {
         }
         if (response["feats"].includes("Great Weapon Master")) {
             e = createHTMLOption("great-weapon-master", false, character_settings);
-            options.append(e);
-        }
-        if (response["class-features"].includes("Brutal Critical") ||
-            response["racial-traits"].includes("Savage Attacks")) {
-            e = createHTMLOption("brutal-critical", false, character_settings);
             options.append(e);
         }
         if (response["class-features"].includes("Rage")) {

--- a/src/extension/popup.js
+++ b/src/extension/popup.js
@@ -100,6 +100,11 @@ function populateCharacter(response) {
             e = createHTMLOption("halfling-lucky", false, character_settings);
             options.append(e);
         }
+        if (response["class-features"].includes("Brutal Critical") ||
+            response["racial-traits"].includes("Savage Attacks")) {
+            e = createHTMLOption("brutal-critical", false, character_settings);
+            options.append(e);
+        }
         if (Object.keys(response.classes).includes("Rogue")) {
             e = createHTMLOption("rogue-sneak-attack", false, character_settings);
             options.append(e);


### PR DESCRIPTION
Fixes #689 
Adds a toggle for Halfling Lucky
Also moves Half-Orc Savage Attacks (starts at level 1) up on the popup.js menu, to let users see it more clearly near the top.