### PR TITLE
Implement Custom Roll for Blood Curse of the Eyeless

### DIFF
--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -1046,6 +1046,14 @@ async function rollAction(paneClass, force_to_hit_only = false, force_damages_on
             "description": description,
             "modifier": inspiration_die
         });
+    } else if (action_name.includes("Blood Curse of the Eyeless")) {
+        const bloodhunter_level = character.getClassLevel("Bloodhunter");
+        let hemocraft_die = bloodhunter_level < 5 ? "1d4" : (bloodhunter_level < 11 ? "1d6" : (bloodhunter_level < 17 ? "1d8" : "1d10"));
+        return sendRollWithCharacter("custom", hemocraft_die, {
+            "name": action_name,
+            "description": description,
+            "modifier": hemocraft_die
+        });
     } else if (Object.keys(properties).includes("Damage") || to_hit !== null || properties["Attack/Save"] !== undefined) {
         const damages = [];
         let damage_types = [];


### PR DESCRIPTION
Fixes #159 
Blood Curse of the Eyeless appears to be the only item that needs a roll like this.

However, it appears there are a ton of Bloodhunter things not implemented. I'm hesitant to go further with it, as it's Unofficial, and there have been no requests for it, but I also like having as complete coverage as possible.

Your thoughts @kakaroto ?