### PR TITLE
added support to the HOMEBREW_MAX crit rules

### DIFF
--- a/src/common/roll_renderer.js
+++ b/src/common/roll_renderer.js
@@ -649,10 +649,12 @@ class Beyond20RollRenderer {
                 const sorcererMod = Object.keys(mods).find(x => x.toLowerCase() === "sorcerer");
                 const mainDamage = damage_rolls.find((roll) => roll[2] === DAMAGE_FLAGS.REGULAR);
                 const critDamage = damage_rolls.find((roll) => roll[2] === (DAMAGE_FLAGS.REGULAR | DAMAGE_FLAGS.CRITICAL));
+                const critRule = parseInt(character.getGlobalSetting("critical-homebrew", CriticalRules.PHB));
+                const doubleForCrit = is_critical && [CriticalRules.PHB, CriticalRules.HOMEBREW_REROLL, CriticalRules.HOMEBREW_MOD].includes(critRule);
 
                 const faces = parseInt(mainDamage[1].dice[0].faces);
                 let burstCount = mainDamage[1].dice[0].rolls.filter(x => x.roll === faces).length;
-                if (critDamage) {
+                if (critRule !== CriticalRules.HOMEBREW_MAX && critDamage) {
                     burstCount += critDamage[1].dice[0].rolls.filter(x => x.roll === faces).length;
                 }
                 
@@ -664,10 +666,7 @@ class Beyond20RollRenderer {
                         selectedModifier = result !== null ? Object.keys(mods)[result] : Object.keys(mods)[0];
                     }
                     let burstRollsLeft = parseInt(mods[selectedModifier]);
-
-                    const critRule = parseInt(character.getGlobalSetting("critical-homebrew", CriticalRules.PHB));
-                    const doubleForCrit = is_critical && [CriticalRules.PHB, CriticalRules.HOMEBREW_REROLL, CriticalRules.HOMEBREW_MOD].includes(critRule);
-
+          
                     const rollBurstDamage = async (burst) => {
                         if (burstRollsLeft <= 0) {
                             return [];

--- a/src/common/roll_renderer.js
+++ b/src/common/roll_renderer.js
@@ -686,8 +686,21 @@ class Beyond20RollRenderer {
                     }
                     const burstRolls = await rollBurstDamage(burstCount);
                     let burstRollCount = 1;
+                    let burstCriticalAmount = 0;
                     for (let burstRoll of burstRolls) {
                         damage_rolls.push([`Burst (${burstRollCount++})`, burstRoll, DAMAGE_FLAGS.ADDITIONAL]);
+                        // Accumulate critical damage if needed
+                        if (is_critical && critRule === CriticalRules.HOMEBREW_MAX) {
+                            burstCriticalAmount += burstRoll.dice.reduce((sum, die) => sum + (die.amount * die.faces), 0);
+                        }
+                    }
+
+                    // Handle critical burst damage roll if needed
+                    if(is_critical && critRule === CriticalRules.HOMEBREW_MAX && burstCriticalAmount > 0) {
+                        const criticalRoll = this._roller.roll(burstCriticalAmount.toString());
+                        criticalRoll.setRollType("critical-damage");
+                        damage_rolls.push([`Burst Critical`, criticalRoll, DAMAGE_FLAGS.ADDITIONAL | DAMAGE_FLAGS.CRITICAL]);
+                        await this._roller.resolveRolls(request.name, [criticalRoll], request);
                     }
                 }
             }


### PR DESCRIPTION
Error when using Perfect Rolls
![image](https://github.com/user-attachments/assets/983a07c8-9e1c-4bc5-b403-af859fe36f7b)

@kakaroto Hi just did some test today and noticed that the refactor was erroring with Perfect Roll Crit rule, So I patched that by moving the code below to the beginning of the main `if` statement. I also noticed that Bursts are not getting included on the crit section, you double the roll if it is a crit which its fine all works out in the end, It might confuse people XD. Perfect Rolls need to be added to the Crit since they are not included in the doubled calculation should we add to the burst result or to crit?

```
const critRule = parseInt(character.getGlobalSetting("critical-homebrew", CriticalRules.PHB));
const doubleForCrit = is_critical && [CriticalRules.PHB, CriticalRules.HOMEBREW_REROLL, CriticalRules.HOMEBREW_MOD].includes(critRule);

```
Standard Crit Rule the Burst is not included on the Crit is that intended?
![image](https://github.com/user-attachments/assets/ba3cc949-8463-4a6c-9dfb-934ae4bd5497)

Homebrew MAX rolls
![image](https://github.com/user-attachments/assets/d1ec5ead-418d-45cb-9cca-f7e3b88709f8)