### PR TITLE
added support for Sorcerous Burst Dmg type selection like Chromatic Orb

### DIFF
--- a/src/common/roll_renderer.js
+++ b/src/common/roll_renderer.js
@@ -625,6 +625,8 @@ class Beyond20RollRenderer {
                         if (mods.length > 1 && selectedModifier === null) {
                             const result = await this.queryGeneric("Spellcasting Ability Modifier", "Burst Ability Modifier", mods);
                             selectedModifier = (result !== null) ? mods[result] : mods[0]; // Use first one if not selected.
+                        } else { 
+                            selectedModifier = mods[0];
                         }
 
                         const modifier = parseInt(request.character.spell_modifiers[selectedModifier]);

--- a/src/common/roll_renderer.js
+++ b/src/common/roll_renderer.js
@@ -610,48 +610,50 @@ class Beyond20RollRenderer {
                     }
                 }
             } else if (request.name.includes("Sorcerous Burst")) {
-                const mods = Object.keys(request.character.spell_modifiers);
+                const mods = request.character.spell_modifiers;
+                const hasSorcerer = Object.keys(mods).some(x => x.toLowerCase() === "sorcerer");
                 let burstRollsLeft = 0;
                 let burstRollCount = 0;
                 let selectedModifier = null;
-                for (let [i, dmg_roll] of damage_rolls.entries()) {
-                    const [dmg_type, roll, flags] = dmg_roll;
-                    const faces = parseInt(roll.dice[0].faces);
-                    const burstCount = roll.dice[0].rolls.filter(x => x.roll === faces).length; // Count how many max rolls occurred
 
-                    if (burstCount > 0) {
-                        burstRollCount++;
-                        // Prompt for the ability modifier if needed (only if there are multiple options)
-                        if (mods.length > 1 && selectedModifier === null) {
-                            const result = await this.queryGeneric("Spellcasting Ability Modifier", "Burst Ability Modifier", mods);
-                            selectedModifier = (result !== null) ? mods[result] : mods[0]; // Use first one if not selected.
-                        } else { 
-                            selectedModifier = mods[0];
-                        }
-
-                        const modifier = parseInt(request.character.spell_modifiers[selectedModifier]);
-                        burstRollsLeft = (burstRollsLeft != 0) ? burstRollsLeft : modifier; // Set burstRollsLeft to the modifier value if not already set
-                        
-                        // Calculate how many rolls are allowed for the burst (delta)
-                        const delta = Math.min(burstCount, burstRollsLeft); // Only allow as many burst rolls as available in burstRollsLeft
-                        
-                        // Reduce burstRollsLeft by delta, ensuring it doesn't go below zero
-                        burstRollsLeft -= delta;
-
-                        // Perform the burst rolls if delta > 0
-                        if (delta > 0 && burstRollsLeft >= 0) {
-                            const burstRoll = this._roller.roll(delta + "d" + faces); // Roll delta number of dice
-                            burstRoll.setRollType("damage"); // Set the roll type to damage
-
-                            // Add the burst damage roll to the damage rolls array
-                            damage_rolls.push([`Burst (${burstRollCount})`, burstRoll, DAMAGE_FLAGS.ADDITIONAL]);
-
-                            // Handle critical damage for burst rolls if applicable
-                            critical_damages.push(...damagesToCrits(character, [burstRoll._formula]));
-                            critical_damage_types.push(`Burst (${burstRollCount})`);
-
-                            // Resolve the burst roll
-                            await this._roller.resolveRolls(request.name, [burstRoll], request);
+                const faces = parseInt(damage_rolls[0][1].dice[0].faces);
+                const initialBurstCount = damage_rolls[0][1].dice[0].rolls.filter(x => x.roll === faces).length;
+                
+                if (initialBurstCount > 0) {
+                    // Determine the selected modifier, prompt only if multiple options and no sorcerer
+                    if (!hasSorcerer && Object.keys(mods).length > 1) {
+                        const result = await this.queryGeneric("Spellcasting Ability Modifier", "Burst Ability Modifier", Object.keys(mods));
+                        selectedModifier = result !== null ? Object.keys(mods)[result] : Object.keys(mods)[0];
+                    } else {
+                        selectedModifier = Object.keys(mods)[0];
+                    }
+                
+                    const modifier = parseInt(mods[selectedModifier]);
+                    burstRollsLeft = modifier;
+                
+                    for (let i = 0; i < damage_rolls.length; i++) {
+                        const [dmg_type, roll] = damage_rolls[i];
+                
+                        if (i === 0 || dmg_type.startsWith("Burst")) {
+                            const burstCount = roll.dice[0].rolls.filter(x => x.roll === faces).length;
+                
+                            if (burstCount > 0) {
+                                burstRollCount++;
+                                const delta = Math.min(burstCount, burstRollsLeft);
+                                burstRollsLeft = Math.max(0, burstRollsLeft - delta); // Ensure non-negative burstRollsLeft
+                
+                                if (delta > 0) {
+                                    const burstRoll = this._roller.roll(`${delta}d${faces}`);
+                                    burstRoll.setRollType("damage");
+                
+                                    damage_rolls.push([`Burst (${burstRollCount})`, burstRoll, DAMAGE_FLAGS.ADDITIONAL]);
+                
+                                    critical_damages.push(...damagesToCrits(character, [burstRoll._formula]));
+                                    critical_damage_types.push(`Burst (${burstRollCount})`);
+                
+                                    await this._roller.resolveRolls(request.name, [burstRoll], request);
+                                }
+                            }
                         }
                     }
                 }

--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -183,6 +183,9 @@ async function buildAttackRoll(character, attack_source, name, description, prop
         if (roll_properties.name === "Chromatic Orb") {
             const choice = await queryDamageTypeFromArray(roll_properties.name, damages, damage_types, ["Acid", "Cold", "Fire", "Lightning", "Poison", "Thunder"]);
             if (choice === null) return null; // Query was cancelled;
+        } else if (roll_properties.name === "Sorcerous Burst") {
+            const choice = await queryDamageTypeFromArray(roll_properties.name, damages, damage_types, ["Acid", "Cold", "Fire", "Lightning", "Poison", "Psychic", "Thunder"]);
+            if (choice === null) return null; // Query was cancelled;
         } else if (roll_properties.name === "Dragon's Breath") {
             const choice = await queryDamageTypeFromArray(roll_properties.name, damages, damage_types, ["Acid", "Cold", "Fire", "Lightning", "Poison"]);
             if (choice === null) return null; // Query was cancelled;


### PR DESCRIPTION
Does not include Burst aspect yet

Related to -> https://github.com/kakaroto/Beyond20/issues/1163

![image](https://github.com/user-attachments/assets/00f4772f-f302-499e-a846-7f99778b3569)

There is an issue with dnd beyond that they are not setting the DMG types properly for high level characters.

![image](https://github.com/user-attachments/assets/7118a041-5daa-44c8-9b83-821778b53a67)

So this PR will need to wait until it is done, dnd beyond needs to sort out their end or we have to write some code to circumvent this 

Created a forum post for this -> https://www.dndbeyond.com/forums/d-d-beyond-general/bugs-support/206716-new-spell-sorcerous-burst-dmg-types-are-incorrect
