### PR TITLE
Adds support for Making Human - Artisan's Intuition

### DIFF
--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -164,7 +164,7 @@ async function rollSkillCheck(paneClass) {
     }
 
     // Mark of Making Human - Artisan's Intuition
-    if (character.hasRacialTrait("Artisan’s Intuition") && skill_name == "Arcana") {
+    if (character.hasRacialTrait("Artisan’s Intuition") && (skill_name == "Arcana" || skill_name.match(/ (Tools|Supplies|Utensils|Kit|Set|Instrument)$/))) {
         roll_properties.modifier += "+1d4";
     }
 


### PR DESCRIPTION
Custom skills are a great way to represent tool proficiencies. This PR adds support for the Mark of Making Human - Artisan's Intuition for any tool proficiency. 