### PR TITLE
Implement Critical Limit 18 for Blade of Disaster

### DIFF
--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -167,6 +167,8 @@ function buildAttackRoll(character, attack_source, name, description, properties
                     }
                 }
             }
+            if (roll_properties.name === "Blade of Disaster")
+                crit_damages[0] = damagesToCrits(character, ["8d12"])[0];
             if (brutal > 0) {
                 const rule = parseInt(character.getGlobalSetting("critical-homebrew", CriticalRules.PHB));
                 let highest_dice = 0;

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -1212,6 +1212,8 @@ function rollSpell(force_display = false, force_to_hit_only = false, force_damag
         if (character.hasClassFeature("Hexblade’s Curse") &&
             character.getSetting("warlock-hexblade-curse", false))
             critical_limit = 19;
+        if (spell_full_name === "Blade of Disaster")
+            critical_limit = 18;
         const roll_properties = buildAttackRoll(character,
             "spell",
             spell_name,


### PR DESCRIPTION
https://www.dndbeyond.com/spells/blade-of-disaster
Attack scores a critical hit if the number on the d20 is 18 or higher.
Also implements "On a critical hit, the blade deals an extra 8d12 force damage (for a total of 12d12 force damage)."