### PR TITLE
Remove TempHPMax Syncing to FoundryVTT

### DIFF
--- a/src/fvtt/page-script.js
+++ b/src/fvtt/page-script.js
@@ -413,7 +413,7 @@ function updateHP(name, current, total, temp) {
 
     const tokens = canvas.tokens.placeables.filter((t) => t.owner && t.name.toLowerCase().trim() == name);
 
-    const dnd5e_data = { "data.attributes.hp.value": current, "data.attributes.hp.temp": temp, "data.attributes.hp.max": total, "data.attributes.hp.tempmax": temp }
+    const dnd5e_data = { "data.attributes.hp.value": current, "data.attributes.hp.temp": temp, "data.attributes.hp.max": total }
     const sws_data = { "data.health.value": current + temp, "data.health.max": total }
     if (tokens.length == 0) {
         const actor = game.actors.entities.find((a) => a.owner && a.name.toLowerCase() == name);


### PR DESCRIPTION
This is due to "tempmax" being poorly documented in FoundryVTT.

Prior belief: "tempmax" = "The Maximum Temporary HP for a character"
Corrected: "tempmax" = "A temporary addition to the Maximum HP for a character"

Evidence:
https://gitlab.com/foundrynet/dnd5e/-/issues/828
Aid (inside FoundryVTT, with no DnDBeyond/Beyond20 help) should be added to TempMax
(Beyond20 already syncs a higher max HP via the "HP Max", so we shouldn't touch this)
![image](https://user-images.githubusercontent.com/7988297/126088257-755a5c21-3c6f-482d-96fd-6bc6a8ca0cf6.png)

Visual Appearance of the bars:
https://gitlab.com/foundrynet/dnd5e/-/issues/306
We want it to look like the second character in the screenshot, Temp HP overlaying the Current HP, not the 5th character in the screenshot.