### PR TITLE
Fix bug in Custom Skills that Query for Ability

### DIFF
--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -23,7 +23,7 @@ async function rollSkillCheck(paneClass) {
     
     if (ability == "--" && character._abilities.length > 0) {
         let prof = "";
-        let prof_val = "";
+        let prof_val = 0;
         if (proficiency == "Proficiency") {
             prof = "proficiency";
             prof_val = parseInt(character._proficiency);


### PR DESCRIPTION
`prof_val` was cast as a String, causing the `mod += prof_val;` later in the code to concatenate a string rather than add Integers