### PR TITLE
feature: added support to exhaustion rules from 2024/2014

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -373,7 +373,7 @@ Make an initiative roll.
 
 Additional fields added to the roll request:
 - `initiative`: the initiative modifier
-- `effects`: (Optional) An `<Array<string>>` array of spell effect names that are applied to this roll
+- `effects`: (Optional) An `<Array<string>>` array of effect names that are applied to this roll
 
 
 #### ability
@@ -385,7 +385,7 @@ Additional fields added to the roll request:
 - `modifier`: The ability modifier
 - `ability-score`: (Optional) The score value of the ability being rolled
 - `d20`: (Optional) The type of dice to roll if it's not a standard `1d20` (Can be `1d20min10` for a minimum roll of 10 for example, in the case of special features)
-- `effects`: (Optional) An `<Array<string>>` array of spell effect names that are applied to this roll
+- `effects`: (Optional) An `<Array<string>>` array of effect names that are applied to this roll
 
 
 #### saving-throw
@@ -397,7 +397,7 @@ Additional fields added to the roll request:
 - `modifier`: The saving throw modifier
 - `proficiency`: (Optional) The type of proficiency the character has (can be `None`, `Proficient` or `Half Proficiency`, or `Expert`)
 - `d20`: (Optional) The type of dice to roll if it's not a standard `1d20` (Can be `1d20min10` for a minimum roll of 10 for example, in the case of special features)
-- `effects`: (Optional) An `<Array<string>>` array of spell effect names that are applied to this roll
+- `effects`: (Optional) An `<Array<string>>` array of effect names that are applied to this roll
 
 #### skill
 Rolls a skill check.
@@ -408,7 +408,7 @@ Additional fields added to the roll request:
 - `modifier`: The skill check modifier
 - `proficiency`: (Optional) The type of proficiency the character has (can be `None`, `Proficient` or `Half Proficiency`, or `Expert`)
 - `d20`: (Optional) The type of dice to roll if it's not a standard `1d20` (Can be `1d20min10` for a minimum roll of 10 for example, in the case of special features)
-- `effects`: (Optional) An `<Array<string>>` array of spell effect names that are applied to this roll
+- `effects`: (Optional) An `<Array<string>>` array of effect names that are applied to this roll
 
 #### trait
 Display a character trait, class feature or special action. This can be used to display different kinds of features, no matter the source.
@@ -458,7 +458,7 @@ Additional fields added to the roll request:
 - `proficient`: (Optional) A `<boolean>` To determine if the character is proficient with this weapon (only for `attack-source: item`)
 - `properties`: (Optional) An `<Array<string>>` array of property strings that relate to the weapon being used (For example, "Light", "Finesse", "Two-handed", etc...)
 - `mastery`: (Optional) A `<string>` with the name of the mastery that the character has over this weapon
-- `effects`: (Optional) An `<Array<string>>` array of spell effect names that are applied to this roll
+- `effects`: (Optional) An `<Array<string>>` array of effect names that are applied to this roll
 
 
 An attack roll (same for a [spell-attack](#spell-attack)) will generally have `rollAttack` or `rollDamage` set to `true` to define if we're rolling the to-hit or the damages. Both can also be set together to roll both at once. 
@@ -534,14 +534,14 @@ Additional fields added to the roll request:
 - `class`: The class name for which the hit dice is being rolled
 - `multiclass`: A `<boolean>` to indicate whether the character is multiclassed
 - `hit-dice`: The Hit Die formula to roll
-- `effects`: (Optional) An `<Array<string>>` array of spell effect names that are applied to this roll
+- `effects`: (Optional) An `<Array<string>>` array of effect names that are applied to this roll
 
 #### death-save
 Roll a death saving throw
 
 Additional fields added to the roll request:
 - `modifier`: (Optional) The modifier to add to the death saving throw (would apply in case of magic items)
-- `effects`: (Optional) An `<Array<string>>` array of spell effect names that are applied to this roll
+- `effects`: (Optional) An `<Array<string>>` array of effect names that are applied to this roll
 
 #### chat-message
 Display a chat message.

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -508,6 +508,13 @@ const character_settings = {
 
     // effects
 
+    "effects-exhaustion": {
+        "title": "Effect: Exhaustion",
+        "description": "Applies 2024 rules for exhaustion. This condition is cumulative and effects all D20 roles applying a -2 * exhaustion level modifier to the roll.",
+        "type": "bool",
+        "default": false
+    },
+
     "effects-bless": {
         "title": "Effect: Bless",
         "description": "Whenever a target makes an attack roll or a saving throw before the spell ends, the target adds 1d4 to the attack roll or save.",

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -508,9 +508,16 @@ const character_settings = {
 
     // effects
 
-    "effects-exhaustion": {
-        "title": "Effect: Exhaustion",
-        "description": "Applies 2024 rules for exhaustion. This condition is cumulative and effects all D20 roles applying a -2 * exhaustion level modifier to the roll.",
+    "effects-exhaustion-2024": {
+        "title": "Effect: Exhaustion 2024",
+        "description": "Applies 2024 rules for exhaustion. This condition is cumulative and effects all D20 rolls applying a -2 * exhaustion level modifier to the roll.",
+        "type": "bool",
+        "default": false
+    },
+
+    "effects-exhaustion-2014": {
+        "title": "Effect: Exhaustion 2014",
+        "description": "Applies 2014 rules for exhaustion. This condition is cumulative and applies disadvantage on ability checks at exhaustion >= 1 and disadvantage on attacks and saving throws on exhaustion >= 3.",
         "type": "bool",
         "default": false
     },

--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -486,10 +486,17 @@ async function sendRoll(character, rollType, fallback, args) {
             addEffect(req, "Bane");
         }
 
-        if (req.character.exhaustion && req.character.exhaustion != 0 && req.character.settings["effects-exhaustion"] && 
+        if (req.character.exhaustion && req.character.exhaustion != 0 && req.character.settings["effects-exhaustion-2024"] && 
             (["attack", "spell-attack"].includes(req.type) && req["to-hit"] || 
             ["initiative", "ability", "saving-throw", "skill", "death-save"].includes(req.type))) {
             req.character.settings["custom-roll-dice"] = (req.character.settings["custom-roll-dice"] || "") + ` -${req.character.exhaustion * 2}`;
+            addEffect(req, `Exhaustion (${req.character.exhaustion})`);
+        } else if (req.character.exhaustion && req.character.exhaustion != 0 && req.character.settings["effects-exhaustion-2014"]) {
+            if((["attack", "spell-attack"].includes(req.type) && req["to-hit"] || ["saving-throw"].includes(req.type)) && req.character.exhaustion && req.character.exhaustion >= 3) {
+                adjustRollAndKeyModifiersWithDisadvantage(req);
+            } else if (["initiative", "ability", "skill", "death-save"].includes(req.type) && req.character.exhaustion && req.character.exhaustion >= 1) {
+                adjustRollAndKeyModifiersWithDisadvantage(req);
+            }
             addEffect(req, `Exhaustion (${req.character.exhaustion})`);
         }
     }

--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -485,6 +485,13 @@ async function sendRoll(character, rollType, fallback, args) {
             req.character.settings["custom-roll-dice"] = (req.character.settings["custom-roll-dice"] || "") + " -1d4";
             addEffect(req, "Bane");
         }
+
+        if (req.character.exhaustion && req.character.exhaustion != 0 && req.character.settings["effects-exhaustion"] && 
+            (["attack", "spell-attack"].includes(req.type) && req["to-hit"] || 
+            ["initiative", "ability", "saving-throw", "skill", "death-save"].includes(req.type))) {
+            req.character.settings["custom-roll-dice"] = (req.character.settings["custom-roll-dice"] || "") + ` -${req.character.exhaustion * 2}`;
+            addEffect(req, `Exhaustion (${req.character.exhaustion})`);
+        }
     }
         
     if (req.whisper === WhisperType.QUERY) {

--- a/src/extension/popup.js
+++ b/src/extension/popup.js
@@ -121,7 +121,10 @@ function populateCharacter(response) {
         e.classList.add("advanced-option");
         options.append(e);
         // effects
-        e = createHTMLOption("effects-exhaustion", false, character_settings);
+        e = createHTMLOption("effects-exhaustion-2024", false, character_settings);
+        e.classList.add("effects-option");
+        options.append(e);
+        e = createHTMLOption("effects-exhaustion-2014", false, character_settings);
         e.classList.add("effects-option");
         options.append(e);
         e = createHTMLOption("effects-bless", false, character_settings);

--- a/src/extension/popup.js
+++ b/src/extension/popup.js
@@ -121,6 +121,9 @@ function populateCharacter(response) {
         e.classList.add("advanced-option");
         options.append(e);
         // effects
+        e = createHTMLOption("effects-exhaustion", false, character_settings);
+        e.classList.add("effects-option");
+        options.append(e);
         e = createHTMLOption("effects-bless", false, character_settings);
         e.classList.add("effects-option");
         options.append(e);


### PR DESCRIPTION
added setting effect that allows any character of what ever version to use 2024 exhaustion rules on their rolls.

# Added New effect setting

> Setting is NOT dependent on the character being a 2024 class, giving the ability for people to decide to use 2024 rules if they want it. it is turned off by default

![image](https://github.com/user-attachments/assets/9fc1cf5e-fd4c-413b-bdc7-d72a6aeee6ab)

# Rolls that it effects

> The following rolls are impacted: `attack`, `spell-attack`, `initiative`, `ability`, `saving-throw`, `skill`, `death-save`. The Effect is shown in the effects list displaying the level of exhaustion.

![image](https://github.com/user-attachments/assets/cf16f505-04a4-4ba4-ad43-a4b719d14548)
![image](https://github.com/user-attachments/assets/49c49f0f-86be-44a4-9ebe-f0239f19eaee)
![image](https://github.com/user-attachments/assets/9f4da66c-5833-40df-8bd3-aa2830a68c32)

# Exhaustion for 2014
![image](https://github.com/user-attachments/assets/77f68e82-afcf-4898-9e0f-ecf9c9fd6dc7

## Ability checks

> Ability checks, Skills, Initiative and Death Saves

![image](https://github.com/user-attachments/assets/1f28ab84-4179-442b-bb56-2a941ccccfbb)

## Attacks

> Attacks and Spell Attacks

![image](https://github.com/user-attachments/assets/3195d518-0cd7-4a51-9149-c53062e1b4fb)

