### PR TITLE
Handle Dragon Wing * Ranged Weapons + Flail of Tiamat Damages

### DIFF
--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -848,6 +848,29 @@ async function rollItem(force_display = false, force_to_hit_only = false, force_
             }
         }
 
+        // Handle Dragon Wing * Ranged Weapons
+        if (item_name.includes("Dragon Wing") || item_name === "Flail of Tiamat") {
+            damages.splice(2,damages.length - 2);
+            let possible_damages = damage_types.splice(1,damage_types.length - 1);
+            const damage_type = properties.Notes && possible_damages.reduce((found, damage) => {
+                if (found) return found;
+                if (properties.Notes.toLowerCase().includes(damage.toLowerCase())) return damage;
+                return null;
+            }, null);
+            if (damage_type) {
+                damage_types.push(damage_type);
+            }
+            else if (item_name.includes("Dragon Wing")) {
+                damage_types.push("Infused");
+            }
+            else if (item_name === "Flail of Tiamat") {
+                damage_types.push("Chosen Type");
+            }
+            else {
+                damage_types.push("Extra");
+            }
+        }
+
         const weapon_damage_length = damages.length;
         
         // If clicking on a spell group within a item (Green flame blade, Booming blade), then add the additional damages from that spell


### PR DESCRIPTION
Lazy setup by DnDBeyond shows all damages for each weapon
Pare down to single additional damage
Allow setting "note" on a weapon to specify damage
"note" must be set to a Damage type available to be infused on the weapon to apply (fallback is "Infused Damage")