### PR TITLE
Add handling for Shadow Blade custom action

### DIFF
--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -567,7 +567,7 @@ function handleSpecialWeaponAttacks(damages=[], damage_types=[], properties, set
         if (character.getSetting("rogue-sneak-attack", false) &&
             (properties["Attack Type"] == "Ranged" ||
             (properties["Properties"] && properties["Properties"].includes("Finesse")) ||
-            (action_name && action_name.includes("Psychic Blade")))) {
+            (action_name && (action_name.includes("Psychic Blade") || action_name.includes("Shadow Blade"))))) {
             const sneak_attack = Math.ceil(character._classes["Rogue"] / 2) + "d6";
             damages.push(sneak_attack);
             damage_types.push("Sneak Attack");
@@ -914,7 +914,8 @@ function rollAction(paneClass, force_to_hit_only = false, force_damages_only = f
         const isMeleeAttack = action_name.includes("Polearm Master - Bonus Attack") || action_name.includes("Unarmed Strike") || action_name.includes("Tavern Brawler Strike")
         || action_name.includes("Psychic Blade") || action_name.includes("Bite") || action_name.includes("Claws") || action_name.includes("Tail")
         || action_name.includes("Ram") || action_name.includes("Horns") || action_name.includes("Hooves") || action_name.includes("Talons") 
-        || action_name.includes("Thunder Gauntlets") || action_name.includes("Unarmed Fighting") || action_name.includes("Arms of the Astral Self");
+        || action_name.includes("Thunder Gauntlets") || action_name.includes("Unarmed Fighting") || action_name.includes("Arms of the Astral Self")
+        || action_name.includes("Shadow Blade");
         
         const isRangedAttack = action_name.includes("Lightning Launcher");
 


### PR DESCRIPTION
Fixes #781
The spell itself is obtuse, https://www.dndbeyond.com/spells/shadow-blade, containing no "To Hit:" or anything relevant to the attack.

Will require DnDBeyond users of the spell to create a Custom Action to cover, but works well.

![image](https://user-images.githubusercontent.com/7988297/115891793-b7ce0c00-a413-11eb-9cc0-2a8c9fa3f5c3.png)

![image](https://user-images.githubusercontent.com/7988297/115891817-c0bedd80-a413-11eb-81ed-f6bba849f7c1.png)
