### PR TITLE
Support Roll20 as a Discord Activity

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -186,6 +186,22 @@
 				"libs/jquery-3.4.1.min.js",
 				"dist/roll20.js"
 			]
+		},
+		{
+			"matches": [
+				"*://1199271093882589195.discordsays.com/*"
+			],
+			"css": [
+				"libs/css/alertify.css",
+				"libs/css/alertify-themes/default.css",
+				"libs/css/alertify-themes/beyond20.css"
+			],
+			"js": [
+				"libs/alertify.min.js",
+				"libs/jquery-3.4.1.min.js",
+				"dist/roll20.js"
+			],
+			"all_frames": true
 		}
 	]
 }

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -108,6 +108,10 @@ function roll20Title(title) {
     return title.replace(" | Roll20", "");
 }
 
+function isRoll20(title) {
+    return title.includes("| Roll20");
+}
+
 function isFVTT(title) {
     return title.includes("Foundry Virtual Tabletop");
 }

--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -66,6 +66,8 @@ function sendMessageToRoll20(request, limit = null, failure = null) {
         let failedSendingViaContentPort = sendMessageToContentScript(request);
         if(failedSendingViaContentPort) {
             sendMessageTo(ROLL20_URL, request, failure);
+        } else {
+            failure(failedSendingViaContentPort);
         }
     }
 }

--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -62,8 +62,11 @@ function sendMessageToRoll20(request, limit = null, failure = null) {
         } else {
             failure(true)
         }
-    } else {
-        sendMessageTo(ROLL20_URL, request, failure)
+    } else { //First try to send via content script port in case we are in Discord Activity
+        let failedSendingViaContentPort = sendMessageToContentScript(request);
+        if(failedSendingViaContentPort) {
+            sendMessageTo(ROLL20_URL, request, failure);
+        }
     }
 }
 
@@ -376,6 +379,27 @@ chrome.tabs.onUpdated.addListener(onTabsUpdated)
 chrome.tabs.onRemoved.addListener(onTabRemoved)
 chrome.permissions.onAdded.addListener(onPermissionsUpdated)
 chrome.permissions.onRemoved.addListener(onPermissionsUpdated)
+
+let contentScriptPort;
+
+chrome.runtime.onConnect.addListener((p) => {
+    console.log("Port connected");
+    contentScriptPort = p;
+});
+
+function sendMessageToContentScript(msg) {
+    if(contentScriptPort) {
+        let succeeded = true;
+        try {
+            contentScriptPort.postMessage(msg);
+        } catch(e) {
+            succeeded = false;
+        }
+        return !succeeded;
+    } else {
+        return true;
+    }
+}
 
 chrome.permissions.getAll((permissions) => {
     currentPermissions = permissions;

--- a/src/extension/popup.js
+++ b/src/extension/popup.js
@@ -354,7 +354,7 @@ function tabMatches(tab, url) {
 
 function actOnCurrentTab(tab) {
     setCurrentTab(tab);
-    if (urlMatches(tab.url, ROLL20_URL) || isFVTT(tab.title)) {
+    if (isRoll20(tab.title) || isFVTT(tab.title)) {
         const vtt = isFVTT(tab.title) ? "Foundry VTT" : "Roll20";
         const options = $(".beyond20-options");
         options.append(

--- a/src/roll20/content-script.js
+++ b/src/roll20/content-script.js
@@ -956,6 +956,22 @@ function handleMessage(request, sender, sendResponse) {
 }
 
 chrome.runtime.onMessage.addListener(handleMessage);
+
+function checkForActivity (tab) {
+    const origin = `${new URL(tab.url).protocol}//${new URL(tab.url).hostname}/*`;
+    if(origin.includes("discord.com") && isRoll20(document.title)) {
+        console.log("Detected Roll20 Discord Activity, using content port...");
+        //We have to use a content port rather than tab messaging in Discord Activity.
+        let myPort = chrome.runtime.connect({ });
+
+        myPort.onMessage.addListener((m) => {
+        handleMessage(m);
+        });
+    }
+}
+
+chrome.runtime.sendMessage({ "action": "get-current-tab" }, checkForActivity);
+
 updateSettings();
 chrome.runtime.sendMessage({ "action": "activate-icon" });
 sendCustomEvent("disconnect");


### PR DESCRIPTION
Hey there!

Roll20 is coming to Discord as an Activity. As part of that we are taking a look at popular extensions that Roll20 users install and seeing what needs to be done to support the Activity version. In particular, it doesn't seem possible to use the messaging feature to send messages between tabs since the Activity runs as a nested iFrame in a different domain from the parent tab (this is a Discord security feature and applies to all Activities). 

Therefore, I put together this quick PR that adds support for using a content port to communicate with the Discord Activity version. It only uses this method if the extension detects that it's running in an Activity, otherwise it uses the current message passing method. 

The one drawback to this is the "filter to a specific tab" feature really isn't supported for the Activity (if you pick a specific tab it just won't work), but I think that's an acceptable tradeoff to get this working.

Let me know if this makes sense or if I can help work on a different approach that would work well for the extension. And thanks for providing this resource to the tabletop gaming community!