### PR TITLE
Fix for Missing Class features

### DIFF
--- a/src/dndbeyond/base/character.js
+++ b/src/dndbeyond/base/character.js
@@ -222,7 +222,7 @@ class Character extends CharacterBase {
     }
 
     featureDetailsToList(selector, name) {
-        const features = $(selector).find(".ct-feature-snippet > .ct-feature-snippet__heading");
+        const features = $(selector).find(".ct-feature-snippet--class > div[class*='styles_heading']");
         const feature_list = [];
         for (let feat of features.toArray()) {
             const feat_name = feat.childNodes[0].textContent.trim();

--- a/src/dndbeyond/base/character.js
+++ b/src/dndbeyond/base/character.js
@@ -222,7 +222,7 @@ class Character extends CharacterBase {
     }
 
     featureDetailsToList(selector, name) {
-        const features = $(selector).find(".ct-feature-snippet--class > div[class*='styles_heading']");
+        const features = $(selector).find(".ct-feature-snippet > .ct-feature-snippet__heading, .ct-feature-snippet--class > div[class*='styles_heading'], .ct-feature-snippet--racial-trait > div[class*='styles_heading'], .ct-feature-snippet--feat > div[class*='styles_heading']")
         const feature_list = [];
         for (let feat of features.toArray()) {
             const feat_name = feat.childNodes[0].textContent.trim();
@@ -256,7 +256,7 @@ class Character extends CharacterBase {
             this._class_features = this.getSetting("class-features", []);
         }
 
-        const race_detail = $(".ct-features .ct-race-detail");
+        const race_detail = $(".ct-features .ct-content-group:has(.ct-feature-snippet--racial-trait)");
         if (race_detail.length > 0) {
             this._racial_traits = this.featureDetailsToList(race_detail, "Racial Traits");
             if (!isListEqual(this._racial_traits, this.getSetting("racial-traits", []))) {


### PR DESCRIPTION
Added fix for https://github.com/kakaroto/Beyond20/issues/1164

Tested in chrome, and mobile, tablet and desktop layouts

After changes code now correctly shows the Genie Wrath and class features are populated (Needs verifying ALL features are working, will look into on another piece of work)

Feature now Shows on list
![image](https://github.com/user-attachments/assets/bd4b5f4d-3ef5-4cf4-86be-86335bfbfedf)

And it is applied correctly
![image](https://github.com/user-attachments/assets/96cedfa4-0e8c-4c41-8683-5951b62ab6d2)

These might be affect (need further testing:

Protector Aasimar: Radiant Soul Damage
MotM Aasimar: Radiant Soul Damage
Cleric: Blessed Strikes
Ranger: Favored Foe
Ranger: Gathered Swarm
Warlock: The Hexblade: Hexblade's Curse
Warlock: The Undead: Grave Touched
Artificer: Battlemaster: Arcane Jolt
Barbarian: Path of the Zealot: Divine Fury
Bard: College of Whispers: Psychic blades
Bloodhunter: Crimson Rite
Cleric: Divine Strike
Fighter: Giant’s Might;
Paladin: Sacred Weapon
Ranger: Gloom Stalker: Dread Ambusher
Ranger: Hunter: Colossus Slayer
Ranger: Monster Slayer: Slayer's Prey
Ranger: Horizon Walker: Planar Warrior
Ranger: Fey Wanderer: Dreadful Strikes
Rogue: Sneak Attack
Warlock: Eldritch Invocation: Lifedrinker

