### PR TITLE
Bugfix for Artificier Arcane Jolt

### DIFF
--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -544,7 +544,7 @@ function handleSpecialWeaponAttacks(damages=[], damage_types=[], properties, set
         if (damages.length > 0 &&
             character.hasClassFeature("Arcane Jolt") &&
             character.getSetting("artificer-arcane-jolt", false) &&
-            item_type.indexOf(", Common") === -1) {
+            (properties["Infused"] || item_type.indexOf(", Common") === -1)) {
             damages.push(character._level < 15 ? "2d6" : "4d6");
             damage_types.push("Arcane Jolt");
         }
@@ -745,6 +745,9 @@ async function rollItem(force_display = false, force_to_hit_only = false, force_
     const is_instrument = isItemAnInstruction(item_name, item_tags);
     const description = descriptionToString(".ct-item-detail__description");
     const quantity = $(".ct-item-pane .ct-simple-quantity .ct-simple-quantity__value .ct-simple-quantity__input").val();
+    const is_infused = $(".ct-item-pane .ct-item-detail__infusion");
+    if (is_infused.length > 0)
+        properties["Infused"] = true;
     let is_versatile = false;
     if (!force_display && Object.keys(properties).includes("Damage")) {
         const item_full_name = $(".ct-item-pane .ct-sidebar__heading .ct-item-name,.ct-item-pane .ct-sidebar__heading .ddbc-item-name").text();


### PR DESCRIPTION
Original code checked to make sure that the weapon being used did not have "Common" in the `item_type`, as Arcane Jolt requires a Magic Weapon.
![image](https://user-images.githubusercontent.com/7988297/167145991-05093584-94bc-466d-b55e-ff42d1eaa7b4.png)

However, when an Artificer uses their Infusion on a weapon, the weapon still has an `item_type` of "Common", but with modified text.
![image](https://user-images.githubusercontent.com/7988297/167146132-ef5fd159-7396-42d2-8dc7-6cb927010a85.png)

This change causes the "common (requires attunement)" check to be added and done first, so it supersedes the exclusion of strictly common items.