### PR TITLE
Add Spell Details to Roll20 Spell Display

### DIFF
--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -300,10 +300,17 @@ const options_list = {
         "default": "Unknown Creature",
         "advanced": true
     },
+    
+    "roll20-spell-details-display": {
+        "title": "Display Spell Details in spell attacks",
+        "description": "When doing a spell attack, display the spell's details (Roll20 only toggle)",
+        "type": "bool",
+        "default": false
+    },
 
     "roll20-spell-description-display": {
         "title": "Display Spell Descriptions in spell attacks",
-        "description": "When doing a spell attack, display the spells full description (Roll20 only toggle)",
+        "description": "When doing a spell attack, display the spell's full description (Roll20 only toggle)",
         "type": "bool",
         "default": false
     },

--- a/src/roll20/content-script.js
+++ b/src/roll20/content-script.js
@@ -513,6 +513,11 @@ function rollSpellAttack(request, custom_roll_dice) {
             }
         }
     }
+    if (settings["roll20-spell-details-display"] === true) {
+		properties["desc"] = properties["desc"] ? properties["desc"] + "\n\n" : "";
+		properties["desc"] += `Range/Area: ${request.range}\n\n`;
+        properties["desc"] += `Duration: ${request.duration}`;
+    }
     if (settings["roll20-spell-description-display"] === true) {
 		properties["desc"] = properties["desc"] ? properties["desc"] + "\n\n" : "";
 		properties["desc"] += `Description: ${request.description}`;


### PR DESCRIPTION
Fixes #1003

Looks like this (Spell Details + Spell Descriptions Enabled):
![image](https://user-images.githubusercontent.com/7988297/178512100-aa84b035-070d-42b4-b1fe-bf126b1ae507.png)

And this (Spell Details Enabled, Spell Descriptions Disabled):
![image](https://user-images.githubusercontent.com/7988297/178513734-0581a8ec-7e1c-4620-af6e-b471e9a9ea7f.png)
