### PR TITLE
fix: small fix to ensure custom action with no damage value can still…

### DIFF
--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -1226,7 +1226,9 @@ async function rollAction(paneClass, force_to_hit_only = false, force_damages_on
         }
 
         // apply for normal die
-        damages[0] = applyGWFIfRequired(action_name, properties, damages[0]);
+        if (damages.length != 0) {
+            damages[0] = applyGWFIfRequired(action_name, properties, damages[0]);
+        }
 
         const isMeleeAttack = action_name.includes("Polearm Master") || action_name.includes("Pole Strike") || action_name.includes("Unarmed Strike") || action_name.includes("Tavern Brawler Strike")
         || action_name.includes("Psychic Blade") || action_name.includes("Bite") || action_name.includes("Claws") || action_name.includes("Tail")


### PR DESCRIPTION
… display

> Small fix to ensure they display, it was setting damages to damages = [undefined] which caused some issues in rare moments

# example
![image](https://github.com/user-attachments/assets/f5224357-0901-411d-9596-ff35f9c53283)
![image](https://github.com/user-attachments/assets/85404d6a-b8af-46a9-923e-b6102bca9383)

# working now
![image](https://github.com/user-attachments/assets/092067a7-397d-421a-8d56-9e25c305ca55)
