### PR TITLE
Adjust padding to prevent jumping text in extension options on Firefox browsers

### DIFF
--- a/options.css
+++ b/options.css
@@ -22,7 +22,7 @@
 	.list-group > .list-group-item > .list-content {
 		display: block;
 		padding: 10px 15px;
-		padding-right: 130px;
+		padding-right: 150px;
 		position: relative;
 	}
 	.list-group > .list-group-item > .list-content h4 {


### PR DESCRIPTION
Fixes #760 

Text no longer jumps around on Firefox 88.0.1 or Firefox Dev 89.0b10. Nothing changed as far as I can see on Chrome 90.0.4430.212, aside from the expected shifting of option description text. Tested on all browsers using a 1920x1080 monitor. 

There is a little bit of horizontally-scrollable area, but I am not sure if that existed prior to this issue or not.