### PR TITLE
Remove Otherworldly Glamour for Skill Checks

### DIFF
--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -183,13 +183,6 @@ async function rollSkillCheck(paneClass) {
         roll_properties.modifier += character._proficiency;
     }
 
-    // Fey Wanderer Ranger - Otherworldly Glamour
-    if (character.hasClassFeature("Otherworldly Glamour") && ability == "CHA") {
-        modifier = parseInt(modifier) + Math.max(character.getAbility("WIS").mod,1);
-        modifier = modifier >= 0 ? `+${modifier}` : `${modifier}`;
-        roll_properties["modifier"] = modifier;
-    }
-
     return sendRollWithCharacter("skill", "1d20" + modifier, roll_properties);
 }
 


### PR DESCRIPTION
DnDBeyond appears to have implemented this themselves now. Leaving the straight Charisma Check code, as they have not done that yet

Fixes #1049 