### PR TITLE
fix: reordered selector keeping old one, to fetch properties of actions

### DIFF
--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -1150,7 +1150,7 @@ async function rollAction(paneClass, force_to_hit_only = false, force_damages_on
         return displayAction(paneClass);
     }
     // b20-action-pane and ct-custom-action-page both use ct-action-detail for the details
-    const properties = propertyListToDict($("." + paneClass + " .ct-action-detail [role=list] > div"));
+    const properties = propertyListToDict($("." + paneClass + " [role=list] > div, .ct-action-detail [role=list] > div"));
     //console.log("Properties are : " + String(properties));
     const action_name = $(".ct-sidebar__heading").text();
     const action_parent = $(".ct-sidebar__header-parent").text();


### PR DESCRIPTION
Added hotfix for Properties from actions that were not being selected.

This is likely a change in the on how the properties are done has broken the original selector.

All actions were broken but this fix corrects that.

![image](https://github.com/user-attachments/assets/b58c8863-a225-49dd-bb31-2a26c1921de0)

![image](https://github.com/user-attachments/assets/6717d043-f06f-412c-a2e5-58f37ef54b5f)
