### PR TITLE
Added Beyond20_Loaded and Beyond20_NewSettings events to DnD Beyond itself

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -768,9 +768,11 @@ The DOM API is a way for Beyond20 to communicate with other extensions or websit
 
 On the D&D Beyond website itself, when rolls are made, they are sent both to VTT tabs but also as DOM events to the D&D Beyond website. The messages are in the format of `Beyond20_${request.action}` so you would expect to see `Beyond20_roll`, `Beyond20_rendered-roll`, `Beyond20-hp-update`, etc... with the `detail` field of the `CustomEvent` containing an array with a single element, which would be the request being sent.
 
-On a custom website, you receive instead the following events:
+On a custom website and on DnD Beyond itself, you receive instead the following events:
 - `Beyond20_Loaded(settings)`: This event is sent when Beyond20 is loaded onto the website. It is a good way for a website to know if Beyond20 is enabled and loaded into it
 - `Beyond20_NewSettings(settings)`: This event is sent shortly after the `Beyond20_Loaded` event and is sent whenever Beyond20 global settings are updated.
+
+On a custom website, you receive the following events:
 - `Beyond20_RenderedRoll(request)`: This event is sent with a `rendered-roll` request in it. If a `roll` message is received, the roll will first be pre-rendered (with `rendered: "fallback"` field set) and will be sent to the DOM as a `Beyond20_RenderedRoll` event too.
 - `Beyond20_UpdateHP(request)`: This event is sent with a `hp-update` request in it.
 - `Beyond20_UpdateConditions(request)`: This event is sent with a `conditions-update` request in it.

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -2576,8 +2576,10 @@ function updateSettings(new_settings = null) {
         if (settings['hotkeys-bindings']) {
             updateHotkeysList();
         }
+        sendCustomEvent("NewSettings", [settings, chrome.runtime.getURL("")]);
     } else {
         getStoredSettings((saved_settings) => {
+            sendCustomEvent("Loaded", [saved_settings]);
             updateSettings(saved_settings);
             documentModified();
         });

--- a/src/dndbeyond/content-scripts/encounter.js
+++ b/src/dndbeyond/content-scripts/encounter.js
@@ -64,9 +64,11 @@ function updateSettings(new_settings = null) {
         settings = new_settings;
         if (character !== null)
             character.setGlobalSettings(settings);
-        key_bindings = getKeyBindings(settings)
+        key_bindings = getKeyBindings(settings);
+        sendCustomEvent("NewSettings", [settings, chrome.runtime.getURL("")]);
     } else {
         getStoredSettings((saved_settings) => {
+            sendCustomEvent("Loaded", [saved_settings]);
             updateSettings(saved_settings);
             documentModified();
         });

--- a/src/dndbeyond/content-scripts/feat.js
+++ b/src/dndbeyond/content-scripts/feat.js
@@ -72,9 +72,11 @@ function updateSettings(new_settings = null) {
         settings = new_settings;
         if (character)
             character.setGlobalSettings(new_settings);
-        key_bindings = getKeyBindings(settings)
+        key_bindings = getKeyBindings(settings);
+        sendCustomEvent("NewSettings", [settings, chrome.runtime.getURL("")]);
     } else {
         getStoredSettings((saved_settings) => {
+            sendCustomEvent("Loaded", [saved_settings]);
             documentLoaded(saved_settings);
             updateSettings(saved_settings);
         });

--- a/src/dndbeyond/content-scripts/item.js
+++ b/src/dndbeyond/content-scripts/item.js
@@ -72,9 +72,11 @@ function updateSettings(new_settings = null) {
         settings = new_settings;
         if (character)
             character.setGlobalSettings(new_settings);
-        key_bindings = getKeyBindings(settings)
+        key_bindings = getKeyBindings(settings);
+        sendCustomEvent("NewSettings", [settings, chrome.runtime.getURL("")]);
     } else {
         getStoredSettings((saved_settings) => {
+            sendCustomEvent("Loaded", [saved_settings]);
             documentLoaded(saved_settings);
             updateSettings(saved_settings);
         });

--- a/src/dndbeyond/content-scripts/monster.js
+++ b/src/dndbeyond/content-scripts/monster.js
@@ -19,9 +19,11 @@ function updateSettings(new_settings = null) {
         settings = new_settings;
         if (character !== null)
             character.setGlobalSettings(settings);
-        key_bindings = getKeyBindings(settings)
+        key_bindings = getKeyBindings(settings);
+        sendCustomEvent("NewSettings", [settings, chrome.runtime.getURL("")]);
     } else {
         getStoredSettings((saved_settings) => {
+            sendCustomEvent("Loaded", [saved_settings]);
             updateSettings(saved_settings);
             documentLoaded(settings);
         });

--- a/src/dndbeyond/content-scripts/source.js
+++ b/src/dndbeyond/content-scripts/source.js
@@ -70,9 +70,11 @@ function updateSettings(new_settings = null) {
         settings = new_settings;
         if (character)
             character.setGlobalSettings(new_settings);
-        key_bindings = getKeyBindings(settings)
+        key_bindings = getKeyBindings(settings);
+        sendCustomEvent("NewSettings", [settings, chrome.runtime.getURL("")]);
     } else {
         getStoredSettings((saved_settings) => {
+            sendCustomEvent("Loaded", [saved_settings]);
             documentLoaded(saved_settings);
             updateSettings(saved_settings);
         });

--- a/src/dndbeyond/content-scripts/spell.js
+++ b/src/dndbeyond/content-scripts/spell.js
@@ -45,9 +45,11 @@ function updateSettings(new_settings = null) {
         settings = new_settings;
         if (character)
             character.setGlobalSettings(settings);
-        key_bindings = getKeyBindings(settings)
+        key_bindings = getKeyBindings(settings);
+        sendCustomEvent("NewSettings", [settings, chrome.runtime.getURL("")]);
     } else {
         getStoredSettings((saved_settings) => {
+            sendCustomEvent("Loaded", [saved_settings]);
             documentLoaded(saved_settings);
             updateSettings(saved_settings);
         });

--- a/src/dndbeyond/content-scripts/vehicle.js
+++ b/src/dndbeyond/content-scripts/vehicle.js
@@ -20,9 +20,11 @@ function updateSettings(new_settings = null) {
         settings = new_settings;
         if (character)
             character.setGlobalSettings(settings);
-        key_bindings = getKeyBindings(settings)
+        key_bindings = getKeyBindings(settings);
+        sendCustomEvent("NewSettings", [settings, chrome.runtime.getURL("")]);
     } else {
         getStoredSettings((saved_settings) => {
+            sendCustomEvent("Loaded", [saved_settings]);
             updateSettings(saved_settings);
             documentLoaded(settings);
         });


### PR DESCRIPTION
As described in #1130 all the custom events are missing on DnD Beyond itself, making it hard to interact with the DOM API when things like settings are important. Since I am not too familiar with Beyond20's code yet, I only added the event triggers for Beyond20_Loaded and Beyond20_NewSettings for now.

Let me know if something is wrong or missing!