### PR TITLE
Add limited support for Goliath "Large Form" trait

### DIFF
--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -773,6 +773,12 @@ const character_settings = {
         "type": "bool",
         "default": true
     },
+    "goliath-large-form": {
+        "title": "Goliath: Large Form",
+        "description": "As a Bonus Action, you change your Size to Large, provided you’re in a big enough space. This transformation lasts for 10 minutes or until you end it as a Bonus Action. During that duration, you have Advantage on Strength Checks, and your Speed increases by 10 feet. Once you use this trait, you can’t use it again until you finish a Long Rest.",
+        "type": "bool",
+        "default": false
+    },
     "discord-target": {
         "title": "Discord Destination",
         "description": "Send rolls to a character specific Discord channel",

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -89,7 +89,8 @@ async function rollSkillCheck(paneClass) {
     }
     if (ability == "STR" &&
         ((character.hasClassFeature("Rage") && character.getSetting("barbarian-rage", false)) ||
-            (character.hasClassFeature("Giant’s Might") && character.getSetting("fighter-giant-might", false)))) {
+            (character.hasClassFeature("Giant’s Might") && character.getSetting("fighter-giant-might", false)) ||
+            (character.hasRacialTrait("Large Form") && character.getSetting("goliath-large-form", false)))) {
         roll_properties["advantage"] = RollType.OVERRIDE_ADVANTAGE;
     }
     if (skill_name == "Acrobatics" && character.hasClassFeature("Bladesong") && character.getSetting("wizard-bladesong", false)) {
@@ -236,7 +237,8 @@ function rollAbilityOrSavingThrow(paneClass, rollType) {
 
     if (ability == "STR" &&
         ((character.hasClassFeature("Rage") && character.getSetting("barbarian-rage", false)) ||
-            (character.hasClassFeature("Giant’s Might") && character.getSetting("fighter-giant-might", false)))) {
+            (character.hasClassFeature("Giant’s Might") && character.getSetting("fighter-giant-might", false)) ||
+            (character.hasRacialTrait("Large Form") && character.getSetting("goliath-large-form", false)))) {
         roll_properties["advantage"] = RollType.OVERRIDE_ADVANTAGE;
     }
     if (character.hasClassFeature("Indomitable Might") && ability == "STR") {
@@ -1029,7 +1031,8 @@ async function rollItem(force_display = false, force_to_hit_only = false, force_
                 }
                 if (ability == "STR" &&
                     ((character.hasClassFeature("Rage") && character.getSetting("barbarian-rage", false)) ||
-                        (character.hasClassFeature("Giant’s Might") && character.getSetting("fighter-giant-might", false)))) {
+                        (character.hasClassFeature("Giant’s Might") && character.getSetting("fighter-giant-might", false)) ||
+                        (character.hasRacialTrait("Large Form") && character.getSetting("goliath-large-form", false)))) {
                     roll_properties["advantage"] = RollType.OVERRIDE_ADVANTAGE;
                 }
                 roll_properties.d20 = "1d20";

--- a/src/extension/popup.js
+++ b/src/extension/popup.js
@@ -116,6 +116,10 @@ function populateCharacter(response) {
             e = createHTMLOption("halfling-lucky", false, character_settings);
             options.append(e);
         }
+        if (response["racial-traits"].includes("Large Form")) {
+            e = createHTMLOption("goliath-large-form", false, character_settings);
+            options.append(e);
+        }
         if (response["class-features"].includes("Brutal Critical") ||
             response["racial-traits"].includes("Savage Attacks")) {
             e = createHTMLOption("brutal-critical", false, character_settings);


### PR DESCRIPTION
This commit adds a partial implementation of the racial trait called "Large Form" that has been introduced for Goliaths as of the latest One D&D playtest. The effects of this bonus action are to (1) grant ADV on STR checks for the duration of the effect, (2) increase the size of the character to Large, and (3) increase the speed of the character by 10 feet. Only the first of these is implemented because it is unclear whether it is even possible (let alone advisable) to temporarily bump the size and speed of the character.