### PR TITLE
Remove DnDBeyond Sale/Offer Banner Workaround

### DIFF
--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -2215,7 +2215,6 @@ function deactivateTooltipListeners(el) {
 var quickRollHideId = 0;
 var quickRollMouseOverEl = null;
 function activateTooltipListeners(el, direction, tooltip, callback) {
-    const site = $("#site");
     el.on('mouseenter', (e) => {
         if (quickRollHideId)
             clearTimeout(quickRollHideId);
@@ -2223,9 +2222,6 @@ function activateTooltipListeners(el, direction, tooltip, callback) {
 
         const target = $(e.currentTarget)
         const position = target.offset()
-        const siteOffset = site.offset(); // Banner on top of the site can shift everything down
-        position.left -= siteOffset.left;
-        position.top -= siteOffset.top;
         if (direction === "up") {
             position.left += target.outerWidth() / 2 - tooltip.outerWidth() / 2;
             position.top -= tooltip.outerHeight() + 5;


### PR DESCRIPTION
Seems to be accounted for in the DnDBeyond Site Design itself now

Current Beyond20 Behavior:
![image](https://user-images.githubusercontent.com/7988297/153463088-3d6f2fd8-5ff2-4785-a7b0-0f952ee5d2b0.png)

Workaround removal:
![image](https://user-images.githubusercontent.com/7988297/153463232-c2b7b0eb-909c-4c24-9920-e7fee398e62e.png)
