### PR TITLE
Fix for inconsistent capitalization of NPC attacks

### DIFF
--- a/src/dndbeyond/base/monster.js
+++ b/src/dndbeyond/base/monster.js
@@ -288,7 +288,7 @@ class Monster extends CharacterBase {
     }
 
     parseAttackInfo(description) {
-        const m = description.match(/(Melee|Ranged)(?: Weapon| Spell)? Attack:.*?(\+[0-9]+) to hit.*?, (?:reach |ranged? |Gibletish )?(.*?)(?:,.*?)?\./)
+        const m = description.match(/(Melee|Ranged)(?: Weapon| Spell)? Attack:.*?(\+[0-9]+) to hit.*?, (?:reach |ranged? |Gibletish )?(.*?)(?:,.*?)?\./i)
         if (m)
             return m.slice(1, 4);
         else


### PR DESCRIPTION
Fix for "weapon" vs "Weapon" and "attack" vs "Attack"

Example NPC: https://www.dndbeyond.com/monsters/screaming-devilkin