### PR TITLE
Remove Otherworldly Glamour from Charisma Saves

### DIFF
--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -183,6 +183,13 @@ async function rollSkillCheck(paneClass) {
         roll_properties.modifier += character._proficiency;
     }
 
+    // Fey Wanderer Ranger - Otherworldly Glamour
+    if (character.hasClassFeature("Otherworldly Glamour") && ability == "CHA") {
+        modifier = parseInt(modifier) + Math.max(character.getAbility("WIS").mod,1);
+        modifier = modifier >= 0 ? `+${modifier}` : `${modifier}`;
+        roll_properties["modifier"] = modifier;
+    }
+
     return sendRollWithCharacter("skill", "1d20" + modifier, roll_properties);
 }
 
@@ -256,7 +263,7 @@ function rollAbilityOrSavingThrow(paneClass, rollType) {
         roll_properties["modifier"] = modifier;
     }
     // Fey Wanderer Ranger - Otherworldly Glamour
-    if (character.hasClassFeature("Otherworldly Glamour") && ability == "CHA") {
+    if (rollType == "ability" && character.hasClassFeature("Otherworldly Glamour") && ability == "CHA") {
         modifier = parseInt(modifier) + Math.max(character.getAbility("WIS").mod,1);
         modifier = modifier >= 0 ? `+${modifier}` : `${modifier}`;
         roll_properties["modifier"] = modifier;


### PR DESCRIPTION
Add Otherworldly Glamour to Skill Checks
Fixes #1017

https://www.dndbeyond.com/classes/ranger#FeyWanderer

```
Otherworldly Glamour
3rd-level Fey Wanderer feature

Your fey qualities give you a supernatural charm. As a result, whenever you make a Charisma check, you gain a bonus to the check equal to your Wisdom modifier (minimum of +1).
```

I read that as applying to Deception/Intimidation/Persuasion as well.