### PR TITLE
fix for ability mod not being found

### DIFF
--- a/src/dndbeyond/base/character.js
+++ b/src/dndbeyond/base/character.js
@@ -123,7 +123,7 @@ class Character extends CharacterBase {
             let modifier = $(ability).find(".ct-ability-summary__primary .ct-signed-number,.ddbc-ability-summary__primary .ddbc-signed-number,.ddbc-ability-summary__primary span[class*='styles_numberDisplay']").text();
             let value = $(ability).find(".ct-ability-summary__secondary,.ddbc-ability-summary__secondary").text();
             if (modifier == "") {
-                modifier = $(ability).find(".ct-ability-summary__secondary .ct-signed-number,.ddbc-ability-summary__secondary span[class*='styles_numberDisplay'], .ct-ability-summary__secondary span[class*='styles_numberDisplay']").text();
+                modifier = $(ability).find(".ct-ability-summary__secondary .ct-signed-number,.ddbc-ability-summary__secondary .ddbc-signed-number,.ddbc-ability-summary__secondary span[class*='styles_numberDisplay'], .ct-ability-summary__secondary span[class*='styles_numberDisplay']").text();  
                 value = $(ability).find(".ct-ability-summary__primary,.ddbc-ability-summary__primary").text();
             }
             this._abilities.push([name, abbr, value, modifier]);

--- a/src/dndbeyond/base/character.js
+++ b/src/dndbeyond/base/character.js
@@ -123,7 +123,7 @@ class Character extends CharacterBase {
             let modifier = $(ability).find(".ct-ability-summary__primary .ct-signed-number,.ddbc-ability-summary__primary .ddbc-signed-number,.ddbc-ability-summary__primary span[class*='styles_numberDisplay']").text();
             let value = $(ability).find(".ct-ability-summary__secondary,.ddbc-ability-summary__secondary").text();
             if (modifier == "") {
-                modifier = $(ability).find(".ct-ability-summary__secondary .ct-signed-number,.ddbc-ability-summary__secondary .ddbc-signed-number, .ct-ability-summary__secondary span[class*='styles_numberDisplay']").text();
+                modifier = $(ability).find(".ct-ability-summary__secondary .ct-signed-number,.ddbc-ability-summary__secondary span[class*='styles_numberDisplay'], .ct-ability-summary__secondary span[class*='styles_numberDisplay']").text();
                 value = $(ability).find(".ct-ability-summary__primary,.ddbc-ability-summary__primary").text();
             }
             this._abilities.push([name, abbr, value, modifier]);


### PR DESCRIPTION
impacted dice injection and number of other things - rather obscure problem it was not showing on all instances

This fix is important there was friend of mine Tomo that raised an issue that his deflect missiles were not working (it was not including the dex mod and it was rolling the incorrect die)

![image](https://github.com/user-attachments/assets/ad514283-a7bd-45fc-ab06-8f6ce135d236)
![image](https://github.com/user-attachments/assets/6a00bab4-ce23-4893-80fe-82b27c693885)
![image](https://github.com/user-attachments/assets/b44f5d05-fe51-481c-afbf-4083f4bcea54)

# I could not reproduce it on 2024

![image](https://github.com/user-attachments/assets/38ac8ec1-36aa-4f1d-8758-d5008f252247)
![image](https://github.com/user-attachments/assets/ca65b01b-f6a1-4492-887d-f6d9400ab940)
![image](https://github.com/user-attachments/assets/711ae466-3ed5-4540-bca1-610350898812)

# Using a 2014 character

But when using his character it was seeing the issue, this was a 2014 issue.

![image](https://github.com/user-attachments/assets/0f798424-bfb0-4a1e-ac51-8c8fffaacdcc)

# Stylecomponents hits again

## They changed the little box where character used this format of abilities 
![image](https://github.com/user-attachments/assets/a4077d2f-41b8-462b-9181-13665415eabd)

## But all works on this format
![image](https://github.com/user-attachments/assets/a9b57832-8a28-41a3-a26d-5b9b36765505)

dndbeyond added styledcomponents to only the mod of the ability which was not getting populated

Making the mod part of the all abilities in i the character miss the mod.

This made the very niche example of "you dexterity modifier ..." fail on dice injection.

This is all working now