### PR TITLE
added fix for Monster actions for 2024

### DIFF
--- a/src/dndbeyond/base/monster.js
+++ b/src/dndbeyond/base/monster.js
@@ -458,11 +458,24 @@ class Monster extends CharacterBase {
     }
 
     parseAttackInfo(description) {
-        const m = description.match(/(Melee|Ranged)(?: Weapon| Spell)? Attack:.*?(\+[0-9]+) to hit.*?, (?:reach |ranged? |Gibletish )?(.*?)(?:,.*?)?\./i)
+        // changed for 2024 info descriptions
+        const m = description.match(/(Melee|Ranged|Spell)(?: Weapon| Spell| Attack) ?(?: Attack|Roll):.*?(\+[0-9]+)(?: to hit.*?|\s?,) (?:reach |ranged? |Gibletish )?(.*?)(?:,.*?)?\./i);
         if (m)
             return m.slice(1, 4);
         else
             return null;
+    }
+
+    parseSaveInfo(description) {
+        const regex2024 = /(?<save>Strength|Dexterity|Constitution|Intelligence|Wisdom|Charisma)(?: Saving Throw:).DC (?<dc>[0-9]+)/;
+        const regex2014 = /DC ([0-9]+) (.*?) saving throw/;
+
+        const match2014 = description.match(regex2014);
+        const match2024 = description.match(regex2024);
+
+        if(match2014) return [match2014[2], match2014[1]];
+        else if(match2024) return [match2024[1], match2024[2]]
+        else return null;
     }
 
     parseHitInfo(description) {
@@ -500,10 +513,10 @@ class Monster extends CharacterBase {
             }
         }
         let save = null;
-        const m = hit.match(/DC ([0-9]+) (.*?) saving throw/)
+        const m = this.parseSaveInfo(hit);
         let preDCDamages = damages.length;
         if (m) {
-            save = [m[2], m[1]];
+            save = m;
             preDCDamages = damage_matches.reduce((total, match) => {
                 if (match.index < m.index)
                     total++;


### PR DESCRIPTION
fixed to hit regex to support 2014 and 2024 monsters 
added saving throw actions support for 2024 monsters

tested with most monsters from 2014 and counter parts in 2024

2014: https://www.dndbeyond.com/monsters/17020-sprite
2024: https://www.dndbeyond.com/monsters/4775845-sprite

2014 BEFORE change
![image](https://github.com/user-attachments/assets/b8440865-a48a-4f7f-b740-2d47e02421df)

2024 BEFORE Change
![image](https://github.com/user-attachments/assets/34711899-cbb0-4f70-aa84-415b65701867)

2014 creature after change
![image](https://github.com/user-attachments/assets/14c2d1cf-f765-497a-8c9b-5c9df5585a9b)

2024 creature after change
![image](https://github.com/user-attachments/assets/918e16c5-cab1-482a-9da1-6e36dc03a090)

This pull requests changes the To hit regex to take into account the changes in 2024 creatures where they have `Melee Attack Roll` Instead of `Melee Weapon Attack` and also the to Hit now doesnt have `to hit` on the text anymore. Some smaller changes were made to take into account other things. But this works now for both versions.

Change the save parsing by a bit I had to split the regex into 2014 and 2024 versions and extract it into a method to make it cleaner. They were very different from one another. (could be improved where we dont need to have strength,charisma etc written out.

There not a lot of 2024 monsters so there is ton of abilities that I can not test because they have not been released. Expect further breaks in this area when all monsters come out.

until then this should fix all the 2024 monsters.