### PR TITLE
Navigating to a character sheet from "My characters" using View button fails to load extension

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -60,7 +60,8 @@
 	"content_scripts": [
 		{
 			"matches": [
-				"*://*.dndbeyond.com/*characters/*"
+				"*://*.dndbeyond.com/*characters/*",
+				"*://*.dndbeyond.com/*characters"
 			],
 			"css": [
 				"dist/beyond20.css"


### PR DESCRIPTION
Resolve issue #1029 by adding the 'My Characters' page to the manifest.

Doing this seemed to resolve things for me when I tested it.