### PR TITLE
Fixes for Saving throw, Ability, Initiative, Attacks, features and Feats

### DIFF
--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -1627,9 +1627,9 @@ async function displaySpell() {
 
 function displayFeature(paneClass) {
     const source_types = {
-        "ct-class-feature-pane": "Class",
+        "b20-class-feature-pane": "Class",
         "ct-racial-trait-pane": "Race",
-        "ct-feat-pane": "Feat"
+        "b20-feat-pane": "Feat"
     }
     const name = $(".ct-sidebar__heading").text();
     const source = $(".ct-sidebar__header-parent").text();
@@ -1777,7 +1777,7 @@ function displayPanel(paneClass) {
             return displayInfusion();
         else if (paneClass == "ct-spell-pane")
             return displaySpell();
-        else if (["ct-class-feature-pane", "ct-racial-trait-pane", "ct-feat-pane"].includes(paneClass))
+        else if (["b20-class-feature-pane", "ct-racial-trait-pane", "b20-feat-pane"].includes(paneClass))
             return displayFeature(paneClass);
         else if (paneClass == "ct-trait-pane")
             return displayTrait();
@@ -1882,7 +1882,7 @@ function injectRollButton(paneClass) {
         if (isRollButtonAdded())
             return;
         addRollButtonEx(paneClass, ".ct-sidebar__heading");
-    } else if (["ct-class-feature-pane", "ct-racial-trait-pane", "ct-feat-pane"].includes(paneClass)) {
+    } else if (["b20-class-feature-pane", "ct-racial-trait-pane", "b20-feat-pane"].includes(paneClass)) {
         if (isRollButtonAdded())
             return;
         addRollButtonEx(paneClass, ".ct-sidebar__heading", { image: false });
@@ -2539,9 +2539,7 @@ function documentModified(mutations, observer) {
     const SUPPORTED_PANES = [
         "ct-custom-skill-pane",
         "ct-skill-pane",
-        "ct-class-feature-pane",
         "ct-racial-trait-pane",
-        "ct-feat-pane",
         "ct-background-pane",
         "ct-trait-pane",
         "ct-item-pane",
@@ -2561,7 +2559,9 @@ function documentModified(mutations, observer) {
         ability: "b20-ability-pane",
         savingThrow: "b20-ability-saving-throws-pane",
         initiative: "b20-initiative-pane",
-        action: "b20-action-pane"
+        action: "b20-action-pane",
+        feat: "b20-feat-pane",
+        feature: "b20-class-feature-pane"
     }
 
     function handlePane(paneClass) {
@@ -2595,12 +2595,20 @@ function documentModified(mutations, observer) {
                 const paneClass = SPECIAL_PANES.ability;
                 markPane(sidebar, paneClass);
                 handlePane(paneClass);
-            } if (sideBarHeader.match(initRegex)) {
+            } else if (sideBarHeader.match(initRegex)) {
                 const paneClass = SPECIAL_PANES.initiative;
                 markPane(sidebar, paneClass);
                 handlePane(paneClass);
-            } if (sidebar.find("span[class*='ddbc-action-name']").length > 0) {
+            } else if (sidebar.find("span[class*='ddbc-action-name']").length > 0) {
                 const paneClass = SPECIAL_PANES.action;
+                markPane(sidebar, paneClass);
+                handlePane(paneClass);
+            } else if (sidebar.parent().find(".ct-feature-snippet--feat").length > 0) {
+                const paneClass = SPECIAL_PANES.feat;
+                markPane(sidebar, paneClass);
+                handlePane(paneClass);
+            } else if (sidebar.parent().find(".ct-feature-snippet--class").length > 0) {
+                const paneClass = SPECIAL_PANES.feature;
                 markPane(sidebar, paneClass);
                 handlePane(paneClass);
             }

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -2564,20 +2564,6 @@ function documentModified(mutations, observer) {
         action: "b20-action-pane"
     }
 
-    const ABILITIES = [
-        "strength",
-        "dexterity",
-        "constitution",
-        "intelligence",
-        "wisdom",
-        "charisma",
-    ]
-
-    const ACTIONS = [ // add more actions here when needed
-        "unarmed", // unarmed strike
-        "vampiric" // vampire fang bite
-    ]
-
     function handlePane(paneClass) {
         console.log("Beyond20: New side panel is : " + paneClass);
         injectRollButton(paneClass);
@@ -2598,21 +2584,22 @@ function documentModified(mutations, observer) {
         pane.each((_, div) => handlePane(div.className));
     } else {
         const sidebar = $(".ct-sidebar__portal .ct-sidebar__header");
+        const initRegex = /\b\w+\s\(([-+]?\d+)\)/g;
         if (sidebar.length > 0) {
             const sideBarHeader = sidebar.text().toLowerCase();
-            if (sideBarHeader.startsWith("saving")) {
+            if (sidebar.closest("svg[class*='ddbc-ability-icon']").length > 0 && sidebar.closest(".ddbc-ability-score-manager").length === 0) {
                 const paneClass = SPECIAL_PANES.savingThrow;
                 markPane(sidebar, paneClass);
                 handlePane(paneClass);
-            } else if (ABILITIES.some(ability => sideBarHeader.startsWith(ability))) {
+            } else if (sidebar.closest(".ddbc-ability-score-manager").length > 0) {
                 const paneClass = SPECIAL_PANES.ability;
                 markPane(sidebar, paneClass);
                 handlePane(paneClass);
-            } if (sideBarHeader.startsWith("initiative")) {
+            } if (sideBarHeader.match(initRegex)) {
                 const paneClass = SPECIAL_PANES.initiative;
                 markPane(sidebar, paneClass);
                 handlePane(paneClass);
-            } if (ACTIONS.some(action => sideBarHeader.startsWith(action))) {
+            } if (sidebar.find("span[class*='ddbc-action-name']").length > 0) {
                 const paneClass = SPECIAL_PANES.action;
                 markPane(sidebar, paneClass);
                 handlePane(paneClass);

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -289,10 +289,10 @@ function rollSavingThrow() {
 }
 
 function rollInitiative() {
-    let initiative = $(".ct-initiative-box__value .ddbc-signed-number, .ct-initiative-box__value span[class*='styles_numberDisplay']").text();
+    let initiative = $(".ct-combat__summary-group--initiative .integrated-dice__container, span[class*='styles_value'] span[class*='styles_numberDisplay']").text();
     let advantage = $(".ct-initiative-box__advantage").length > 0;
     if (initiative == "") {
-        initiative = $(".ct-combat-mobile__extra--initiative .ct-combat-mobile__extra-value").text();
+        initiative = $(".ct-combat-mobile__extras section div[class*='styles_value'] .integrated-dice__container span[class*='styles_numberDisplay']").text();
         advantage = $(".ct-combat-mobile__advantage").length > 0;
     }
     //console.log("Initiative " + ("with" if (advantage else "without") + " advantage ) { " + initiative);
@@ -1750,7 +1750,7 @@ async function execute(paneClass, {force_to_hit_only = false, force_damages_only
                 await rollAbilityCheck();
             else if (paneClass == "b20-ability-saving-throws-pane")
                 await rollSavingThrow();
-            else if (paneClass == "ct-initiative-pane")
+            else if (paneClass == "b20-initiative-pane")
                 await rollInitiative();
             else if (paneClass == "ct-item-pane")
                 await rollItem(false, force_to_hit_only, force_damages_only, force_versatile, spell_group);
@@ -1878,7 +1878,7 @@ function injectRollButton(paneClass) {
         "ct-skill-pane",
         "b20-ability-pane",
         "b20-ability-saving-throws-pane",
-        "ct-initiative-pane"].includes(paneClass)) {
+        "b20-initiative-pane"].includes(paneClass)) {
         if (isRollButtonAdded())
             return;
         addRollButtonEx(paneClass, ".ct-sidebar__heading");
@@ -2308,9 +2308,8 @@ function deactivateQuickRolls() {
     const spells = $(".ct-spells-spell .ct-spells-spell__action,.ddbc-spells-spell .ddbc-spells-spell__action");
     const spells_to_hit = $(".ct-spells-spell .ct-spells-spell__tohit .integrated-dice__container, .ddbc-spells-spell .ddbc-spells-spell__tohit .integrated-dice__container");
     const spells_damage = $(".ct-spells-spell .ct-spells-spell__damage .integrated-dice__container, .ddc-spells-spell .ddc-spells-spell__damage .integrated-dice__container");
-    let initiative = $(".ct-initiative-box__value .integrated-dice__container, .ct-combat-mobile__extra--initiative .ct-combat-mobile__extra-value .integrated-dice__container");
-    if (initiative.length === 0)
-        initiative = $(".ct-initiative-box__value .ddbc-signed-number, .ct-combat-mobile__extra--initiative .ct-combat-mobile__extra-value .ddbc-signed-number, .ct-initiative-box__value span[class*='styles_numberDisplay'], .ct-combat-mobile__extra--initiative .ct-combat-mobile__extra-value span[class*='styles_numberDisplay']");
+    const initiative = $(".ct-combat__summary-group--initiative div[class*='styles_value'] .integrated-dice__container, .ct-combat-tablet__extra--initiative .integrated-dice__container, .ct-combat-mobile__extras section div[class*='styles_value'] .integrated-dice__container");
+
     hideTooltipIfDestroyed();
     deactivateTooltipListeners(initiative);
     deactivateTooltipListeners(abilities);
@@ -2348,9 +2347,14 @@ function activateQuickRolls() {
         return;
 
     activateTooltipListeners(initiative, 'up', beyond20_tooltip, (el) => {
-        el.closest(".ct-initiative-box__value, .ct-combat-mobile__extra-value").trigger('click');
-        if ($(".ct-initiative-pane").length)
-            execute("ct-initiative-pane");
+        el.closest(".ct-combat__summary-group--initiative section[class*='styles_box'] div, section, div[class*='styles_label']").trigger('click');
+        
+        if(!$(".ct-sidebar__portal .ct-sidebar__header").parent().hasClass("b20-initiative-pane")) {
+            $(".ct-sidebar__portal .ct-sidebar__header").parent().addClass("b20-initiative-pane");
+        };
+
+        if ($(".b20-initiative-pane").length)
+            execute("b20-initiative-pane");
         else
             quick_roll = true;
     });
@@ -2535,7 +2539,6 @@ function documentModified(mutations, observer) {
     const SUPPORTED_PANES = [
         "ct-custom-skill-pane",
         "ct-skill-pane",
-        "ct-initiative-pane",
         "ct-class-feature-pane",
         "ct-racial-trait-pane",
         "ct-feat-pane",
@@ -2557,7 +2560,8 @@ function documentModified(mutations, observer) {
 
     const SPECIAL_PANES = {
         ability: "b20-ability-pane",
-        savingThrow: "b20-ability-saving-throws-pane"
+        savingThrow: "b20-ability-saving-throws-pane",
+        initiative: "b20-initiative-pane"
     }
 
     const ABILITIES = [
@@ -2593,6 +2597,12 @@ function documentModified(mutations, observer) {
             handlePane(paneClass);
         } else if (ABILITIES.some(ability => sideBarHeader.startsWith(ability))) {
             const paneClass = SPECIAL_PANES.ability;
+            if (!sidebar.parent().hasClass(paneClass)) {
+                sidebar.parent().addClass(paneClass);
+            }
+            handlePane(paneClass);
+        } if (sideBarHeader.startsWith("initiative")) {
+            const paneClass = SPECIAL_PANES.initiative;
             if (!sidebar.parent().hasClass(paneClass)) {
                 sidebar.parent().addClass(paneClass);
             }


### PR DESCRIPTION
First time doing a fix like this, hmmm there was not much we could do (that i could see) with the fact that DNDBEYOND team removed the class names from the panes saving throw and ability panes. 

So .... 

To minimise the code changes I added a class name that doesn't exist, I changed the "ct" to "b20" and modified all the code to support that, Including the injection on the document modified event.

The code i pushing works on chrome, I have not tested on other browsers.

If there is any problems or you wish not accept this pull request, it is oke, "I am not married to it".

I would not normally make changes like this, just havent had much practice with this front end stuff is a while.

Some other things can be optimised also.

Fixes; https://github.com/kakaroto/Beyond20/issues/1140 and https://github.com/kakaroto/Beyond20/issues/1145 and https://github.com/kakaroto/Beyond20/issues/1146 and https://github.com/kakaroto/Beyond20/issues/1148 and https://github.com/kakaroto/Beyond20/issues/1149 and on https://github.com/kakaroto/Beyond20/issues/1150 and https://github.com/kakaroto/Beyond20/issues/1152 and https://github.com/kakaroto/Beyond20/issues/1153