### PR TITLE
Support for Healing NPC Attacks

### DIFF
--- a/src/dndbeyond/base/monster.js
+++ b/src/dndbeyond/base/monster.js
@@ -472,7 +472,7 @@ class Monster extends CharacterBase {
             hit = description.slice(hit_idx);
         // Using match with global modifier then map to regular match because RegExp.matchAll isn't available on every browser
         const damage_regexp = new RegExp(/([\w]* )(?:([0-9]+)(?!d))?(?: *\(?([0-9]*d[0-9]+(?:\s*[-+]\s*[0-9]+)?(?: plus [^\)]+)?)\)?)? ([\w ]+?) damage/)
-        const healing_regexp = new RegExp(/regains (?:([0-9]+)(?!d))?(?: *\(?([0-9]*d[0-9]+(?:\s*[-+]\s*[0-9]+)?)(?: plus [^\)]+)?\)?)? hit points/)
+        const healing_regexp = new RegExp(/gains (?:([0-9]+)(?!d))?(?: *\(?([0-9]*d[0-9]+(?:\s*[-+]\s*[0-9]+)?)(?: plus [^\)]+)?\)?)? (?:temporary)?\s*hit points/)
         const damage_matches = reMatchAll(damage_regexp, hit) || [];
         const healing_matches = reMatchAll(healing_regexp, hit) || [];
         const damages = [];

--- a/src/dndbeyond/base/monster.js
+++ b/src/dndbeyond/base/monster.js
@@ -472,7 +472,9 @@ class Monster extends CharacterBase {
             hit = description.slice(hit_idx);
         // Using match with global modifier then map to regular match because RegExp.matchAll isn't available on every browser
         const damage_regexp = new RegExp(/([\w]* )(?:([0-9]+)(?!d))?(?: *\(?([0-9]*d[0-9]+(?:\s*[-+]\s*[0-9]+)?(?: plus [^\)]+)?)\)?)? ([\w ]+?) damage/)
+        const healing_regexp = new RegExp(/regains (?:([0-9]+)(?!d))?(?: *\(?([0-9]*d[0-9]+(?:\s*[-+]\s*[0-9]+)?)(?: plus [^\)]+)?\)?)? hit points/)
         const damage_matches = reMatchAll(damage_regexp, hit) || [];
+        const healing_matches = reMatchAll(healing_regexp, hit) || [];
         const damages = [];
         const damage_types = [];
         for (let dmg of damage_matches) {
@@ -487,6 +489,13 @@ class Monster extends CharacterBase {
             if (damage) {
                 damages.push(damage.replace("plus", "+"));
                 damage_types.push(dmg[4]);
+            }
+        }
+        for (let dmg of healing_matches) {
+            const damage = dmg[2] || dmg[1];
+            if (damage) {
+                damages.push(damage.replace("plus", "+"));
+                damage_types.push("Healing");
             }
         }
         let save = null;

--- a/src/dndbeyond/base/monster.js
+++ b/src/dndbeyond/base/monster.js
@@ -493,7 +493,7 @@ class Monster extends CharacterBase {
         }
         for (let dmg of healing_matches) {
             const damage = dmg[2] || dmg[1];
-			const healingType = dmg[3] ? "Temp HP" : "Healing"
+            const healingType = dmg[3] ? "Temp HP" : "Healing"
             if (damage) {
                 damages.push(damage.replace("plus", "+"));
                 damage_types.push(healingType);

--- a/src/dndbeyond/base/monster.js
+++ b/src/dndbeyond/base/monster.js
@@ -472,7 +472,7 @@ class Monster extends CharacterBase {
             hit = description.slice(hit_idx);
         // Using match with global modifier then map to regular match because RegExp.matchAll isn't available on every browser
         const damage_regexp = new RegExp(/([\w]* )(?:([0-9]+)(?!d))?(?: *\(?([0-9]*d[0-9]+(?:\s*[-+]\s*[0-9]+)?(?: plus [^\)]+)?)\)?)? ([\w ]+?) damage/)
-        const healing_regexp = new RegExp(/gains (?:([0-9]+)(?!d))?(?: *\(?([0-9]*d[0-9]+(?:\s*[-+]\s*[0-9]+)?)(?: plus [^\)]+)?\)?)? (?:temporary)?\s*hit points/)
+        const healing_regexp = new RegExp(/gains (?:([0-9]+)(?!d))?(?: *\(?([0-9]*d[0-9]+(?:\s*[-+]\s*[0-9]+)?)(?: plus [^\)]+)?\)?)? (temporary)?\s*hit points/)
         const damage_matches = reMatchAll(damage_regexp, hit) || [];
         const healing_matches = reMatchAll(healing_regexp, hit) || [];
         const damages = [];
@@ -493,9 +493,10 @@ class Monster extends CharacterBase {
         }
         for (let dmg of healing_matches) {
             const damage = dmg[2] || dmg[1];
+			const healingType = dmg[3] ? "Temp HP" : "Healing"
             if (damage) {
                 damages.push(damage.replace("plus", "+"));
-                damage_types.push("Healing");
+                damage_types.push(healingType);
             }
         }
         let save = null;


### PR DESCRIPTION
Fixes #1070

Matches text for healing-based actions in monster stat blocks to allow rolling on those abilities.
