### PR TITLE
fix: added check for settings monsters dont have these

### DIFF
--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -505,13 +505,15 @@ async function sendRoll(character, rollType, fallback, args) {
         }
     }
 
-    // effects 
-    if(["saving-throw", "ability", "skill"].includes(rollType) && req.ability == "STR" && req.character.settings["effects-enlarge"]) {
-        adjustRollAndKeyModifiersWithAdvantage(req);
-        addEffect(req, "Enlarge");
-    } else if(["saving-throw", "ability", "skill"].includes(rollType) && req.ability == "STR" && req.character.settings["effects-reduce"]) {
-        adjustRollAndKeyModifiersWithDisadvantage(req);
-        addEffect(req, "Reduce");
+    if(req.character.settings){
+        // effects 
+        if(["saving-throw", "ability", "skill"].includes(rollType) && req.ability == "STR" && req.character.settings["effects-enlarge"]) {
+            adjustRollAndKeyModifiersWithAdvantage(req);
+            addEffect(req, "Enlarge");
+        } else if(["saving-throw", "ability", "skill"].includes(rollType) && req.ability == "STR" && req.character.settings["effects-reduce"]) {
+            adjustRollAndKeyModifiersWithDisadvantage(req);
+            addEffect(req, "Reduce");
+        }
     }
 
     if (character.getGlobalSetting("use-digital-dice", false) && DigitalDiceManager.isEnabled()) {


### PR DESCRIPTION
Small fix for bug introduced with spell effects,

Monsters dont have settings so when rolling STR from the monster Extra tab it was throwing an error.

fixes https://github.com/kakaroto/Beyond20/issues/1216