### PR TITLE
Stop settings button overlaying tidbits DDB

### DIFF
--- a/src/extension/beyond20.css
+++ b/src/extension/beyond20.css
@@ -392,3 +392,8 @@ span.dice-roll.beyond20-tooltip-content {
 .ct-beyond20-icon {
     vertical-align: middle;
 }
+
+/* Stops Beyond20 buttons overlaying ddb tidbits */
+.ct-character-header-info .ddbc-character-tidbits {
+    min-width:auto;
+}


### PR DESCRIPTION
Fixes #1129

Overrides tidbit min-width:300px which is causing the overlap between the settings button and the tidbit section. This is happening between 768px and around 812px. Chose to use CSS override due to wanting to keep in line with DDBs general approach for styling buttons at tablet width rather than going straight down to an icon. 

Testing screenshot taken using Chrome in responsive mode at 768px wide:

<img width="498" alt="Screenshot 2024-06-05 at 20 04 34" src="https://github.com/kakaroto/Beyond20/assets/48557245/19384613-18b5-4c6b-b1a1-8662fe3c472c">
