### PR TITLE
added fix for monster side panel

### DIFF
--- a/src/dndbeyond/base/monster.js
+++ b/src/dndbeyond/base/monster.js
@@ -829,15 +829,15 @@ class Monster extends CharacterBase {
         let hp = null;
         let max_hp = null;
         let temp_hp = null;
-        const groups = $(".ct-creature-pane .ct-collapsible__content .ct-creature-pane__adjuster-group,.ct-creature-pane .ddbc-collapsible__content .ct-creature-pane__adjuster-group");
+        const groups = $(".b20-creature-pane .ct-collapsible__content .b20-creature-pane__adjuster-group,.b20-creature-pane .ddbc-collapsible__content .b20-creature-pane__adjuster-group");
         for (let item of groups.toArray()) {
-            const label = $(item).find(".ct-creature-pane__adjuster-group-label").text();
+            const label = $(item).find(".b20-creature-pane__adjuster-group-label").text();
             if (label == "Current HP") {
-                hp = parseInt($(item).find(".ct-creature-pane__adjuster-group-value").text());
+                hp = parseInt($(item).find(".b20-creature-pane__adjuster-group-value").text());
             } else if (label == "Max HP") {
-                max_hp = parseInt($(item).find(".ct-creature-pane__adjuster-group-value").text());
+                max_hp = parseInt($(item).find(".b20-creature-pane__adjuster-group-value").text());
             } else if (label == "Temp HP") {
-                temp_hp = parseInt($(item).find(".ct-creature-pane__adjuster-group-value input").val());
+                temp_hp = parseInt($(item).find(".b20-creature-pane__adjuster-group-value input").val());
             }
         }
         if (hp !== null && max_hp !== null && (this._hp != hp || this._max_hp != max_hp || this._temp_hp != temp_hp)) {

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -2089,7 +2089,7 @@ function injectRollButton(paneClass) {
                 })
             }, ".ct-health-manager__deathsaves-group--fails", { custom: true });
         }
-    } else if (paneClass == "ct-creature-pane") {
+    } else if (paneClass == "b20-creature-pane") {
         if (isRollButtonAdded() || isCustomRollIconsAdded()) {
             if (creature)
                 creature.updateInfo();
@@ -2554,7 +2554,6 @@ function documentModified(mutations, observer) {
         "ct-spell-pane",
         "ct-reset-pane",
         "ct-health-manage-pane",
-        "ct-creature-pane",
         "ct-vehicle-pane",
         "ct-condition-manage-pane",
         "ct-proficiencies-pane"
@@ -2569,7 +2568,9 @@ function documentModified(mutations, observer) {
         feat: "b20-feat-pane",
         feature: "b20-class-feature-pane",
         racialTrait: "b20-racial-trait-pane",
-        character: "b20-character-manage-pane"
+        character: "b20-character-manage-pane",
+        creature: "b20-creature-pane"
+
     }
 
     function handlePane(paneClass) {
@@ -2633,6 +2634,11 @@ function documentModified(mutations, observer) {
             } else if (sidebar.parent().find(".ct-feature-snippet--racial-trait").length > 0) {
                 // In case DDB remove the ct-racial-trait-pane class from the sidebar
                 const paneClass = SPECIAL_PANES.racialTrait;
+                markPane(sidebar, paneClass);
+                handlePane(paneClass);
+            } else if (sidebar.parent().find(".ddbc-creature-block").length > 0) {
+                // In case DDB remove the ct-racial-trait-pane class from the sidebar
+                const paneClass = SPECIAL_PANES.creature;
                 markPane(sidebar, paneClass);
                 handlePane(paneClass);
             }

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -2637,7 +2637,6 @@ function documentModified(mutations, observer) {
                 markPane(sidebar, paneClass);
                 handlePane(paneClass);
             } else if (sidebar.parent().find(".ddbc-creature-block").length > 0) {
-                // In case DDB remove the ct-racial-trait-pane class from the sidebar
                 const paneClass = SPECIAL_PANES.creature;
                 markPane(sidebar, paneClass);
                 handlePane(paneClass);


### PR DESCRIPTION
monster side panel css was removed

ct-monster-panel was removed, so i made the same change we have done before when a panel is changed.

There is now a b20-monster-panel class to let all the code find and get the pane

**Before change**
![image](https://github.com/user-attachments/assets/14245aef-0c75-444b-9837-ef58edd6b6e8)

**After the changes side panel is now working.**
![image](https://github.com/user-attachments/assets/6b3a1c29-9c3d-4f7d-8397-ed949a0caec4)

**Tested with 2024 and 2014 monsters too to ensure nothing was affected (does not seem like it has)**
![image](https://github.com/user-attachments/assets/ecf86a69-cc59-4b49-ab4f-003a51fd6534)
![image](https://github.com/user-attachments/assets/0e4ddfc7-eb52-4a46-8ba0-389cac1c2b74)
