### PR TITLE
Features: Classes 2024

### DIFF
--- a/src/dndbeyond/base/character.js
+++ b/src/dndbeyond/base/character.js
@@ -256,6 +256,8 @@ class Character extends CharacterBase {
         let is2024 = false;
         if((feat_name.toLowerCase() === "great weapon master" ||
             feat_name.toLowerCase() === "sharpshooter" ||
+            feat_name.toLowerCase() === "dread ambusher" ||
+            feat_name.toLowerCase() === "stalker’s flurry" ||            
             feat_name.toLowerCase() === "charger" ||
             feat_name.toLowerCase() === "polearm master") && 
             feat_reference.toLowerCase().includes("2024")) {

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -1882,14 +1882,21 @@ function findModifiers(character, custom_roll) {
             // If text length changes, we can check again for another modifier;
             text_len = text.length;
 
-            find_static_modifier = (name, value, {add_your=true}={}) => {
-                const mod_string = add_your ? " + your " + name : name;
-                if (text.toLowerCase().startsWith(mod_string)) {
-                    strong.append(text.substring(0, mod_string.length));
-                    roll_formula += " + " + value;
-                    text = text.substring(mod_string.length);
+            find_static_modifier = (name, value, { add_your = true } = {}) => {
+                // Define the modifier strings to check
+                const mod_strings = add_your 
+                    ? [` + your ${name}`, ` plus your ${name}`] 
+                    : [name];
+                
+                for (const mod_string of mod_strings) {
+                    if (text.toLowerCase().startsWith(mod_string)) {
+                        strong.append(text.substring(0, mod_string.length));
+                        roll_formula += " + " + value;
+                        text = text.substring(mod_string.length);
+                        break; // Exit loop once a match is found
+                    }
                 }
-            }
+            };
 
             for (let ability of character._abilities)
                 find_static_modifier(ability[0].toLowerCase() + " modifier", ability[3]);

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -526,7 +526,8 @@ function handleSpecialGeneralAttacks(damages=[], damage_types=[], properties, se
         if ((((item_name || action_name) && to_hit != null) || (spell_name && spell_level.includes("Cantrip"))) &&
             character.hasClassFeature("Blessed Strikes") &&
             character.getSetting("cleric-blessed-strikes", false)) {
-            damages.push("1d8");
+            if(character.hasClassFeature("Improved Blessed Strikes")) damages.push("2d8");
+            else damages.push("1d8");
             damage_types.push("Blessed Strikes");
         }
     }

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -704,9 +704,18 @@ function handleSpecialWeaponAttacks(damages=[], damage_types=[], properties, set
     if (character.hasClass("Ranger")) {
         // Ranger: Gloom Stalker: Dread Ambusher
         if (character.getSetting("ranger-dread-ambusher", false)) {
-            damages.push("1d8");
-            damage_types.push("Dread Ambusher");
-            settings_to_change["ranger-dread-ambusher"] = false;
+            const hasDreadAmbusher = character.hasClassFeature("Dread Ambusher");
+            const hasDreadAmbusher2024 = character.hasClassFeature("Dread Ambusher 2024");
+            
+            if (hasDreadAmbusher || hasDreadAmbusher2024) {
+                damages.push(
+                    hasDreadAmbusher 
+                        ? "1d8" 
+                        : (character.hasClassFeature("Stalker’s Flurry 2024") ? "2d8" : "2d6")
+                );
+                damage_types.push("Dread Ambusher");
+                settings_to_change["ranger-dread-ambusher"] = false;
+            }
         }
         
         // Ranger: Hunter: Colossus Slayer

--- a/src/extension/popup.js
+++ b/src/extension/popup.js
@@ -169,7 +169,7 @@ function populateCharacter(response) {
             e = createHTMLOption("bloodhunter-crimson-rite", false, character_settings);
             options.append(e);
         }
-        if (response["class-features"].includes("Dread Ambusher")) {
+        if (response["class-features"].includes("Dread Ambusher") || response["class-features"].includes("Dread Ambusher 2024")) {
             e = createHTMLOption("ranger-dread-ambusher", false, character_settings);
             options.append(e);
         }


### PR DESCRIPTION
Added support for the following features:

> Main fix is the text content changes from "+ your ..." to "plus your ...." so adding support for that fixed a ton of features.

- Cleric: add support for: Improved Blessed Strikes (life)
- Cleric: add support for: Radiance of the Dawn (light)
- Cleric: add support for: Warding Flare (light)
- Cleric: add support for: Improved Warding Flare (light)
- Cleric: add support for: Sear Undead (light)
- Ranger: add support for: Tireless
- Ranger: add support for: Dreadful Strikes (Gloomstalker)
- Ranger: add support for: Stalker’s Flurry (Gloomstalker)
- Monk: add Support for: Deflect Attacks and Redirect Attack
- Monk: add Support for: Hand of Harm and Healing
- Monk: add Support for: Hand of Ultimate Mercy