### PR TITLE
Savage / Brutal Critical Fix

### DIFF
--- a/src/common/roll_renderer.js
+++ b/src/common/roll_renderer.js
@@ -499,6 +499,8 @@ class Beyond20RollRenderer {
             const damage_types = request["damage-types"];
             const critical_damages = request["critical-damages"];
             const critical_damage_types = request["critical-damage-types"];
+            const brutal_critical_and_savage_attack_damages = request["brutal-and-savage-damages"];
+            const brutal_critical_and_savage_attack_damage_types = request["brutal-and-savage-damage-types"];
             if (request.name === "Chromatic Orb") {
                 const damage_choices = {}
                 const critical_damage_choices = {}
@@ -609,6 +611,11 @@ class Beyond20RollRenderer {
             }
             if (is_critical) {
                 const critical_damage_rolls = []
+                if (request["brutal-and-savage-damage-types"].length > 0){
+                    const WeaponDiceType = await this.queryDamageType(request.name, brutal_critical_and_savage_attack_damage_types);
+                    critical_damages.push(brutal_critical_and_savage_attack_damages[WeaponDiceType]);
+                    critical_damage_types.push(brutal_critical_and_savage_attack_damage_types[WeaponDiceType]);
+                }
                 for (let i = 0; i < (critical_damages.length); i++) {
                     const roll = this._roller.roll(critical_damages[i]);
                     critical_damage_rolls.push(roll);

--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -173,7 +173,7 @@ function buildAttackRoll(character, attack_source, name, description, properties
                 crit_damages[0] = damagesToCrits(character, ["3d4"])[0];
             if (brutal > 0) {
                 const rule = parseInt(character.getGlobalSetting("critical-homebrew", CriticalRules.PHB));
-                let highest_dice = 0;
+                let weapon_dice = 0;
                 let homebrew_max_damage = 0;
                 if (rule == CriticalRules.HOMEBREW_MAX) {
                     let highest_damage = 0;
@@ -188,15 +188,15 @@ function buildAttackRoll(character, attack_source, name, description, properties
                         const match = dmg.match(/[0-9]*d([0-9]+)/);
                         if (match) {
                             const sides = parseInt(match[1]);
-                            if (sides > highest_dice)
-                                highest_dice = sides;
+                            if (weapon_dice == 0)
+                                weapon_dice = sides;
                         }
                     }
                 }
                 const isBrutal = character.hasClassFeature("Brutal Critical");
                 const isSavage = character.hasRacialTrait("Savage Attacks");
-                if (highest_dice != 0) {
-                    let brutal_dmg = `${brutal}d${highest_dice}`
+                if (weapon_dice != 0) {
+                    let brutal_dmg = `${brutal}d${weapon_dice}`
                     // Apply great weapon fighting to brutal damage dice
                     if ((character.hasClassFeature("Great Weapon Fighting", true) || character.hasFeat("Great Weapon Fighting", true)) &&
                         properties["Attack Type"] == "Melee" &&

--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -199,18 +199,21 @@ function buildAttackRoll(character, attack_source, name, description, properties
                 const isBrutal = character.hasClassFeature("Brutal Critical");
                 const isSavage = character.hasRacialTrait("Savage Attacks");
                 if (Array.isArray(weapon_dice) && weapon_dice.length) {
-                    let brutal_dmg = `${brutal}d${weapon_dice}`
-                    // Apply great weapon fighting to brutal damage dice
-                    if ((character.hasClassFeature("Great Weapon Fighting", true) || character.hasFeat("Great Weapon Fighting", true)) &&
-                        properties["Attack Type"] == "Melee" &&
-                        (properties["Properties"].includes("Versatile") || properties["Properties"].includes("Two-Handed"))) {
-                        brutal_dmg += "ro<=2"
+                    for(let i = 0; i < WeaponDamageLength; i++){
+                        let brutal_dmg = `${brutal}d${weapon_dice[i]}`
+                        // Apply great weapon fighting to brutal damage dice
+                        if ((character.hasClassFeature("Great Weapon Fighting", true) || character.hasFeat("Great Weapon Fighting", true)) &&
+                            properties["Attack Type"] == "Melee" &&
+                            (properties["Properties"].includes("Versatile") || properties["Properties"].includes("Two-Handed"))) {
+                            brutal_dmg += "ro<=2"
+                        }
+                        crit_damages.push(brutal_dmg);
+                        crit_damage_types.push(isBrutal && isSavage ? "Savage Attacks & Brutal " + damage_types[i] : (isBrutal ? "Brutal " + damage_types[i] : "Savage Attacks " + damage_types[i]));
                     }
-                    crit_damages.push(brutal_dmg);
-                    crit_damage_types.push(isBrutal && isSavage ? "Savage Attacks & Brutal" : (isBrutal ? "Brutal" : "Savage Attacks"));
+
                 } else if (rule == CriticalRules.HOMEBREW_MAX) {
                     crit_damages.push(`${homebrew_max_damage}`);
-                    crit_damage_types.push(isBrutal && isSavage ? "Savage Attacks & Brutal" : (isBrutal ? "Brutal" : "Savage Attacks"));
+                    crit_damage_types.push(isBrutal && isSavage ? "Savage Attacks & Brutal " : (isBrutal ? "Brutal " : "Savage Attacks "));
                 }
 
             }

--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -99,7 +99,7 @@ function damagesToCrits(character, damages) {
     return crits;
 }
 
-function buildAttackRoll(character, attack_source, name, description, properties,
+function buildAttackRoll(character, attack_source, name, description, properties, WeaponDamageLength,
                          damages = [], damage_types = [], to_hit = null,
                          brutal = 0, force_to_hit_only = false, force_damages_only = false) {
     const roll_properties = {
@@ -173,7 +173,7 @@ function buildAttackRoll(character, attack_source, name, description, properties
                 crit_damages[0] = damagesToCrits(character, ["3d4"])[0];
             if (brutal > 0) {
                 const rule = parseInt(character.getGlobalSetting("critical-homebrew", CriticalRules.PHB));
-                let weapon_dice = 0;
+                let weapon_dice = [];
                 let homebrew_max_damage = 0;
                 if (rule == CriticalRules.HOMEBREW_MAX) {
                     let highest_damage = 0;
@@ -184,18 +184,21 @@ function buildAttackRoll(character, attack_source, name, description, properties
                     }
                     homebrew_max_damage = brutal * highest_damage;
                 } else {
-                    for (let dmg of crit_damages) {
-                        const match = dmg.match(/[0-9]*d([0-9]+)/);
-                        if (match) {
-                            const sides = parseInt(match[1]);
-                            if (weapon_dice == 0)
-                                weapon_dice = sides;
-                        }
+                    let WeaponDamageInc = 0;
+                    for (let dmg of crit_damages){
+                        if(WeaponDamageInc < WeaponDamageLength){
+                            const match = dmg.match(/[0-9]*d([0-9]+)/);
+                            if(match){
+                                const sides = parseInt(match[1]);
+                                weapon_dice.push(sides);
+                            }
+                            WeaponDamageInc++
+                        }      
                     }
                 }
                 const isBrutal = character.hasClassFeature("Brutal Critical");
                 const isSavage = character.hasRacialTrait("Savage Attacks");
-                if (weapon_dice != 0) {
+                if (Array.isArray(weapon_dice) && weapon_dice.length) {
                     let brutal_dmg = `${brutal}d${weapon_dice}`
                     // Apply great weapon fighting to brutal damage dice
                     if ((character.hasClassFeature("Great Weapon Fighting", true) || character.hasFeat("Great Weapon Fighting", true)) &&

--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -148,6 +148,8 @@ function buildAttackRoll(character, attack_source, name, description, properties
             const crits = damagesToCrits(character, damages, damage_types);
             const crit_damages = [];
             const crit_damage_types = [];
+            const brutal_and_savage_damages = [];
+            const brutal_and_savage_damage_types = [];
             for (let [i, dmg] of crits.entries()) {
                 if (dmg != "") {
                     crit_damages.push(dmg);
@@ -207,18 +209,20 @@ function buildAttackRoll(character, attack_source, name, description, properties
                             (properties["Properties"].includes("Versatile") || properties["Properties"].includes("Two-Handed"))) {
                             brutal_dmg += "ro<=2"
                         }
-                        crit_damages.push(brutal_dmg);
-                        crit_damage_types.push(isBrutal && isSavage ? "Savage Attacks & Brutal " + damage_types[i] : (isBrutal ? "Brutal " + damage_types[i] : "Savage Attacks " + damage_types[i]));
+                        brutal_and_savage_damages.push(brutal_dmg);
+                        brutal_and_savage_damage_types.push(isBrutal && isSavage ? "Savage Attacks & Brutal " + damage_types[i] : (isBrutal ? "Brutal " + damage_types[i] : "Savage Attacks " + damage_types[i]));
                     }
 
                 } else if (rule == CriticalRules.HOMEBREW_MAX) {
-                    crit_damages.push(`${homebrew_max_damage}`);
-                    crit_damage_types.push(isBrutal && isSavage ? "Savage Attacks & Brutal " : (isBrutal ? "Brutal " : "Savage Attacks "));
+                    brutal_and_savage_damages.push(`${homebrew_max_damage}`);
+                    brutal_and_savage_damage_types.push(isBrutal && isSavage ? "Savage Attacks & Brutal " : (isBrutal ? "Brutal " : "Savage Attacks "));
                 }
 
             }
             roll_properties["critical-damages"] = crit_damages;
             roll_properties["critical-damage-types"] = crit_damage_types;
+            roll_properties["brutal-and-savage-damages"] = brutal_and_savage_damages;
+            roll_properties["brutal-and-savage-damage-types"] = brutal_and_savage_damage_types;
         }
     }
 

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -873,9 +873,9 @@ function rollAction(paneClass, force_to_hit_only = false, force_damages_only = f
     if (action_name == "Superiority Dice" || action_parent == "Maneuvers") {
         const fighter_level = character.getClassLevel("Fighter");
         let superiority_die = fighter_level < 10 ? "1d8" : (fighter_level < 18 ? "1d10" : "1d12");
-        if (action_name === "Parry")
+        if (action_name === "Maneuvers: Parry")
             superiority_die += " + " + character.getAbility("DEX").mod;
-        else if (action_name === "Rally")
+        else if (action_name === "Maneuvers: Rally")
             superiority_die += " + " + character.getAbility("CHA").mod;
         return sendRollWithCharacter("custom", superiority_die, {
             "name": action_name,

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -919,12 +919,12 @@ function rollAction(paneClass, force_to_hit_only = false, force_damages_only = f
         || action_name.includes("Psychic Blade") || action_name.includes("Bite") || action_name.includes("Claws") || action_name.includes("Tail")
         || action_name.includes("Ram") || action_name.includes("Horns") || action_name.includes("Hooves") || action_name.includes("Talons") 
         || action_name.includes("Thunder Gauntlets") || action_name.includes("Unarmed Fighting") || action_name.includes("Arms of the Astral Self");
+
+        const WeaponDamageLength = damages.length;
         
         const isRangedAttack = action_name.includes("Lightning Launcher");
 
         to_hit = handleSpecialGeneralAttacks(damages, damage_types, properties, settings_to_change, {to_hit, action_name});
-
-        const WeaponDamageLength = damages.length;
 
         if (isMeleeAttack || isRangedAttack) {
             to_hit = handleSpecialWeaponAttacks(damages, damage_types, properties, settings_to_change, {to_hit, action_name});

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -702,6 +702,9 @@ function rollItem(force_display = false, force_to_hit_only = false, force_damage
                 break;
             }
         }
+
+        const WeaponDamageLength = damages.length;
+
         // If clicking on a spell group within a item (Green flame blade, Booming blade), then add the additional damages from that spell
         if (spell_group) {
             const group_name = $(spell_group).find(".ct-item-detail__spell-damage-group-name").text();
@@ -768,6 +771,7 @@ function rollItem(force_display = false, force_to_hit_only = false, force_damage
             item_name,
             description,
             properties,
+            WeaponDamageLength,
             damages,
             damage_types,
             to_hit,
@@ -920,6 +924,8 @@ function rollAction(paneClass, force_to_hit_only = false, force_damages_only = f
 
         to_hit = handleSpecialGeneralAttacks(damages, damage_types, properties, settings_to_change, {to_hit, action_name});
 
+        const WeaponDamageLength = damages.length;
+
         if (isMeleeAttack || isRangedAttack) {
             to_hit = handleSpecialWeaponAttacks(damages, damage_types, properties, settings_to_change, {to_hit, action_name});
             if (character.hasAction("Channel Divinity: Legendary Strike") &&
@@ -963,6 +969,7 @@ function rollAction(paneClass, force_to_hit_only = false, force_damages_only = f
             action_name,
             description,
             properties,
+            WeaponDamageLength,
             damages,
             damage_types,
             to_hit,
@@ -1230,6 +1237,8 @@ function rollSpell(force_display = false, force_to_hit_only = false, force_damag
             damage_types.push(dmgtype);
         }
 
+        const WeaponDamageLength = damages.length;
+        
         if (damages.length > 0) {
             to_hit = handleSpecialGeneralAttacks(damages, damage_types, properties, settings_to_change, {to_hit, spell_name, spell_level: level});
         
@@ -1278,6 +1287,7 @@ function rollSpell(force_display = false, force_to_hit_only = false, force_damag
             spell_name,
             description,
             properties,
+            WeaponDamageLength,
             damages,
             damage_types,
             to_hit,


### PR DESCRIPTION
Weapon dice are the first ones passed into Roll20 and Foundry so this gets that first dice size and uses it for the calculation.

Tested it with a 14 Barbarian / Champion Fighter 4 / Rogue 2 Build with Great Weapon Fighting Style.

The first critical damage from a dagger was:
- 1d4(2)+5=7 for the dagger damage
- 1d4(3)=3 for the dagger crit damage
- 1d6(3)=3 for the sneak attack damage
- 1d6(4)=4 for the sneak attack crit damage
- 2d4(1+2)=3 for the level 14 brutal critical damage from the dagger

It only rolls 2 extra d4s for the brutal critical like it should

The second critical damage from a greatsword was:
- 2d6(1(dropped and rerolled as 5)+2(dropped and rerolled as 2))+5=12 for the greatsword damage
- 2d6(2(dropped and rerolled as 2)+6) = 8 for the greatsword crit damage
- 2d6(2(dropped and rerolled as 5)+1(dropped and rerolled as 3)) = 8 for the level 14 brutal critical damage from the greatsword

It only roll 2 extra d6s for the brutal critical like it should

![Brutal Crticial Savage Attacks Fix](https://user-images.githubusercontent.com/21990225/115455681-42cebc80-a1f0-11eb-87c9-24272e4451e1.png)

I think this should fix #305 by making brutal critical just roll the damage dice for the weapon. Wasn't as easy to fix as the maneuvers, especially when I'm still learning javascript.