### PR TITLE
fix: added small fix to select the correct feat for gwf

### DIFF
--- a/src/dndbeyond/base/character.js
+++ b/src/dndbeyond/base/character.js
@@ -467,7 +467,7 @@ class Character extends CharacterBase {
         const hasGWF2014 = this.hasClassFeature("Fighting Style: Great Weapon Fighting") ||
                 this.hasClassFeature("Additional Fighting Style: Great Weapon Fighting") ||
                 this.hasClassFeature("Fighting Initiate: Great Weapon Fighting") ||
-                this.hasFeat("Great Weapon Fighting");
+                this.hasFeat("Fighting Initiate: Great Weapon Fighting");
         const hasGWF2024 = this.hasClassFeature("Fighting Style 2024: Great Weapon Fighting") ||
                 this.hasClassFeature("Additional Fighting Style 2024: Great Weapon Fighting") ||
                 this.hasFeat("Great Weapon Fighting 2024");


### PR DESCRIPTION
# fix for great weapon fighting 2014

> the feat selection was not working, and to avoid using substrings, i have changed it to look for the entire feat plus selection

# example
![image](https://github.com/user-attachments/assets/3efc94c9-f0af-472d-b060-6b0ba156cbcb)
![image](https://github.com/user-attachments/assets/617a8df1-9087-4906-ac89-d78f7428b1e0)

# fix 
![image](https://github.com/user-attachments/assets/c94928fe-6174-4a9c-9674-9970ea0e3813)

