### PR TITLE
allow rendered rolls to come from custom domains

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,8 @@
 		"*://beyond20.kicks-ass.org/roll",
 		"*://app.roll20.net/editor/",
 		"*://*.dndbeyond.com/*",
-		"*://*.forge-vtt.com/game"
+		"*://*.forge-vtt.com/game",
+		"*://*.osrbeyond.com/*"
 	],
     "optional_permissions": ["*://*/"],
 	"icons": {

--- a/manifest.json
+++ b/manifest.json
@@ -10,8 +10,7 @@
 		"*://beyond20.kicks-ass.org/roll",
 		"*://app.roll20.net/editor/",
 		"*://*.dndbeyond.com/*",
-		"*://*.forge-vtt.com/game",
-		"*://*.osrbeyond.com/*"
+		"*://*.forge-vtt.com/game"
 	],
     "optional_permissions": ["*://*/"],
 	"icons": {

--- a/src/generic-site/content-script.js
+++ b/src/generic-site/content-script.js
@@ -36,7 +36,7 @@ function updateSettings(new_settings = null) {
 }
 chrome.runtime.onMessage.addListener(handleMessage);
 
-function sendRollToGameLog(message) {
+function sendMessageToBeyond20(message) {
     console.log(message)
     chrome.runtime.sendMessage(message)
 }
@@ -62,7 +62,7 @@ function handleIncomingSettings({ character, action, type} = {}) {
 }
 
 var registered_events = [];
-registered_events.push(addCustomEventListener("rendered-roll", sendRollToGameLog));
+registered_events.push(addCustomEventListener("send-message", sendMessageToBeyond20));
 registered_events.push(addCustomEventListener("disconnect", disconnectAllEvents));
 registered_events.push(addCustomEventListener("settings", handleIncomingSettings));
 


### PR DESCRIPTION
Not as complicated as I imagined on the extension side, really just opened the rendered-roll event listener on the dom. The allows my web application to send dom events up with roll info. Working on documenting the roll data structure in another PR.