### PR TITLE
fixed Great Weapon Fighting, Great Weapon Master and Polearm Master …

### DIFF
--- a/src/dndbeyond/base/character.js
+++ b/src/dndbeyond/base/character.js
@@ -227,7 +227,7 @@ class Character extends CharacterBase {
         for (let feat of features.toArray()) {
             const feat_reference = $(feat).parent().find("span[class*='styles_metaItem'] > p[class*='styles_reference'] > span[class*='styles_name']").eq(0).text();
             const feat_base_name = feat.childNodes[0].textContent.trim()
-            const feat_name = this.getFeatureVersionName(feat_base_name, feat_reference);
+            const [feat_name, is2024] = this.getFeatureVersionName(feat_base_name, feat_reference);
             feature_list.push(feat_name);
             const options = $(feat).parent().find(".ct-feature-snippet__option > .ct-feature-snippet__heading");
             for (let option of options.toArray()) {
@@ -238,7 +238,8 @@ class Character extends CharacterBase {
             if (choices.length > 0) {
                 for (const choice of choices.toArray()) {
                     const choiceText = descriptionToString(choice);
-                    feature_list.push(feat_name + ": " + choiceText);
+                    if (is2024) feature_list.push(feat_name + ": " + `${choiceText} 2024`);
+                    else feature_list.push(feat_name + ": " + choiceText);
                 }
             }            
         }
@@ -249,14 +250,20 @@ class Character extends CharacterBase {
 
     getFeatureVersionName(feat_name, feat_reference) {
         if (!feat_reference) return feat_name;
+        let is2024 = false;
         if((feat_name.toLowerCase() === "great weapon master" ||
-            feat_name.toLowerCase() === "sharpshooter") && 
+            feat_name.toLowerCase() === "sharpshooter" ||
+            feat_name.toLowerCase() === "polearm master") && 
             feat_reference.toLowerCase().includes("2024")) {
-            return `${feat_name} 2024`; // just using something set by us so if it changes in the future we dont care
-        } else {
-            return feat_name;
+                is2024 = true;
+        } else if ((feat_name.toLowerCase() === "fighting style" ||
+            feat_name.toLowerCase() === "great weapon fighting") &&
+            feat_reference.toLowerCase().includes("free-rules")) {
+                is2024 = true;
         }
-        
+
+        if (is2024) return [`${feat_name} 2024`, is2024]; // just using something set by us so if it changes in the future we dont care
+        else return [feat_name, is2024];
     }
 
     updateFeatures() {

--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -284,7 +284,8 @@ async function buildAttackRoll(character, attack_source, name, description, prop
                         crit_damages.push(damagesToCrits(character, [brutal_dmg])[0]);
                     } else {
                         // Apply great weapon fighting to brutal damage dice
-                        if ((character.hasClassFeature("Great Weapon Fighting", true) || character.hasFeat("Great Weapon Fighting", true)) &&
+                        // TODO need to support 2024 version for GWF and Polearm Master (action name is pole strike now) and feats can be mixed
+                        if ((character.hasClassFeature("Great Weapon Fighting", false) || character.hasFeat("Great Weapon Fighting", false)) &&
                             ((properties["Attack Type"] == "Melee" &&
                             ((properties["Properties"].includes("Versatile") && character.getSetting("versatile-choice") != "one") || properties["Properties"].includes("Two-Handed"))) ||
                             name == "Polearm Master - Bonus Attack")) {

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -2632,13 +2632,14 @@ function documentModified(mutations, observer) {
             // the page is modified, giving us enoguh time to catch "Initiative" string and add the class name
             // to the div, before the text gets translated
             const initRegex = /\bInitiative\s\(([-+]?\d+)\)/i;
-            if (sidebar.parent().find(".ddbc-ability-score-manager").length > 0) {
+            if (sidebar.parent().find("svg[class*='ddbc-ability-icon']").length > 0 && sidebar.find("div[class*='styles_interactive']").length === 0) { // not saving throw
                 const paneClass = SPECIAL_PANES.ability;
                 markPane(sidebar, paneClass);
                 handlePane(paneClass);
-            } else if (sidebar.find("svg[class*='ddbc-ability-icon']").length > 0) {
+            } else if (sidebar.parent().find("svg[class*='ddbc-ability-icon']").length > 0 && sidebar.find("div[class*='styles_interactive']").length > 0) {
                 // Saving throws have no specific class, but the preview icon has the ddbc-ability-icon class
                 // so we can use that to detect saving throws (excluding ability scores, already handled above)
+                // Also checking for saving throws text bit exist since dndbeyond added that.
                 const paneClass = SPECIAL_PANES.savingThrow;
                 markPane(sidebar, paneClass);
                 handlePane(paneClass);

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -791,7 +791,7 @@ async function rollItem(force_display = false, force_to_hit_only = false, force_
                 let damage_type = properties["Damage Type"] || "";
                 let versatile_damage = value.find(".ct-item-detail__versatile-damage,.ddbc-item-detail__versatile-damage").text().slice(1, -1);
                 if (damages.length == 0 &&
-                    ((character.hasClassFeature("Great Weapon Fighting", false) || character.hasFeat("Great Weapon Fighting", false)) &&
+                    ((character.hasClassFeature("Fighting Style: Great Weapon Fighting", false)) &&
                     (!character.hasClassFeature("Great Weapon Fighting 2024", false) || !character.hasFeat("Great Weapon Fighting 2024", false))) &&
                     properties["Attack Type"] == "Melee" &&
                     (properties["Properties"].includes("Versatile") || properties["Properties"].includes("Two-Handed"))) {
@@ -864,7 +864,7 @@ async function rollItem(force_display = false, force_to_hit_only = false, force_
                         if (dmg_info != "")
                             dmg_type += " (" + dmg_info + ")";
 
-                        if (((character.hasClassFeature("Great Weapon Fighting", false) || character.hasFeat("Great Weapon Fighting", false)) && 
+                        if (((character.hasClassFeature("Fighting Style: Great Weapon Fighting", false)) && 
                             (!character.hasClassFeature("Great Weapon Fighting 2024", false) || !character.hasFeat("Great Weapon Fighting 2024", false))) &&
                             properties["Attack Type"] == "Melee" &&
                             (properties["Properties"].includes("Two-Handed") ||
@@ -1160,11 +1160,11 @@ async function rollAction(paneClass, force_to_hit_only = false, force_damages_on
         // Polearm master bonus attack using the other end of the polearm is considered a melee attack.
         // check for both versions
         if (action_name.includes("Polearm Master") && 
-            ((character.hasClassFeature("Great Weapon Fighting", false) || character.hasFeat("Great Weapon Fighting", false)) && 
+            ((character.hasClassFeature("Fighting Style: Great Weapon Fighting", false)) && 
             (!character.hasClassFeature("Great Weapon Fighting 2024", false) || !character.hasFeat("Great Weapon Fighting 2024", false)))) {
             damages[0] = damages[0].replace(/[0-9]*d[0-9]+/g, "$&ro<=2");
         } else if (action_name.includes("Polearm Master") && 
-        ((!character.hasClassFeature("Great Weapon Fighting", false) || !character.hasFeat("Great Weapon Fighting", false)) && 
+        ((!character.hasClassFeature("Fighting Style: Great Weapon Fighting", false)) && 
         (character.hasClassFeature("Great Weapon Fighting 2024", false) || character.hasFeat("Great Weapon Fighting 2024", false)))) {
             damages[0] = damages[0].replace(/([0-9]*)d([0-9]+)([^\s+-]*)(.*)/g, (match, amount, faces, roll_mods, mods) => {
                 return new Array(parseInt(amount) || 1).fill(`1d${faces}${roll_mods}min3`).join(" + ") + mods;
@@ -1178,7 +1178,7 @@ async function rollAction(paneClass, force_to_hit_only = false, force_damages_on
                 return new Array(parseInt(amount) || 1).fill(`1d${faces}${roll_mods}min3`).join(" + ") + mods;
             });
         } else if (action_name.includes("Pole Strike") && (character.hasFeat("Polearm Master 2024", false)) && 
-            (character.hasClassFeature("Great Weapon Fighting", false) || character.hasFeat("Great Weapon Fighting", false))) {
+            (character.hasClassFeature("Fighting Style: Great Weapon Fighting", false))) {
             damages[0] = damages[0].replace(/[0-9]*d[0-9]+/g, "$&ro<=2");
         }
 


### PR DESCRIPTION
…to work as per 2024 rules

fixes: https://github.com/kakaroto/Beyond20/issues/1186

added support gwf for fighting style
added support gwf for feat
added support for gwf in additional damages
added support for gwf and gwm for polearm master Pole Strike
fixed ability and saving throw pane selection since there were changes to the panes by dndbeyond

Great weapon Fighting as per 2024 rules works like elemental adept where each die can only role a minimum of 3
which is different from 2014 which was reroll 1s and 2s.

i had to mark the difference between them and also review other cases like Great Weapon master and Polearm Master which work differently in 2024

now all cases, GWF applies to all damages including additional damages like the frostbrand extra cold damage

Polearm Master changed the action name to "Pole Strike" from the old Polearm Master ones, so patched that and made it work with GWF and GWM

everything has been tested with all crit rules, common, magical weapons and cantrip damages like booming blade etc.

Mind you GWF as per old ways does not apply to booming blade but if it applies to the additional damages i think should apply to it too, but i have not made that change. everything is per existing functionality (besides the core rules changes on the styles)