### PR TITLE
Fix Digital Dice Force Crits Bug

### DIFF
--- a/src/roll20/content-script.js
+++ b/src/roll20/content-script.js
@@ -564,6 +564,9 @@ function rollSpellAttack(request, custom_roll_dice) {
         template_type = "dmg";
         dmg_props["charname"] = request.character.name;
         dmg_props["rname"] = request.name;
+        if (request.rollCritical) {
+            dmg_props["crit"] = 1;
+        }
     }
     if (request.damages && request.damages.length > 0 &&
         request["to-hit"] !== undefined && !request.rollDamage) {


### PR DESCRIPTION
Fix a bug with:

1. Digital Dice: Enabled (DnDBeyond)
2. Use Digital Dice: Disabled (Beyond20 settings)
3. Force Crits: Enabled
4. Clicking the Digital Dice Damage button
![image](https://user-images.githubusercontent.com/7988297/133534258-05b2bc72-9372-4e71-be88-9d9463d9ad72.png)

Previously would fail to actually force the crit, but only for Spell Attacks.
