### PR TITLE
proposed fix for width in beyond20 settings

### DIFF
--- a/libs/css/alertify-themes/beyond20.css
+++ b/libs/css/alertify-themes/beyond20.css
@@ -13,7 +13,7 @@
 }
 .alertify .ajs-modal {
   z-index: 100002;
-} 
+}
 .alertify-notifier {
   z-index: 100003;
 }
@@ -35,6 +35,6 @@
 }
 
 /* Make ajs dialog readable on larger screens in "Beyond20 Settings" */
-.ajs-dialog {
+.alertify .ajs-dialog {
   max-width: 950px;
 }

--- a/libs/css/alertify-themes/beyond20.css
+++ b/libs/css/alertify-themes/beyond20.css
@@ -35,6 +35,10 @@
 }
 
 /* Make ajs dialog readable on larger screens in "Beyond20 Settings" */
+.alertify.ajs-maximized .ajs-dialog {
+  max-width: 950px !important;
+}
+
 .alertify .ajs-dialog {
-  max-width: 950px;
+  max-width: 950px !important;
 }

--- a/libs/css/alertify-themes/beyond20.css
+++ b/libs/css/alertify-themes/beyond20.css
@@ -33,3 +33,8 @@
 .alertify.ajs-maximized .ajs-body .ajs-content {
   top: 64px;
 }
+
+/* Make ajs dialog readable on larger screens in "Beyond20 Settings" */
+.ajs-dialog {
+  max-width: 950px;
+}


### PR DESCRIPTION
Set a max-width property to the ajs-dialog of 1250px; this was tested on an ultrawide 1080p monitor and a 16:9 monitor. Feel free to test and adjust the pixel value set in the beyond20.css file at the bottom. I've commented the relevant section.