### PR TITLE
Implement Extra Damage from Vicious Weapons

### DIFF
--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -223,6 +223,14 @@ async function buildAttackRoll(character, attack_source, name, description, prop
                 crit_damages[0] = damagesToCrits(character, ["8d12"])[0];
             if (roll_properties.name === "Jim’s Magic Missile")
                 crit_damages[0] = damagesToCrits(character, ["3d4"])[0];
+            const matchViciousWeapon = description.match(/When you roll a 20 on your attack roll with this magic weapon, the target takes an extra (\d+) damage of the weapon’s type./);
+            if (matchViciousWeapon) {
+                if (!damages.some(damage => damage === matchViciousWeapon[1])) {
+                    damages.push(matchViciousWeapon[1]);
+                    damage_types.push("Vicious(20 On The Attack Roll)");
+                } 
+            }
+                       
             if (brutal > 0) {
                 const rule = parseInt(character.getGlobalSetting("critical-homebrew", CriticalRules.PHB));
                 let highest_dice = 0;


### PR DESCRIPTION
Vicious Weapons do an extra flat 7 Damage on attack rolls
![image](https://user-images.githubusercontent.com/7988297/166152183-cd887e65-183f-4e21-a638-deda22de5159.png)

This is similar to Swords of Sharpness:
![image](https://user-images.githubusercontent.com/7988297/166152206-65779acf-6563-47ae-90f3-3262e4ce0a37.png)

Except DnDBeyond did not deign to implement the extra damage. This change makes the Vicious Weapons appear essentially the same as the Swords of Sharpness in rolls.

![image](https://user-images.githubusercontent.com/7988297/166152296-e7208f88-ee5a-4cb2-80c1-8ae7876cf8f4.png)

![image](https://user-images.githubusercontent.com/7988297/166152305-22f67b7f-65f0-4657-85a1-479a43d499b7.png)
