### PR TITLE
added additional selectors to fix the find to hit issue

### DIFF
--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -767,12 +767,12 @@ async function rollItem(force_display = false, force_to_hit_only = false, force_
         force_display = true;
     }
     if (!force_display && Object.keys(properties).includes("Damage")) {
-        const item_full_name = $(".ct-item-pane .ct-sidebar__heading .ct-item-name,.ct-item-pane .ct-sidebar__heading .ddbc-item-name").text();
+        const item_full_name = $(".ct-item-pane .ct-sidebar__heading .ct-item-name,.ct-item-pane .ct-sidebar__heading .ddbc-item-name, .ct-item-pane .ct-sidebar__heading span[class*='styles_itemName']").text();
         let to_hit = properties["To Hit"] !== undefined && properties["To Hit"] !== "--" ? properties["To Hit"] : null;
         const settings_to_change = {}
 
         if (to_hit === null)
-            to_hit = findToHit(item_full_name, ".ct-combat-attack--item,.ddbc-combat-attack--item", ".ct-item-name,.ddbc-item-name", ".ct-combat-attack__tohit,.ddbc-combat-attack__tohit");
+            to_hit = findToHit(item_full_name, ".ct-combat-attack--item,.ddbc-combat-attack--item", ".ct-item-name,.ddbc-item-name,span[class*='styles_itemName']", ".ct-combat-attack__tohit,.ddbc-combat-attack__tohit");
 
         if (to_hit !== null)
             character._cacheToHit(item_full_name, to_hit);


### PR DESCRIPTION
This fixes an Issue found by **Knightfyre** from Discord

**Knightfyre** — _Today at 08:08_
Upon further testing, it seems that what it is actually doing is applying whatever the total Attack Roll Modifier is for the first/top weapon in the HIT/DC list to ALL weapon attack rolls below it.
When I have a Club that uses STR as the modifier for attack rolls as the first weapon in my list of Attack options, it applies STR  + Proficiency Bonus as the total modifier for attack rolls made with the Club and ALL weapons listed below it.
If I check the box on the Club to designate it as my Pact Weapon, it then correctly applies CHA + Proficiency to the attack rolls for the Club; however, it now applies CHA + Proficiency as the total modifier to the attack rolls of all subsequent weapons in the list.
If I unequip the Club, removing it from the list of Attack options, the weapon at the top of the list is "Crossbow, hand".  It now correctly applies DEX + Proficiency for all attack rolls made with it... but, DEX + Proficiency is now being applied to the attack rolls of every other weapon below that in the list.
If the first weapon in the list is one that I am not proficient with, my Proficiency Bonus is not applied for attack rolls made with that weapon or any other weapon in the list below that. If I am proficient with that first weapon, my Proficiency Bonus is applied to the attack rolls for all weapons in the list.

NOTE: This only seems to be affecting attack rolls made for weapons — attack rolls for Spells and Unarmed Strikes do not appear to be affected by this bug. 

---------------

The selector that is used in the findtohit method needed to be updated since the dndbeyond also changed item names again on the action list. styledcomponent issue.

![image](https://github.com/user-attachments/assets/3ceaec5b-fdc5-4d5d-9e4e-3c0899f8c9ec)

Added the styles item name to the selector, and now all works.