### PR TITLE
fix: remove effects bless and bane from spells without to-hit

### DIFF
--- a/src/dndbeyond/base/extras.js
+++ b/src/dndbeyond/base/extras.js
@@ -155,7 +155,7 @@ class MonsterExtras extends CharacterBase {
                                 initiative = $(
                                     E.div({ class: `${attribute_prefix} ${initiative_selector} ${classNames["attribute"]}`,
                                             "data-modifier": modifier },
-                                        E.span({ class: `${attribute_prefix}-label ${classNames["label"]}` }, "Roll Initiative!"),
+                                        E.strong({ class: `${attribute_prefix}-label ${classNames["label"]}` }, "Roll Initiative!"),
                                         E.span({ class: `${attribute_prefix}-data` },
                                             E.span({ class: `${attribute_prefix}-data-value ${classNames["value"]}` }, "  " + modifier)
                                         )

--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -478,10 +478,10 @@ async function sendRoll(character, rollType, fallback, args) {
             req.character.settings["custom-roll-dice"] = (req.character.settings["custom-roll-dice"] || "") + ` ${operator}${modifier}`;
         }
 
-        if (req.character.settings["effects-bless"] && ["attack", "spell-attack", "saving-throw"].includes(req.type)) {
+        if (req.character.settings["effects-bless"] && (["attack", "spell-attack"].includes(req.type) && req["to-hit"] || req.type === "saving-throw")) {
             req.character.settings["custom-roll-dice"] = (req.character.settings["custom-roll-dice"] || "") + " +1d4";
             addEffect(req, "Bless");
-        } else if (req.character.settings["effects-bane"] && ["attack", "spell-attack", "saving-throw"].includes(req.type)) {  
+        } else if (req.character.settings["effects-bane"] && (["attack", "spell-attack"].includes(req.type) && req["to-hit"] || req.type === "saving-throw")) {
             req.character.settings["custom-roll-dice"] = (req.character.settings["custom-roll-dice"] || "") + " -1d4";
             addEffect(req, "Bane");
         }


### PR DESCRIPTION
Just checking for spells-attack, and attack was adding bless effects to spells that should not get it.

there was no mechanical changes but to make sure there is no issues only spells with to-hit and attacks should get this effect.

# example of spell that should not have the effect

> Armor of Agathys

![image](https://github.com/user-attachments/assets/0c8844f7-2cd6-4a2b-b5df-9056442b036e)

# code changes
![image](https://github.com/user-attachments/assets/13775bd3-bd08-483f-a501-5e4ef5b83e93)

![image](https://github.com/user-attachments/assets/5c59b5f2-08d2-4e4a-a003-179724386a7e)

# Fix graphic fix for Monster Extras

added strong to the elements so that the Roll Initiative! is bolded correctly

![image](https://github.com/user-attachments/assets/2100d6a4-45a1-45bb-be0d-094231429e36)
