### PR TITLE
Additional fixes for Critical Processing

### DIFF
--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -205,58 +205,61 @@ async function buildAttackRoll(character, attack_source, name, description, prop
                 crit_damage_types.push(damage_types[i]);
             }
         }
-        if (character.hasFeat("Piercer")) {
-            for (let i = 0; i < damage_types.length; i++) {
-                if (damage_types[i].includes("Piercing")){
-                    const piercer_damage = damagesToCrits(character, [damages[i]]);
-                    if (piercer_damage.length > 0 && piercer_damage[0] != "") {    
-                        piercer_damage[0] = piercer_damage[0].replace(/([0-9]+)d([0-9]+)/, '1d$2');
-                        crit_damages.push(piercer_damage[0]);
-                        crit_damage_types.push("Piercer Feat");
-                        break;
+        if (to_hit) {
+            if (character.hasFeat("Piercer")) {
+                for (let i = 0; i < damage_types.length; i++) {
+                    if (damage_types[i].includes("Piercing")){
+                        const piercer_damage = damagesToCrits(character, [damages[i]]);
+                        if (piercer_damage.length > 0 && piercer_damage[0] != "") {    
+                            piercer_damage[0] = piercer_damage[0].replace(/([0-9]+)d([0-9]+)/, '1d$2');
+                            crit_damages.push(piercer_damage[0]);
+                            crit_damage_types.push("Piercer Feat");
+                            break;
+                        }
                     }
                 }
             }
-        }
-        if (roll_properties.name === "Blade of Disaster")
-            crit_damages[0] = damagesToCrits(character, ["8d12"])[0];
-        if (roll_properties.name === "Jim’s Magic Missile")
-            crit_damages[0] = damagesToCrits(character, ["3d4"])[0];
-        if (brutal > 0) {
-            const rule = parseInt(character.getGlobalSetting("critical-homebrew", CriticalRules.PHB));
-            let highest_dice = 0;
-            let weapon_damage_counter = 0;
-            for (let dmg of damages) {
-                if (weapon_damage_length && weapon_damage_counter >= weapon_damage_length) break;
-                const match = dmg.match(/[0-9]*d([0-9]+)/);
-                if (match) {
-                    const sides = parseInt(match[1]);
-                    if (sides > highest_dice)
-                        highest_dice = sides;
-                }
-                weapon_damage_counter++;
-            }
-            const isBrutal = character.hasClassFeature("Brutal Critical");
-            const isSavage = character.hasRacialTrait("Savage Attacks");
-            if (highest_dice != 0) {
-                let brutal_dmg = `${brutal}d${highest_dice}`
-                if (rule == CriticalRules.HOMEBREW_MAX) {
-                    crit_damages.push(damagesToCrits(character, [brutal_dmg])[0]);
-                } else {
-                    // Apply great weapon fighting to brutal damage dice
-                    if ((character.hasClassFeature("Great Weapon Fighting", true) || character.hasFeat("Great Weapon Fighting", true)) &&
-                        properties["Attack Type"] == "Melee" &&
-                        ((properties["Properties"].includes("Versatile") && character.getSetting("versatile-choice") != "one") || properties["Properties"].includes("Two-Handed"))) {
-                        brutal_dmg += "ro<=2"
+            if (roll_properties.name === "Blade of Disaster")
+                crit_damages[0] = damagesToCrits(character, ["8d12"])[0];
+            if (roll_properties.name === "Jim’s Magic Missile")
+                crit_damages[0] = damagesToCrits(character, ["3d4"])[0];
+            if (brutal > 0) {
+                const rule = parseInt(character.getGlobalSetting("critical-homebrew", CriticalRules.PHB));
+                let highest_dice = 0;
+                let weapon_damage_counter = 0;
+                for (let dmg of damages) {
+                    if (weapon_damage_length && weapon_damage_counter >= weapon_damage_length) break;
+                    const match = dmg.match(/[0-9]*d([0-9]+)/);
+                    if (match) {
+                        const sides = parseInt(match[1]);
+                        if (sides > highest_dice)
+                            highest_dice = sides;
                     }
-                    crit_damages.push(brutal_dmg);
+                    weapon_damage_counter++;
                 }
-                crit_damage_types.push(isBrutal && isSavage ? "Savage Attacks & Brutal" : (isBrutal ? "Brutal" : "Savage Attacks"));
-            }
+                const isBrutal = character.hasClassFeature("Brutal Critical");
+                const isSavage = character.hasRacialTrait("Savage Attacks");
+                if (highest_dice != 0) {
+                    let brutal_dmg = `${brutal}d${highest_dice}`
+                    if (rule == CriticalRules.HOMEBREW_MAX) {
+                        crit_damages.push(damagesToCrits(character, [brutal_dmg])[0]);
+                    } else {
+                        // Apply great weapon fighting to brutal damage dice
+                        if ((character.hasClassFeature("Great Weapon Fighting", true) || character.hasFeat("Great Weapon Fighting", true)) &&
+                            properties["Attack Type"] == "Melee" &&
+                            ((properties["Properties"].includes("Versatile") && character.getSetting("versatile-choice") != "one") || properties["Properties"].includes("Two-Handed"))) {
+                            brutal_dmg += "ro<=2"
+                        }
+                        crit_damages.push(brutal_dmg);
+                    }
+                    crit_damage_types.push(isBrutal && isSavage ? "Savage Attacks & Brutal" : (isBrutal ? "Brutal" : "Savage Attacks"));
+                }
 
+            }
         }
         roll_properties["critical-damages"] = crit_damages;
         roll_properties["critical-damage-types"] = crit_damage_types;
+        
     }
 
     return roll_properties;

--- a/src/roll20/content-script.js
+++ b/src/roll20/content-script.js
@@ -366,7 +366,7 @@ function rollAttack(request, custom_roll_dice = "") {
         dmg_props["saveattr"] = request["save-ability"];
         dmg_props["savedc"] = request["save-dc"];
     }
-    if (request.rollDamage && !request.rollAttack) {
+    if (request.rollDamage && (!request.rollAttack || request["to-hit"] == undefined)) {
         template_type = "dmg";
         dmg_props["charname"] = request.character.name;
         dmg_props["rname"] = request.name;
@@ -513,7 +513,7 @@ function rollSpellAttack(request, custom_roll_dice) {
 		properties["desc"] = properties["desc"] ? properties["desc"] + "\n\n" : "";
 		properties["desc"] += `Description: ${request.description}`;
     }
-    if (request.rollDamage && !request.rollAttack) {
+    if (request.rollDamage && (!request.rollAttack || request["to-hit"] == undefined)) {
         template_type = "dmg";
         dmg_props["charname"] = request.character.name;
         dmg_props["rname"] = request.name;


### PR DESCRIPTION
Moves some things back into a `to_hit` check, which should actually only occur with a `to_hit`.

Fixes for Roll20 to allow the following combo:
DnDBeyond Digital Dice enabled on Character Sheet
"Use DnDBeyond Digital Dice" disabled in Beyond20 settings

To roll things like this properly:
![image](https://user-images.githubusercontent.com/7988297/151997055-1dbc6115-6af7-47cb-bc68-a83f3d298cd5.png)
