### PR TITLE
added small change to fix items / weapon rolls

### DIFF
--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -750,7 +750,7 @@ async function rollItem(force_display = false, force_to_hit_only = false, force_
     const properties = propertyListToDict(prop_list);
     properties["Properties"] = properties["Properties"] || "";
     //console.log("Properties are : " + String(properties));
-    const item_name = $(".ct-item-pane .ct-sidebar__heading .ct-item-name,.ct-item-pane .ct-sidebar__heading .ddbc-item-name")[0].firstChild.textContent;
+    const item_name = $(".ct-item-pane .ct-sidebar__heading span[class*='styles_itemName'],.ct-item-pane .ct-sidebar__heading .ddbc-item-name")[0].firstChild.textContent;
     const item_type = $(".ct-item-detail__intro").text();
     const item_tags = $(".ct-item-detail__tags-list .ct-item-detail__tag").toArray().map(elem => elem.textContent);
     const item_customizations = $(".ct-item-pane .ct-item-detail__class-customize-item .ddbc-checkbox--is-enabled .ddbc-checkbox__label").toArray().map(e => e.textContent);


### PR DESCRIPTION
they added styled components to the name of the items so the selector was not finding it.

FIXES - > https://github.com/kakaroto/Beyond20/issues/1174, https://github.com/kakaroto/Beyond20/issues/1176

Error
![image](https://github.com/user-attachments/assets/2b9cc061-4029-4fae-b9fb-d9ca8711d004)

HTML
![image](https://github.com/user-attachments/assets/9666910d-26cd-40a3-92eb-ae96ad59ce0c)

Fix
![image](https://github.com/user-attachments/assets/32ddb19b-fb12-49e1-a9b4-ad2f70b3a5bc)

Foundry
![image](https://github.com/user-attachments/assets/d24358b9-7c29-4eb3-a93e-a7992961bace)

Roll20
![image](https://github.com/user-attachments/assets/57f57146-42fb-4bbb-9f70-9c210410ef6a)
