### PR TITLE
Fix for displaying dropped dice indication for advantage/disadvantage in roll20, when using digital dice and D&D 5E By Roll20 template

### DIFF
--- a/src/roll20/content-script.js
+++ b/src/roll20/content-script.js
@@ -679,7 +679,9 @@ async function handleOGLRenderedRoll(request) {
     if (request.attack_rolls.length > 1) {
         atk_props["r1"] = convertRollToText(request.whisper, request.attack_rolls[0]);
         atk_props["r2"] = request.attack_rolls.slice(1).map(roll => convertRollToText(request.whisper, roll)).join(" | ")
-        atk_props["always"] = "1";
+        if (request.attack_rolls.length === 2 && request.request.advantage === RollType.ADVANTAGE) atk_props["advantage"] = "1";
+        else if (request.attack_rolls.length === 2 && request.request.advantage === RollType.DISADVANTAGE) atk_props["disadvantage"] = "1";
+        else atk_props["always"] = "1";
         atk_props["attack"] = "1"
     } else if (request.attack_rolls.length > 0) {
         atk_props["r1"] = convertRollToText(request.whisper, request.attack_rolls[0]);


### PR DESCRIPTION
**Problem:**
When rolling with advantage/disadvantage into roll20, while using digital dice and the D&D 5E By Roll20 template, both rolls were shown in dark black. Correctly one of them should be lighter to indicate it being dropped due to the advantage/disadvantage.
Currently showing: 
![image](https://user-images.githubusercontent.com/8955367/155859633-8acc8297-614c-4b21-b79b-7573579f986a.png)
Correct version for disadvantage:
![image](https://user-images.githubusercontent.com/8955367/155859655-e163f015-0f2d-46c2-aca7-aea53fa19a23.png)

**Changes summary:**
Originally attack prop `always: "1"` was being added. I added 2 special cases for when the roll is indicated to be with advantage/disadvantage and the number of rolled dice is 2 (because rolls beyond 2 are grouped into the second roll and the advantage indicator in the template is unable to process those)