### PR TITLE
Add integration with SendingStone

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -60,6 +60,10 @@ const SRC_FILES = {
         "src/astral/common.js",
         "src/astral/page-script.js"
     ],
+    sendingstone: [
+        ...ROLL_RENDERER_DEPS,
+        "src/sendingstone/content-script.js"
+    ],
     roll20: [
         ...ROLL_RENDERER_DEPS,
         "src/roll20/renderer.js",

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,8 @@
 		"*://app.roll20.net/editor/",
 		"*://*.dndbeyond.com/*",
 		"*://*.forge-vtt.com/game",
-		"*://*.astraltabletop.com/play/*"
+		"*://*.astraltabletop.com/play/*",
+		"*://*.sendingstone.com/room/*"
 	],
 	"icons": {
 		"16": "images/icons/icon16.png",
@@ -201,6 +202,14 @@
 				"libs/jquery-3.4.1.min.js",
 				"libs/lz-string.min.js",
 				"dist/astral.js"
+			]
+		},
+		{
+			"matches": [
+				"*://*.sendingstone.com/room/*"
+			],
+			"js": [
+				"dist/sendingstone.js"
 			]
 		}
 	]

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -1,6 +1,7 @@
 ROLL20_URL = "*://app.roll20.net/editor/";
 FVTT_URL = "*://*/game";
 ASTRAL_URL =  "*://*.astraltabletop.com/play/*";
+SENDINGSTONE_URL =  "*://*.sendingstone.com/room/*";
 DNDBEYOND_CHARACTER_URL = "*://*.dndbeyond.com/*characters/*";
 DNDBEYOND_MONSTER_URL = "*://*.dndbeyond.com/monsters/*";
 DNDBEYOND_ENCOUNTERS_URL = "*://*.dndbeyond.com/my-encounters";

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -101,6 +101,10 @@ function astralTitle(title) {
     return title.replace(" | Astral TableTop", "");
 }
 
+function sendingStoneTitle(title) {
+    return title.replace("SendingStone", "");
+}
+
 function urlMatches(url, matching) {
     return url.match(matching.replace(/\*/g, "[^]*")) !== null;
 }

--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -108,6 +108,23 @@ function sendMessageToFVTT(request, limit, failure = null) {
     }
 }
 
+function sendMessageToSendingStone(request, limit = null, failure = null) {
+    if (limit) {
+        const vtt = limit.vtt || "sendingstone"
+        if (vtt == "sendingstone") {
+            chrome.tabs.query({ "url": SENDINGSTONE_URL }, (tabs) => {
+                found = filterVTTTab(request, limit, tabs, sendingStoneTitle)
+                if (failure)
+                    failure(!found)
+            })
+        } else {
+            failure(true)
+        }
+    } else {
+        sendMessageTo(SENDINGSTONE_URL, request, failure = failure)
+    }
+}
+
 function sendMessageToBeyond(request) {
     sendMessageTo(DNDBEYOND_CHARACTER_URL, request)
     sendMessageTo(DNDBEYOND_MONSTER_URL, request)
@@ -204,6 +221,7 @@ function onMessage(request, sender, sendResponse) {
             sendMessageToRoll20(request, settings["vtt-tab"], failure = makeFailureCB(trackFailure, "roll20", sendResponse))
             sendMessageToFVTT(request, settings["vtt-tab"], failure = makeFailureCB(trackFailure, "fvtt", sendResponse))
             sendMessageToAstral(request, settings["vtt-tab"], failure = makeFailureCB(trackFailure, "astral", sendResponse))
+            sendMessageToSendingStone(request, settings["vtt-tab"], failure = makeFailureCB(trackFailure, "astral", sendResponse))
         }
         return true
     } else if (request.action == "settings") {
@@ -213,6 +231,7 @@ function onMessage(request, sender, sendResponse) {
         sendMessageToBeyond(request)
         sendMessageToFVTT(request)
         sendMessageToAstral(request)
+        sendMessageToSendingStone(request)
     } else if (request.action == "activate-icon") {
         // popup doesn't have sender.tab so we grab it from the request.
         const tab = request.tab || sender.tab;

--- a/src/sendingstone/content-script.js
+++ b/src/sendingstone/content-script.js
@@ -1,0 +1,3 @@
+console.log("Beyond20: SendingStone module loaded.");
+
+chrome.runtime.onMessage.addListener((data) => window.postMessage(data));


### PR DESCRIPTION
Hi 👋

I'm building a video conferencing meets VTT app called [SendingStone](https://www.sendingstone.com/) and some early users have expressed interest in integrating with your wonderful chrome extension. I'd love to start off with syncing over dice rolls.

This enables that by simply forwarding over all messages from D&D Beyond with `postMessage`. SendingStone will then parse the message body on its side and do what it needs.

https://user-images.githubusercontent.com/555859/111938448-9635d980-8a8f-11eb-80f4-0b11864eb24b.mov

Thanks for your consideration!