### PR TITLE
Fix for Actor Creation Issue `bug` 

### DIFF
--- a/FVTT-module/beyond20/beyond20.js
+++ b/FVTT-module/beyond20/beyond20.js
@@ -36,8 +36,8 @@ class Beyond20 {
                     user: game.user.id
                 }
             },
-            permission: {
-                [game.userId]: CONST.DOCUMENT_PERMISSION_LEVELS.OWNER
+            ownership: {
+                [game.userId]: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER
             }
         };
         if (!["Character", "Monster", "Creature"].includes(request.character.type)) {
@@ -750,8 +750,8 @@ class Beyond20CreateNativeActorsApplication extends FormApplication {
                             user: user.id
                         }
                     },
-                    permission: {
-                        [user.id]: CONST.DOCUMENT_PERMISSION_LEVELS.OWNER
+                    ownership: {
+                        [user.id]: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER
                     }
                 });
                 ui.notifications.info(`Created Beyond20 Actor for user ${user.name}`);


### PR DESCRIPTION
Fixed "Create Actors" functionality by updating the Actor object to use the ownership property instead of permission, aligning with FoundryVTT v12 API changes and Actor Schema.