### PR TITLE
Fix for DnDBeyond changing Name Fields

### DIFF
--- a/src/dndbeyond/base/character.js
+++ b/src/dndbeyond/base/character.js
@@ -36,7 +36,7 @@ class Character extends CharacterBase {
 
         // Static values that need an edit to change;
         if (this._name === null) {
-            this._name = $(".ddbc-character-name").text();
+            this._name = $(".ddb-character-app-1d1w1it").text();
             // This can happen when you reload the page;
             if (this._name == "")
                 this._name = null;

--- a/src/dndbeyond/base/digital-dice.js
+++ b/src/dndbeyond/base/digital-dice.js
@@ -190,7 +190,7 @@ class DigitalDiceManager {
                 const collapse = $(".ct-sidebar__control--collapse, .sidebar__control:has(.sidebar__control--collaspe)");
                 // Collapse the side bar, or if it's locked, fake a click on the character name to change the sidepanel
                 if (collapse.length > 0) collapse.click();
-                else $(".ddbc-character-name").click();
+                else $(".ddb-character-app-1d1w1it").click();
             }
             return;
         }

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -2055,7 +2055,7 @@ function injectRollButton(paneClass) {
         }
     } else if (paneClass == "ct-character-manage-pane") {
         const avatar = $(".ct-character-manage-pane .ct-character-manage-pane__summary-avatar");
-        const char_name = $(".ct-character-manage-pane .ct-character-manage-pane__summary-description .ddbc-character-name").text().trim();
+        const char_name = $(".ct-character-manage-pane .ct-character-manage-pane__summary-description .ddb-character-app-1pdl6ha").text().trim();
         let avatar_link = avatar.css('background-image');
         if (avatar_link && avatar_link.startsWith("url("))
             avatar_link = avatar_link.slice(5, -2);


### PR DESCRIPTION
Sensible, human-readable name fields abandoned
Replaced by ridiculous machine-generated field names