### PR TITLE
added support to 2024 Great Weapon Master and Sharpshooter and small bug fixes

### DIFF
--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -755,7 +755,7 @@ const character_settings = {
         "title": "Feat: Great Weapon Master 2024 (Apply to next roll only)",
         "description": "Heavy Weapon Mastery. Apply extra damage equals your Proficiency Bonus.",
         "type": "bool",
-        "default": false
+        "default": true
     },
     "sharpshooter": {
         "title": "Feat: Sharpshooter (Apply to next roll only)",

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -751,6 +751,12 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+    "great-weapon-master-2024": {
+        "title": "Feat: Great Weapon Master 2024 (Apply to next roll only)",
+        "description": "Heavy Weapon Mastery. Apply extra damage equals your Proficiency Bonus.",
+        "type": "bool",
+        "default": false
+    },
     "sharpshooter": {
         "title": "Feat: Sharpshooter (Apply to next roll only)",
         "description": "Apply Sharpshooter -5 penalty to roll and +10 to damage",

--- a/src/dndbeyond/base/character.js
+++ b/src/dndbeyond/base/character.js
@@ -225,8 +225,9 @@ class Character extends CharacterBase {
         const features = $(selector).find(".ct-feature-snippet > .ct-feature-snippet__heading, .ct-feature-snippet--class > div[class*='styles_heading'], .ct-feature-snippet--racial-trait > div[class*='styles_heading'], .ct-feature-snippet--feat > div[class*='styles_heading']")
         const feature_list = [];
         for (let feat of features.toArray()) {
-            const feat_reference = $(feat).parent().find("span[class*='styles_metaItem'] > p[class*='styles_reference'] > span[class*='styles_name']");
-            const feat_name = this.getFeatureVersionName(feat.childNodes[0].textContent.trim(), feat_reference.length > 0 ? feat_reference[0].textContent.trim() : undefined);
+            const feat_reference = $(feat).parent().find("span[class*='styles_metaItem'] > p[class*='styles_reference'] > span[class*='styles_name']").eq(0).text();
+            const feat_base_name = feat.childNodes[0].textContent.trim()
+            const feat_name = this.getFeatureVersionName(feat_base_name, feat_reference);
             feature_list.push(feat_name);
             const options = $(feat).parent().find(".ct-feature-snippet__option > .ct-feature-snippet__heading");
             for (let option of options.toArray()) {

--- a/src/dndbeyond/base/character.js
+++ b/src/dndbeyond/base/character.js
@@ -225,17 +225,37 @@ class Character extends CharacterBase {
         const features = $(selector).find(".ct-feature-snippet > .ct-feature-snippet__heading, .ct-feature-snippet--class > div[class*='styles_heading'], .ct-feature-snippet--racial-trait > div[class*='styles_heading'], .ct-feature-snippet--feat > div[class*='styles_heading']")
         const feature_list = [];
         for (let feat of features.toArray()) {
-            const feat_name = feat.childNodes[0].textContent.trim();
+            const feat_reference = $(feat).parent().find("span[class*='styles_metaItem'] > p[class*='styles_reference'] > span[class*='styles_name']");
+            const feat_name = this.getFeatureVersionName(feat.childNodes[0].textContent.trim(), feat_reference.length > 0 ? feat_reference[0].textContent.trim() : undefined);
             feature_list.push(feat_name);
             const options = $(feat).parent().find(".ct-feature-snippet__option > .ct-feature-snippet__heading");
             for (let option of options.toArray()) {
                 const option_name = option.childNodes[0].textContent.trim();
                 feature_list.push(feat_name + ": " + option_name);
             }
+            const choices = $(feat).parent().find(".ct-feature-snippet__choices .ct-feature-snippet__choice");
+            if (choices.length > 0) {
+                for (const choice of choices.toArray()) {
+                    const choiceText = descriptionToString(choice);
+                    feature_list.push(feat_name + ": " + choiceText);
+                }
+            }            
         }
 
         //console.log(name, feature_list);
         return feature_list;
+    }
+
+    getFeatureVersionName(feat_name, feat_reference) {
+        if (!feat_reference) return feat_name;
+        if((feat_name.toLowerCase() === "great weapon master" ||
+            feat_name.toLowerCase() === "sharpshooter") && 
+            feat_reference.toLowerCase().includes("2024")) {
+            return `${feat_name} 2024`; // just using something set by us so if it changes in the future we dont care
+        } else {
+            return feat_name;
+        }
+        
     }
 
     updateFeatures() {

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -443,7 +443,7 @@ function handleSpecialMeleeAttacks(damages=[], damage_types=[], properties, sett
     }
 
     if (to_hit !== null && 
-        character.getSetting("great-weapon-master-2024", false) &&
+        character.getSetting("great-weapon-master-2024", true) &&
         character.hasFeat("Great Weapon Master 2024") &&
         (properties["Properties"] && properties["Properties"].includes("Heavy") ||
         action_name.includes("Polearm Master")) &&
@@ -451,7 +451,6 @@ function handleSpecialMeleeAttacks(damages=[], damage_types=[], properties, sett
         const proficiency = parseInt(character._proficiency);
         damages.push(proficiency.toString());
         damage_types.push("Great Weapon Master");
-        settings_to_change["great-weapon-master-2024"] = false;
     }
 
 

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -442,6 +442,19 @@ function handleSpecialMeleeAttacks(damages=[], damage_types=[], properties, sett
         settings_to_change["great-weapon-master"] = false;
     }
 
+    if (to_hit !== null && 
+        character.getSetting("great-weapon-master-2024", false) &&
+        character.hasFeat("Great Weapon Master 2024") &&
+        (properties["Properties"] && properties["Properties"].includes("Heavy") ||
+        action_name.includes("Polearm Master")) &&
+        properties["Proficient"] == "Yes") {
+        const proficiency = parseInt(character._proficiency);
+        damages.push(proficiency.toString());
+        damage_types.push("Great Weapon Master");
+        settings_to_change["great-weapon-master-2024"] = false;
+    }
+
+
     // Charger Feat
     if (character.hasFeat("Charger") &&
         character.getSetting("charger-feat")) {

--- a/src/extension/popup.js
+++ b/src/extension/popup.js
@@ -145,6 +145,10 @@ function populateCharacter(response) {
             e = createHTMLOption("great-weapon-master", false, character_settings);
             options.append(e);
         }
+        if (response["feats"].includes("Great Weapon Master 2024")) {
+            e = createHTMLOption("great-weapon-master-2024", false, character_settings);
+            options.append(e);
+        }
         if (response["class-features"].includes("Rage")) {
             e = createHTMLOption("barbarian-rage", false, character_settings);
             options.append(e);


### PR DESCRIPTION
added support for 2024 versions of feats, added settings, and fixed features options and choices as they not getting caught.

Adds more fixes for https://github.com/kakaroto/Beyond20/issues/1164

Great Weapon master 2024
![image](https://github.com/user-attachments/assets/15264148-455d-43ce-aa97-0efa96797f6a)

New setttings
![image](https://github.com/user-attachments/assets/53a9fa2e-472d-464b-884d-85ffee7b1094)

Sharpshooter 2024
![image](https://github.com/user-attachments/assets/d0720479-6813-4b56-b798-0f13db768f45)

Sharpshooter no longer gives extra damage
```
General Feat (Prerequisite: Level 4+, Dexterity 13+)

You gain the following benefits.

Ability Score Increase. Increase your Dexterity score by 1, to a maximum of 20.

Bypass Cover. Your ranged attacks with weapons ignore [Half Cover](https://www.dndbeyond.com/sources/basic-rules/combat#Cover) and [Three-Quarters Cover](https://www.dndbeyond.com/sources/basic-rules/combat#Cover).

Firing in Melee. Being within 5 feet of an enemy doesn’t impose Disadvantage on your attack rolls with Ranged weapons.

Long Shots. Attacking at long range doesn’t impose Disadvantage on your attack rolls with Ranged weapons.
```

sharpshooter 2014
![image](https://github.com/user-attachments/assets/37b323d7-8f76-4c66-9cd7-dd0dbc8df7be)

great weapon master 2014
![image](https://github.com/user-attachments/assets/cd594962-983c-4756-8dfa-3e1391e2c23d)

For funs BOTH versions of the feat together!!!
![image](https://github.com/user-attachments/assets/b6316be4-798e-4c42-829a-2abe12cbfdbc)

Add choices support in addition to options which i think they changed it abd broken the features removing s bunch of things from the features list so now they all show where available

![image](https://github.com/user-attachments/assets/82a5a1fa-4747-4f9b-97bd-b684efaa220b)


