### PR TITLE
fix: fixing dndbeyond incorrect sorcerous burst damage values

### DIFF
--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -218,7 +218,7 @@ async function buildAttackRoll(character, attack_source, name, description, prop
             const choice = await queryDamageTypeFromArray(roll_properties.name, damages, damage_types, ["Acid", "Cold", "Fire", "Lightning", "Poison", "Thunder"]);
             if (choice === null) return null; // Query was cancelled;
         } else if (roll_properties.name === "Sorcerous Burst") {
-            // fix dndbeyond dmg issue
+            // HACK ALERT: temporarily use acid damage....
             damages = damages.map(m => damages[0]); // set everything to the correct acid dmg
             roll_properties["damages"] = damages; // reset roll_properties
             const choice = await queryDamageTypeFromArray(roll_properties.name, damages, damage_types, ["Acid", "Cold", "Fire", "Lightning", "Poison", "Psychic", "Thunder"]);

--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -218,6 +218,9 @@ async function buildAttackRoll(character, attack_source, name, description, prop
             const choice = await queryDamageTypeFromArray(roll_properties.name, damages, damage_types, ["Acid", "Cold", "Fire", "Lightning", "Poison", "Thunder"]);
             if (choice === null) return null; // Query was cancelled;
         } else if (roll_properties.name === "Sorcerous Burst") {
+            // fix dndbeyond dmg issue
+            damages = damages.map(m => damages[0]); // set everything to the correct acid dmg
+            roll_properties["damages"] = damages; // reset roll_properties
             const choice = await queryDamageTypeFromArray(roll_properties.name, damages, damage_types, ["Acid", "Cold", "Fire", "Lightning", "Poison", "Psychic", "Thunder"]);
             if (choice === null) return null; // Query was cancelled;
         } else if (roll_properties.name === "Dragon's Breath") {


### PR DESCRIPTION
DND Beyond when they set up the new cantrip sorcerous burst they set the damage values incorrectly

# Incorrect values
![image](https://github.com/user-attachments/assets/9cb88046-510e-4770-bbbe-bfd148383b9e)

> We use the properties of the spell to show which dmg type the person wants, this fix will use the first damage value which is the correct one and apply it to all damage types.

#
> [!IMPORTANT]
> There is NO check to see if the first number if the highest, this is simple fix to set all values the same. it relies on dndbeyond damage values to be correct.

## Casting the spell
![image](https://github.com/user-attachments/assets/8c5b645b-3a53-46a0-86e0-c05886937ec6)
![image](https://github.com/user-attachments/assets/0e688296-e6d7-408c-bccc-5b14ebe7ffb8)
 