### PR TITLE
Fix issue regarding the restrained condition being mispelled on the VTT

### DIFF
--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -2095,7 +2095,7 @@ function injectRollButton(paneClass) {
         let exhaustion_level = $(".ct-condition-manage-pane__condition--special .ct-number-bar__option--active,.ct-condition-manage-pane__condition--special .ddbc-number-bar__option--active").text();
         const conditions = [];
         for (let cond of j_conditions.toArray()) {
-            var condition_name = $(cond).find(".ct-condition-manage-pane__condition-name").text();
+            const condition_name = $(cond).find(".ct-condition-manage-pane__condition-name").text();
             conditions.push(condition_name);
         }
         if (exhaustion_level == "")

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -2094,8 +2094,10 @@ function injectRollButton(paneClass) {
         const j_conditions = $(".ct-condition-manage-pane .ct-toggle-field--enabled,.ct-condition-manage-pane .ddbc-toggle-field--is-enabled").closest(".ct-condition-manage-pane__condition");
         let exhaustion_level = $(".ct-condition-manage-pane__condition--special .ct-number-bar__option--active,.ct-condition-manage-pane__condition--special .ddbc-number-bar__option--active").text();
         const conditions = [];
-        for (let cond of j_conditions.toArray())
-            conditions.push(cond.textContent);
+        for (let cond of j_conditions.toArray()) {
+            var condition_name = $(cond).find(".ct-condition-manage-pane__condition-name").text();
+            conditions.push(condition_name);
+        }
         if (exhaustion_level == "")
             exhaustion_level = 0;
         else


### PR DESCRIPTION
![unknown](https://user-images.githubusercontent.com/31316420/199274178-f6a855e4-3cbc-463c-a3be-3e5ab23eb3b6.png)
`Restrained` is being spelled out as `RRestrained` on the virtual table top when updating conditions on a character sheet.

The issue stemmed from the code taking the text inside a `div` and using that as the text for the condition. However the Restrained div had 3 `divs` inside of it, one of which had an `svg` with the letter `R` in it. This updated PR takes the specific div with the desired text instead