### PR TITLE
Add Specificity for Genie's Wrath Damage

### DIFF
--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -509,7 +509,16 @@ function handleSpecialGeneralAttacks(damages=[], damage_types=[], properties, se
             character.hasClassFeature("Genie’s Vessel") &&
             character.getSetting("genies-vessel", false)) {
             damages.push(character._proficiency);
-            damage_types.push("Genie's Wrath");
+            if (character.hasClassFeature("Genie’s Vessel: Genie's Wrath (Dao)"))
+                damage_types.push("Genie's Wrath (Bludgeoning)");
+            else if (character.hasClassFeature("Genie’s Vessel: Genie's Wrath (Djinni)"))
+                damage_types.push("Genie's Wrath (Thunder)");
+            else if (character.hasClassFeature("Genie’s Vessel: Genie's Wrath (Efreeti)"))
+                damage_types.push("Genie's Wrath (Fire)");
+            else if (character.hasClassFeature("Genie’s Vessel: Genie's Wrath (Marid)"))
+                damage_types.push("Genie's Wrath (Cold)");
+            else
+                damage_types.push("Genie's Wrath");
         }
 
         // Warlock: The Undead: Grave Touched


### PR DESCRIPTION
Adds the specific damage type based on the Genie type the Warlock is associated with
![image](https://user-images.githubusercontent.com/7988297/167158559-3e5dc63e-1bf6-4bcd-b61a-23b83ef706a9.png)

![image](https://user-images.githubusercontent.com/7988297/167158692-aa242441-7005-456f-bf4c-6a72842f6456.png)
