### PR TITLE
fix missing mod in rendered roll

### DIFF
--- a/src/roll20/content-script.js
+++ b/src/roll20/content-script.js
@@ -741,17 +741,17 @@ async function handleOGLRenderedRoll(request) {
         atk_props["dmg2"] = convertRollToText(request.whisper, request.damage_rolls[1][1]);
         atk_props["dmg2type"] = request.damage_rolls[1][0];
     }
-    if (originalRequest.rollAttack && originalRequest["to-hit"] !== undefined) {
         // let d20_roll = originalRequest.d20 || "1d20";
-        // if (originalRequest["critical-limit"])
-        //     d20_roll += "cs>" + originalRequest["critical-limit"];
-        let custom_roll_dice = "";
-        if (originalRequest.character && originalRequest.character.type === "Character")
-            custom_roll_dice = originalRequest.character.settings["custom-roll-dice"] || "";
-        atk_props["mod"] = originalRequest["to-hit"] + "+" + custom_roll_dice;
-        // properties["r1"] = genRoll(d20_roll, { "": originalRequest["to-hit"], "CUSTOM": custom_roll_dice });
-        // properties["attack"] = 1;
+    // if (originalRequest["critical-limit"])
+    //     d20_roll += "cs>" + originalRequest["critical-limit"];
+    if (originalRequest.rollAttack && originalRequest["to-hit"] !== undefined) {
+        atk_props["mod"] = originalRequest["to-hit"];
+        if (originalRequest.character && originalRequest.character.type === "Character" && originalRequest.character.settings["custom-roll-dice"].length > 0) {
+            atk_props["mod"] += "+" + originalRequest.character.settings["custom-roll-dice"];
+        }
     }
+    // properties["r1"] = genRoll(d20_roll, { "": originalRequest["to-hit"], "CUSTOM": custom_roll_dice });
+    // properties["attack"] = 1;
 
     message += template(request, atkType, atk_props) + "\n";
 

--- a/src/roll20/content-script.js
+++ b/src/roll20/content-script.js
@@ -748,7 +748,7 @@ async function handleOGLRenderedRoll(request) {
         let custom_roll_dice = "";
         if (originalRequest.character && originalRequest.character.type === "Character")
             custom_roll_dice = originalRequest.character.settings["custom-roll-dice"] || "";
-        atk_props["mod"] = originalRequest["to-hit"] + custom_roll_dice;
+        atk_props["mod"] = originalRequest["to-hit"] + "+" + custom_roll_dice;
         // properties["r1"] = genRoll(d20_roll, { "": originalRequest["to-hit"], "CUSTOM": custom_roll_dice });
         // properties["attack"] = 1;
     }

--- a/src/roll20/content-script.js
+++ b/src/roll20/content-script.js
@@ -748,7 +748,7 @@ async function handleOGLRenderedRoll(request) {
         let custom_roll_dice = "";
         if (originalRequest.character && originalRequest.character.type === "Character")
             custom_roll_dice = originalRequest.character.settings["custom-roll-dice"] || "";
-        atk_props["mod"] = originalRequest["to-hit"] + format_plus_mod(custom_roll_dice);
+        atk_props["mod"] = originalRequest["to-hit"] + custom_roll_dice;
         // properties["r1"] = genRoll(d20_roll, { "": originalRequest["to-hit"], "CUSTOM": custom_roll_dice });
         // properties["attack"] = 1;
     }

--- a/src/roll20/content-script.js
+++ b/src/roll20/content-script.js
@@ -464,8 +464,10 @@ function rollSpellAttack(request, custom_roll_dice) {
         let d20_roll = request.d20 || "1d20";
         if (request["critical-limit"])
             d20_roll += "cs>" + request["critical-limit"];
-        properties["mod"] = request["to-hit"] + format_plus_mod(custom_roll_dice);
-        properties["r1"] = genRoll(d20_roll, { "": request["to-hit"], "CUSTOM": custom_roll_dice });
+        properties["mod"] = request["to-hit"];
+        if (custom_roll_dice.length > 0)
+            properties["mod"] += " + " + custom_roll_dice;
+	properties["r1"] = genRoll(d20_roll, { "": request["to-hit"], "CUSTOM": custom_roll_dice });
         properties["attack"] = 1;
     }
     if (request.damages !== undefined) {

--- a/src/roll20/content-script.js
+++ b/src/roll20/content-script.js
@@ -741,6 +741,17 @@ async function handleOGLRenderedRoll(request) {
         atk_props["dmg2"] = convertRollToText(request.whisper, request.damage_rolls[1][1]);
         atk_props["dmg2type"] = request.damage_rolls[1][0];
     }
+    if (originalRequest.rollAttack && originalRequest["to-hit"] !== undefined) {
+        // let d20_roll = originalRequest.d20 || "1d20";
+        // if (originalRequest["critical-limit"])
+        //     d20_roll += "cs>" + originalRequest["critical-limit"];
+        let custom_roll_dice = "";
+        if (originalRequest.character && originalRequest.character.type === "Character")
+            custom_roll_dice = originalRequest.character.settings["custom-roll-dice"] || "";
+        atk_props["mod"] = originalRequest["to-hit"] + format_plus_mod(custom_roll_dice);
+        // properties["r1"] = genRoll(d20_roll, { "": originalRequest["to-hit"], "CUSTOM": custom_roll_dice });
+        // properties["attack"] = 1;
+    }
 
     message += template(request, atkType, atk_props) + "\n";
 

--- a/src/roll20/content-script.js
+++ b/src/roll20/content-script.js
@@ -467,7 +467,7 @@ function rollSpellAttack(request, custom_roll_dice) {
         properties["mod"] = request["to-hit"];
         if (custom_roll_dice.length > 0)
             properties["mod"] += " + " + custom_roll_dice;
-	properties["r1"] = genRoll(d20_roll, { "": request["to-hit"], "CUSTOM": custom_roll_dice });
+        properties["r1"] = genRoll(d20_roll, { "": request["to-hit"], "CUSTOM": custom_roll_dice });
         properties["attack"] = 1;
     }
     if (request.damages !== undefined) {

--- a/src/roll20/content-script.js
+++ b/src/roll20/content-script.js
@@ -202,7 +202,7 @@ function template(request, name, properties) {
 
 function format_plus_mod(custom_roll_dice) {
     const prefix = custom_roll_dice && !["+", "-", "?", "&", ""].includes(custom_roll_dice.trim()[0]) ? " + " : "";
-    return prefix + (custom_roll_dice || "").replace(/([0-9]*d[0-9]+)/, "$1cs0cf0");;
+    return prefix + (custom_roll_dice || "").replace(/([0-9]*d[0-9]+)/g, "$1cs0cf0");;
 }
 
 function createTable(request, name, properties) {
@@ -345,7 +345,9 @@ function rollAttack(request, custom_roll_dice = "") {
         let d20_roll = request.d20 || "1d20";
         if (request["critical-limit"])
             d20_roll += "cs>" + request["critical-limit"];
-        properties["mod"] = request["to-hit"] + format_plus_mod(custom_roll_dice);
+        properties["mod"] = request["to-hit"];
+        if (custom_roll_dice.length > 0)
+            properties["mod"] += " + " + custom_roll_dice;
         properties["r1"] = genRoll(d20_roll, { "": request["to-hit"], "CUSTOM": custom_roll_dice });
         properties["attack"] = 1;
     }
@@ -741,18 +743,13 @@ async function handleOGLRenderedRoll(request) {
         atk_props["dmg2"] = convertRollToText(request.whisper, request.damage_rolls[1][1]);
         atk_props["dmg2type"] = request.damage_rolls[1][0];
     }
-        // let d20_roll = originalRequest.d20 || "1d20";
-    // if (originalRequest["critical-limit"])
-    //     d20_roll += "cs>" + originalRequest["critical-limit"];
     if (originalRequest.rollAttack && originalRequest["to-hit"] !== undefined) {
         atk_props["mod"] = originalRequest["to-hit"];
-        if (originalRequest.character && originalRequest.character.type === "Character" && originalRequest.character.settings["custom-roll-dice"].length > 0) {
+        if (originalRequest.character.settings["custom-roll-dice"].length > 0) {
             atk_props["mod"] += "+" + originalRequest.character.settings["custom-roll-dice"];
         }
     }
-    // properties["r1"] = genRoll(d20_roll, { "": originalRequest["to-hit"], "CUSTOM": custom_roll_dice });
-    // properties["attack"] = 1;
-
+    
     message += template(request, atkType, atk_props) + "\n";
 
     let damages = request.damage_rolls.slice(2)


### PR DESCRIPTION
Rendered roll function was missing a check for the "to-hit" property (among others) added this in at the relevant spot and tested. Let me know if this is sufficient, or if anything needs to be added/modified.