### PR TITLE
fix: Hp syncing and death saving throws

### DIFF
--- a/src/dndbeyond/base/character.js
+++ b/src/dndbeyond/base/character.js
@@ -135,18 +135,33 @@ class Character extends CharacterBase {
     }
 
     updateHP() {
-        const health_pane = $(".ct-health-manager");
+        const health_pane = $(".b20-health-manage-pane");
         let hp = null;
         let max_hp = null;
         let temp_hp = null;
         if (health_pane.length > 0) {
-            hp = parseInt(health_pane.find(".ct-health-manager__health-item--cur .ct-health-manager__health-item-value").text());
-            max_hp = parseInt(health_pane.find(".ct-health-manager__health-item--max .ct-health-manager__health-item-value .ct-health-manager__health-max-current").text());
-            temp_hp = parseInt(health_pane.find(".ct-health-manager__health-item--temp .ct-health-manager__health-item-value input").val());
-        } else {
-            const hp_items = $(".ct-health-summary__hp-group--primary .ct-health-summary__hp-item, .ct-quick-info__health div[class*='styles_hitPointsBox'] div[class*='styles_innerContainer'] div[class*='styles_item']");
+            const hp_items = health_pane.find("div[class*='styles_container'] div[class*='styles_innerContainer'] div[class*='styles_item']");
             for (let item of hp_items.toArray()) {
-                const label = $(item).find("h2[class*='styles_label']").text().trim();
+                const label = $(item).find("label[class*='styles_label'], span[class*='styles_label']").text().trim();
+                if (label == "Current") {
+                    const number = $(item).find("input[class*='styles_input']");
+                    if (number.length > 0)
+                        hp = parseInt(number.val());
+                } else if (label == "Max") {
+                    max_hp = parseInt($(item).find("div[class*='styles_maxContainer']").text());
+                }
+            }
+            const temp_item = health_pane.find("div[class*='styles_container'] div[class*='styles_temp']");
+            if (temp_item.length > 0) {
+                // Can be hp-empty class instead;
+                temp_hp = parseInt(temp_item.find("input[class*='styles_input']").val()) || 0;
+            } else {
+                temp_hp = this._temp_hp;
+            }
+        } else {
+            const hp_items = $(".ct-health-summary__hp-group--primary .ct-health-summary__hp-item, .ct-quick-info__health div[class*='styles_container'] div[class*='styles_innerContainer'] div[class*='styles_item']");
+            for (let item of hp_items.toArray()) {
+                const label = $(item).find("label[class*='styles_label'], span[class*='styles_label']").text().trim();
                 if (label == "Current") {
                     // Make sure it's !an input being modified;
                     const number = $(item).find("button[class*='styles_valueButton']");

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -2156,15 +2156,15 @@ function injectRollButton(paneClass) {
                 return
             removeRollButtons(pane);
         }
-    } else if (paneClass == "ct-health-manage-pane") {
-        const deathsaves = $(".ct-health-manage-pane .ct-health-manager__deathsaves");
+    } else if (paneClass == "b20-health-manage-pane") {
+        const deathsaves = $(".b20-health-manage-pane .ct-health-manager__deathsaves");
         if (deathsaves.length > 0) {
             if (isRollButtonAdded(deathsaves) || isCustomRollIconsAdded(deathsaves))
                 return;
             
             // Check for Advantage/Disadvantage Badges, as Lineages: Reborn advantage on Death Saves or similar will supply
-            const skill_badge_adv = $(".ct-health-manage-pane .ct-health-manager__deathsaves .ddbc-advantage-icon").length > 0;
-            const skill_badge_disadv = $(".ct-health-manage-pane .ct-health-manager__deathsaves .ddbc-disadvantage-icon").length > 0;
+            const skill_badge_adv = $(".b20-health-manage-pane .ct-health-manager__deathsaves .ddbc-advantage-icon").length > 0;
+            const skill_badge_disadv = $(".b20-health-manage-pane .ct-health-manager__deathsaves .ddbc-disadvantage-icon").length > 0;
             let deathSaveRollType = RollType.NORMAL;
             if (skill_badge_adv && skill_badge_disadv) {
                 deathSaveRollType = RollType.QUERY;
@@ -2666,7 +2666,6 @@ function documentModified(mutations, observer) {
         "ct-custom-action-pane",
         "ct-spell-pane",
         "ct-reset-pane",
-        "ct-health-manage-pane",
         "ct-vehicle-pane",
         "ct-condition-manage-pane",
         "ct-proficiencies-pane",
@@ -2684,7 +2683,8 @@ function documentModified(mutations, observer) {
         racialTrait: "b20-racial-trait-pane",
         character: "b20-character-manage-pane",
         creature: "b20-creature-pane",
-        background: "b20-background-pane"
+        background: "b20-background-pane",
+        healthManager: "b20-health-manage-pane"
     }
 
     function handlePane(paneClass) {
@@ -2760,7 +2760,12 @@ function documentModified(mutations, observer) {
                 const paneClass = SPECIAL_PANES.creature;
                 markPane(sidebar, paneClass);
                 handlePane(paneClass);
-            }
+            } else if (Array.from(sidebar.parent().find("h1, h2"))
+                .some(e => e.textContent.includes("HP Management"))) {
+                    const paneClass = SPECIAL_PANES.healthManager;
+                    markPane(sidebar, paneClass);
+                    handlePane(paneClass);
+                }
         } else {
             // Special panes with now headers
             const avatarPane = $(".ct-sidebar__inner div[class*='styles_characterManagePane']");

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -2157,14 +2157,14 @@ function injectRollButton(paneClass) {
             removeRollButtons(pane);
         }
     } else if (paneClass == "b20-health-manage-pane") {
-        const deathsaves = $(".b20-health-manage-pane .ct-health-manager__deathsaves");
+        const deathsaves = $(".b20-health-manage-pane .ct-health-manager__deathsaves, .b20-health-manage-pane div[class*='styles_deathSavesGroups']");
         if (deathsaves.length > 0) {
             if (isRollButtonAdded(deathsaves) || isCustomRollIconsAdded(deathsaves))
                 return;
             
             // Check for Advantage/Disadvantage Badges, as Lineages: Reborn advantage on Death Saves or similar will supply
-            const skill_badge_adv = $(".b20-health-manage-pane .ct-health-manager__deathsaves .ddbc-advantage-icon").length > 0;
-            const skill_badge_disadv = $(".b20-health-manage-pane .ct-health-manager__deathsaves .ddbc-disadvantage-icon").length > 0;
+            const skill_badge_adv = $(".b20-health-manage-pane .ct-health-manager__deathsaves .ddbc-advantage-icon, .b20-health-manage-pane div[class*='styles_diceAdjustments'] span[class*='ddbc-advantage-icon']").length > 0;
+            const skill_badge_disadv = $(".b20-health-manage-pane .ct-health-manager__deathsaves .ddbc-disadvantage-icon, .b20-health-manage-pane div[class*='styles_diceAdjustments'] span[class*='ddbc-disadvantage-icon']").length > 0;
             let deathSaveRollType = RollType.NORMAL;
             if (skill_badge_adv && skill_badge_disadv) {
                 deathSaveRollType = RollType.QUERY;
@@ -2199,7 +2199,7 @@ function injectRollButton(paneClass) {
                     "modifier": modifier,
                     "advantage": deathSaveRollType
                 })
-            }, ".ct-health-manager__deathsaves-group--fails", { custom: true });
+            }, ".b20-health-manage-pane div[class*='styles_deathSavesGroups'] div[class*='styles_container']:first", { custom: true });
         }
     } else if (paneClass == "b20-creature-pane") {
         if (isRollButtonAdded() || isCustomRollIconsAdded()) {


### PR DESCRIPTION
# HP sync

> Fixes: https://github.com/kakaroto/Beyond20/issues/1234

# HP sync

> hp sync now works both in destop and mobile

![image](https://github.com/user-attachments/assets/e75892e0-87aa-490d-99ac-25e1d4637bf3)
![image](https://github.com/user-attachments/assets/45778c14-4cf4-48d8-8e04-a9f02d023a6e)

# side panel class

> side panel now works again

![image](https://github.com/user-attachments/assets/f2333cdc-62bd-401c-93a7-3238d40c5bd1)

# Death saving throws

> Fixed death saving throws, added roll dice back

![image](https://github.com/user-attachments/assets/8ef8c992-6397-47d5-ad0b-2d5b84caad32)