### PR TITLE
Parsing functions bugfixes

### DIFF
--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -1174,7 +1174,7 @@ function handleSpecialHealingSpells(spell_name, damages=[], damage_types=[], {sp
     if (character.hasClass("Cleric")) {
         if (character.hasClassFeature("Supreme Healing")) {
             for (let i = 0; i < damages.length; i++) {
-                if (damage_types[i] !== "Healing") continue;
+                if (!damage_types[i].includes("Healing")) continue;
                 damages[i] = damages[i].replace(/([0-9]*)d([0-9]+)?/, (match, dice, faces) => {
                     return String(parseInt(dice || 1) * parseInt(faces));
                 });

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -1072,6 +1072,7 @@ function handleSpecialSpells(spell_name, damages=[], damage_types=[], {spell_sou
         }
     }
     
+    // NOTE: Below this line are things that work on ALL damages, they should stay there
     // Artificer
     if (character.hasClass("Artificer")) {
         if (character.hasClassFeature("Alchemical Savant") &&
@@ -1088,7 +1089,7 @@ function handleSpecialSpells(spell_name, damages=[], damage_types=[], {spell_sou
             }
         }
     }
-
+    
     // Check for Draconic Sorcerer's Elemental Affinity;
     let elementalAffinity = null;
     for (let feature of character._class_features) {
@@ -1098,19 +1099,21 @@ function handleSpecialSpells(spell_name, damages=[], damage_types=[], {spell_sou
             break;
         }
     }
-    const elementalAdepts = [];
-    for (let feature of character._feats) {
-        const match = feature.match("Elemental Adept \\((.*)\\)");
-        if (match) {
-            elementalAdepts.push(match[1]);
-        }
-    }
     if (elementalAffinity && damage_types.includes(elementalAffinity)) {
         for (let ability of character._abilities) {
             if (ability[1] == "CHA" && ability[3] != "" && ability[3] != "0") {
                 damages.push(ability[3]);
                 damage_types.push(elementalAffinity + " (Elemental Affinity)");
             }
+        }
+    }
+    
+    // Check for Elemental Adept Feats
+    const elementalAdepts = [];
+    for (let feature of character._feats) {
+        const match = feature.match("Elemental Adept \\((.*)\\)");
+        if (match) {
+            elementalAdepts.push(match[1]);
         }
     }
     for (let elementalAdept of elementalAdepts) {

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -1230,6 +1230,12 @@ function rollSpell(force_display = false, force_to_hit_only = false, force_damag
             damage_types.push(dmgtype);
         }
 
+        if (damages.length > 0) {
+            to_hit = handleSpecialGeneralAttacks(damages, damage_types, properties, settings_to_change, {to_hit, spell_name, spell_level: level});
+        
+            handleSpecialSpells(spell_name, damages, damage_types, {spell_level: level, spell_source, castas});
+        }
+
         // We can then add healing types
         for (let modifier of healing_modifiers.toArray()) {
             let dmg = $(modifier).find(".ct-spell-caster__modifier-amount").text();
@@ -1257,11 +1263,6 @@ function rollSpell(force_display = false, force_to_hit_only = false, force_damag
         }
         if (healing_modifiers.length > 0) {
             handleSpecialHealingSpells(spell_name, damages, damage_types, {spell_level: level, spell_source, castas});
-        }
-        else {
-            to_hit = handleSpecialGeneralAttacks(damages, damage_types, properties, settings_to_change, {to_hit, spell_name, spell_level: level});
-        
-            handleSpecialSpells(spell_name, damages, damage_types, {spell_level: level, spell_source, castas});
         }
 
         addCustomDamages(damages, damage_types);

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -326,7 +326,8 @@ function handleSpecialMeleeAttacks(damages=[], damage_types=[], properties, sett
 
     // Feats
     // Great Weapon Master Feat
-    if (character.getSetting("great-weapon-master", false) &&
+    if (to_hit !== null && 
+        character.getSetting("great-weapon-master", false) &&
         character.hasFeat("Great Weapon Master") &&
         (properties["Properties"] && properties["Properties"].includes("Heavy") ||
         action_name.includes("Polearm Master - Bonus Attack")) &&
@@ -351,7 +352,8 @@ function handleSpecialMeleeAttacks(damages=[], damage_types=[], properties, sett
 function handleSpecialRangedAttacks(damages=[], damage_types=[], properties, settings_to_change={}, {to_hit, action_name=""}={}) {
     // Feats
     // Sharpshooter Feat
-    if (character.getSetting("sharpshooter", false) &&
+    if (to_hit !== null && 
+        character.getSetting("sharpshooter", false) &&
         character.hasFeat("Sharpshooter") &&
         properties["Proficient"] == "Yes") {
         to_hit += " - 5";
@@ -514,7 +516,8 @@ function handleSpecialWeaponAttacks(damages=[], damage_types=[], properties, set
 
     if (character.hasClass("Paladin")) {
         // Paladin: Sacred Weapon
-        if (character.getSetting("paladin-sacred-weapon", false)) {
+        if (to_hit !== null && 
+            character.getSetting("paladin-sacred-weapon", false)) {
             const charisma_attack_mod =  Math.max(character.getAbility("CHA").mod, 1);
             to_hit += `+ ${charisma_attack_mod}`;
         }
@@ -1227,10 +1230,6 @@ function rollSpell(force_display = false, force_to_hit_only = false, force_damag
             damage_types.push(dmgtype);
         }
 
-        to_hit = handleSpecialGeneralAttacks(damages, damage_types, properties, settings_to_change, {to_hit, spell_name, spell_level: level});
-        
-        handleSpecialSpells(spell_name, damages, damage_types, {spell_level: level, spell_source, castas});
-
         // We can then add healing types
         for (let modifier of healing_modifiers.toArray()) {
             let dmg = $(modifier).find(".ct-spell-caster__modifier-amount").text();
@@ -1258,6 +1257,11 @@ function rollSpell(force_display = false, force_to_hit_only = false, force_damag
         }
         if (healing_modifiers.length > 0) {
             handleSpecialHealingSpells(spell_name, damages, damage_types, {spell_level: level, spell_source, castas});
+        }
+        else {
+            to_hit = handleSpecialGeneralAttacks(damages, damage_types, properties, settings_to_change, {to_hit, spell_name, spell_level: level});
+        
+            handleSpecialSpells(spell_name, damages, damage_types, {spell_level: level, spell_source, castas});
         }
 
         addCustomDamages(damages, damage_types);


### PR DESCRIPTION
`handleSpecialGeneralAttacks` now checks, where appropriate for `to_hit != null`
Removed redundant checks in `handleSpecialMeleeAttacks` and `handleSpecialRangedAttacks` for `to_hit != null`, as that's handled in the function calling logic
Re-ordered some parts of `handleSpecialSpells` and `handleSpecialHealingSpells` so that features which work on ALL damage types now have their chance to do so.