### PR TITLE
druid: added support for lunar radiance 2024

### DIFF
--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -799,6 +799,12 @@ const character_settings = {
         "type": "bool",
         "default": true
     },
+    "druid-improved-lunar-radiance": {
+        "title": "Druid: Improved Lunar Radiance",
+        "description": "Once per turn, you can deal an extra 2d10 Radiant damage to a target you hit with a Wild Shape forms attack.",
+        "type": "bool",
+        "default": false
+    },
     "discord-target": {
         "title": "Discord Destination",
         "description": "Send rolls to a character specific Discord channel",

--- a/src/dndbeyond/base/extras.js
+++ b/src/dndbeyond/base/extras.js
@@ -501,6 +501,12 @@ class MonsterExtras extends CharacterBase {
                                 roll_properties["damages"].push(String(rage_damage));
                                 roll_properties["damage-types"].push("Rage");
                             }
+
+                            if(this._parent_character.hasClass("Druid") && this._parent_character.hasClassFeature("Improved Lunar Radiance", true) && this._parent_character.getSetting("druid-improved-lunar-radiance", false))
+                            {
+                                roll_properties["damages"].push(String("2d10"));
+                                roll_properties["damage-types"].push("Lunar Radiance");
+                            }
                             // Add custom damages to wild shape attacks
                             addCustomDamages(character, roll_properties["damages"], roll_properties["damage-types"]);
                         }

--- a/src/extension/popup.js
+++ b/src/extension/popup.js
@@ -310,6 +310,10 @@ function populateCharacter(response) {
             e = createHTMLOption("cleric-circle-of-mortality", false, character_settings);
             options.append(e);
         }
+        if (response["class-features"].includes("Lunar Form: Wild Shape: Improved Lunar Radiance")) {
+            e = createHTMLOption("druid-improved-lunar-radiance", false, character_settings);
+            options.append(e);
+        }
     }
     $('.beyond20-option-input').off('change', save_settings);
     $('.beyond20-option-input').change(save_settings);


### PR DESCRIPTION
Added Improved Lunar Radiance for Wild shape forms.

This change works on wild shape forms when the person attacks.

> https://www.dndbeyond.com/sources/dnd/phb-2024/character-classes#Level6ImprovedCircleForms

![image](https://github.com/user-attachments/assets/1eef5189-34ea-437a-ade3-9e1937039838)

# New setting
![Screenshot 2024-12-07 150922](https://github.com/user-attachments/assets/48da9f7e-67cf-4851-b1c0-27e0e6093b9c)
# How it shows on wild shape form
![image](https://github.com/user-attachments/assets/05c928e9-38e7-46be-97dd-631491fa7f31)
![Screenshot 2024-12-07 150912](https://github.com/user-attachments/assets/95090034-3296-4f34-8f3d-e36c791d8a17)
