### PR TITLE
Paladin: Fix for 'Radiant Strikes'

### DIFF
--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -608,7 +608,7 @@ const character_settings = {
         "default": true
     },
     "paladin-improved-divine-smite": {
-        "title": "Paladin: Improved Divine Smite",
+        "title": "Paladin: Radiant Strikes (Improved Divine Smite)",
         "description": "Roll an extra 1d8 radiant damage whenever you hit with a melee weapon",
         "type": "bool",
         "default": true

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -409,8 +409,8 @@ function handleSpecialMeleeAttacks(damages=[], damage_types=[], properties, sett
     }
 
     if (character.hasClass("Paladin")) {
-        //Paladin: Improved Divine Smite
-        if (character.hasClassFeature("Improved Divine Smite") &&
+        //Paladin: Radiant Strikes (Formerly: Improved Divine Smite)
+        if ((character.hasClassFeature("Radiant Strikes") || character.hasClassFeature("Improved Divine Smite")) &&
             character.getSetting("paladin-improved-divine-smite", true)) {
             damages.push("1d8");
             damage_types.push("Radiant");

--- a/src/extension/popup.js
+++ b/src/extension/popup.js
@@ -189,7 +189,7 @@ function populateCharacter(response) {
             e = createHTMLOption("ranger-gathered-swarm", false, character_settings);
             options.append(e);
         }
-        if (response["class-features"].includes("Improved Divine Smite")) {
+        if (response["class-features"].includes("Radiant Strikes") || response["class-features"].includes("Improved Divine Smite")) {
             e = createHTMLOption("paladin-improved-divine-smite", false, character_settings);
             options.append(e);
         }


### PR DESCRIPTION
The Paladin feature "Improved Divine Smite" was renamed to "Radiant Strikes" in the 2024 PHB.  This PR updates the popup and damage script to check for either name.  