### PR TITLE
Change Vicious Weapon Damage to only show on Crits

### DIFF
--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -236,8 +236,8 @@ async function buildAttackRoll(character, attack_source, name, description, prop
             const matchViciousWeapon = description.match(/When you roll a 20 on your attack roll with this magic weapon, the target takes an extra (\d+) damage of the weapon’s type./);
             if (matchViciousWeapon) {
                 if (!damages.some(damage => damage === matchViciousWeapon[1])) {
-                    damages.push(matchViciousWeapon[1]);
-                    damage_types.push("Vicious(20 On The Attack Roll)");
+                    crit_damages.push(matchViciousWeapon[1]);
+                    crit_damage_types.push("Vicious (20 On The Attack Roll)");
                 } 
             }
                        


### PR DESCRIPTION
As discussed on Discord.
Requires rolling a 20 to trigger, so this is more sensical.