### PR TITLE
feature: added support for locking checkboxes

### DIFF
--- a/options.css
+++ b/options.css
@@ -99,6 +99,37 @@
 	    left: 20px;
 	}
 
+	/* Scoped under .material-switch--padlock to prevent conflicts */
+.material-switch--padlock {
+    position: absolute;
+    right: 55px;
+    top: 50%;
+    transform: translateY(-50%);
+    margin-right: 5px;
+}
+
+.material-switch--padlock > input[type="checkbox"] {
+    display: none;
+}
+
+.material-switch--padlock > label {
+	font-size: 24px;
+	cursor: pointer;
+	transition: color 0.3s ease-in-out;
+	user-select: none;
+	font-family: "Segoe UI Symbol", "Segoe UI", Arial, sans-serif;
+}
+
+.material-switch--padlock > label::before {
+    content: "\01F513"; /* 🔓 */
+    color: #9E9E9E;
+}
+
+.material-switch--padlock > input[type="checkbox"]:checked + label::before {
+    content: "\01F512"; /* 🔒 */
+    color: rgb(66, 133, 244);
+}
+
 
 .disabled {
     pointer-events: none;

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -736,8 +736,13 @@ const character_settings = {
         "default": false
     },
     "rogue-sneak-attack": {
-        "title": "Rogue: Sneak Attack",
+        "title": "Rogue: Sneak Attack (Apply to next roll only)",
         "description": "Send Sneak Attack damage with each attack roll",
+        "type": "bool",
+        "default": true,
+        "lock": "rogue-sneak-attack-lock"
+    },
+    "rogue-sneak-attack-lock": {
         "type": "bool",
         "default": true
     },

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -579,6 +579,11 @@ const character_settings = {
         "title": "Bard: College of Whispers: Psychic Blades",
         "description": "Use your Bardic Inspiration to deal extra psychic damage (Apply to next roll only)",
         "type": "bool",
+        "default": false,
+        "lock": "bard-psychic-blades-lock"
+    },
+    "bard-psychic-blades-lock": {
+        "type": "bool",
         "default": false
     },
     "bard-spiritual-focus": {

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -832,13 +832,23 @@ const character_settings = {
         "title": "Feat: Great Weapon Master (Apply to next roll only)",
         "description": "Apply Great Weapon Master -5 penalty to roll and +10 to damage",
         "type": "bool",
+        "default": false,
+        "lock": "great-weapon-master-lock"
+    },
+    "great-weapon-master-lock": {
+        "type": "bool",
         "default": false
     },
     "great-weapon-master-2024": {
-        "title": "Feat: Great Weapon Master 2024",
+        "title": "Feat: Great Weapon Master 2024 (Apply to next roll only)",
         "description": "Heavy Weapon Mastery. Apply extra damage equals your Proficiency Bonus.",
         "type": "bool",
-        "default": true
+        "default": true,
+        "lock": "great-weapon-master-2024-lock"
+    },
+    "great-weapon-master-2024-lock": {
+        "type": "bool",
+        "default": false
     },
     "sharpshooter": {
         "title": "Feat: Sharpshooter (Apply to next roll only)",

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -733,7 +733,7 @@ const character_settings = {
     },
     "rogue-cunning-strike": {
         "title": "Rogue: Cunning Strike",
-        "description": "When you deal Sneak Attack damage, you can add Cunning Strike effects to the roll.",
+        "description": "When you deal Sneak Attack damage, you can add Cunning Strike effects to the roll. (Apply to next roll only)",
         "type": "bool",
         "default": false,
         "lock": "rogue-cunning-strike-lock"
@@ -980,16 +980,17 @@ function createHTMLOptionEx(name, option, short = false, {advanced=false}={}) {
     const description_p = description ? description.split("\n").map(desc => E.p({}, desc)) : [];
     const title = short ? option.short : option.title;
     const lock = option.lock;
+    const lockDiv = lock ? E.div({ class: 'material-switch--padlock pull-right' },  
+            E.input({ id: lock, class: "beyond20-option-input", lock, type: "checkbox" }),  
+            E.label({ for: lock })
+        ): null; 
     let e = null;
     if (option.type == "bool") {
         e = E.li({ class: "list-group-item beyond20-option beyond20-option-bool" },
             E.label({ class: "list-content", for: name },
                 E.h4({}, title),
                 ...description_p,
-                (_ => lock ? E.div({ class: 'material-switch--padlock pull-right' },
-                    E.input({ id: lock, class: "beyond20-option-input", lock, type: "checkbox" }),
-                    E.label({ for: lock })
-                ) : null )(),
+                ...(lock ? [lockDiv] : []),
                 E.div({ class: 'material-switch pull-right' },
                     E.input({ id: name, class: "beyond20-option-input", name, type: "checkbox" }),
                     E.label({ for: name, class: "label-default" })

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -821,6 +821,11 @@ const character_settings = {
         "title": "Feat: Charger Extra Damage (Apply to next roll only)",
         "description": "You charge into battle, lending weight to your blow!",
         "type": "bool",
+        "default": false,
+        "lock": "charger-feat-lock"
+    },
+    "charger-feat-lock": {
+        "type": "bool",
         "default": false
     },
     "great-weapon-master": {

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -735,6 +735,11 @@ const character_settings = {
         "title": "Rogue: Cunning Strike",
         "description": "When you deal Sneak Attack damage, you can add Cunning Strike effects to the roll.",
         "type": "bool",
+        "default": false,
+        "lock": "rogue-cunning-strike-lock"
+    },
+    "rogue-cunning-strike-lock": {
+        "type": "bool",
         "default": false
     },
     "rogue-assassinate": {
@@ -974,12 +979,17 @@ function createHTMLOptionEx(name, option, short = false, {advanced=false}={}) {
     const description = short ? option.short_description : option.description;
     const description_p = description ? description.split("\n").map(desc => E.p({}, desc)) : [];
     const title = short ? option.short : option.title;
+    const lock = option.lock;
     let e = null;
     if (option.type == "bool") {
         e = E.li({ class: "list-group-item beyond20-option beyond20-option-bool" },
             E.label({ class: "list-content", for: name },
                 E.h4({}, title),
                 ...description_p,
+                (_ => lock ? E.div({ class: 'material-switch--padlock pull-right' },
+                    E.input({ id: lock, class: "beyond20-option-input", lock, type: "checkbox" }),
+                    E.label({ for: lock })
+                ) : null )(),
                 E.div({ class: 'material-switch pull-right' },
                     E.input({ id: name, class: "beyond20-option-input", name, type: "checkbox" }),
                     E.label({ for: name, class: "label-default" })
@@ -1126,7 +1136,8 @@ function extractSettingsData(_list = options_list) {
     return settings;
 }
 
-function loadSettings(settings, _list = options_list) {
+function 
+loadSettings(settings, _list = options_list) {
     for (let option in settings) {
         if (!_list[option]) {
             continue;

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -698,6 +698,11 @@ const character_settings = {
         "title": "Ranger: Gloom Stalker: Dread Ambusher (Apply to next roll only)",
         "description": "You skills in ambushing your enemies lend more damage to your initial strike",
         "type": "bool",
+        "default": false,
+        "lock": "ranger-dread-ambusher-lock"
+    },
+    "ranger-dread-ambusher-lock": {
+        "type": "bool",
         "default": false
     },
     "ranger-planar-warrior": {

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -854,6 +854,11 @@ const character_settings = {
         "title": "Feat: Sharpshooter (Apply to next roll only)",
         "description": "Apply Sharpshooter -5 penalty to roll and +10 to damage",
         "type": "bool",
+        "default": false,
+        "lock": "sharpshooter-lock"
+    },
+    "sharpshooter-lock": {
+        "type": "bool",
         "default": false
     },
     "brutal-critical": {

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -576,8 +576,8 @@ const character_settings = {
         "default": true
     },
     "bard-psychic-blades": {
-        "title": "Bard: College of Whispers: Psychic Blades",
-        "description": "Use your Bardic Inspiration to deal extra psychic damage (Apply to next roll only)",
+        "title": "Bard: College of Whispers: Psychic Blades (Apply to next roll only)",
+        "description": "Use your Bardic Inspiration to deal extra psychic damage.",
         "type": "bool",
         "default": false,
         "lock": "bard-psychic-blades-lock"
@@ -742,8 +742,8 @@ const character_settings = {
         "default": true
     },
     "rogue-cunning-strike": {
-        "title": "Rogue: Cunning Strike",
-        "description": "When you deal Sneak Attack damage, you can add Cunning Strike effects to the roll. (Apply to next roll only)",
+        "title": "Rogue: Cunning Strike (Apply to next roll only)",
+        "description": "When you deal Sneak Attack damage, you can add Cunning Strike effects to the roll.",
         "type": "bool",
         "default": false,
         "lock": "rogue-cunning-strike-lock"
@@ -754,7 +754,12 @@ const character_settings = {
     },
     "rogue-assassinate": {
         "title": "Rogue: Assassin: Assassinate Surprise Attack (Apply to next roll only)",
-        "description": "Roll with advantage and roll critical damage dice",
+        "description": "Roll with advantage and roll critical damage dice.",
+        "type": "bool",
+        "default": false,
+        "lock": "rogue-assassinate-lock"
+    },
+    "rogue-assassinate-lock": {
         "type": "bool",
         "default": false
     },

--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -266,7 +266,8 @@ async function buildAttackRoll(character, attack_source, name, description, prop
 
         // TODO: refactor into a method and remove it from build attack roll 
         if (character.hasClass("Rogue") && character.hasClassFeature("Sneak Attack 2024") && 
-            character.getSetting("rogue-sneak-attack", false) && 
+            (character.getSetting("rogue-sneak-attack", false) || 
+            name.includes("Sneak Attack") && !character.getSetting("rogue-sneak-attack", false) && character.getSetting("rogue-cunning-strike", false)) && 
             !name.includes("Psionic Power: Psychic Whispers") && 
             (properties["Attack Type"] == "Ranged" ||
             (properties["Properties"] && properties["Properties"].includes("Finesse")) ||
@@ -285,7 +286,8 @@ async function buildAttackRoll(character, attack_source, name, description, prop
                     validChoices.push(choice);
                 }
                 roll_properties["cunning-strike-effects"] = validChoices.map(m => m.action).join(", ") || undefined;
-                settings_to_change["rogue-cunning-strike"] = false;
+                const isLocked = character.getSetting("rogue-cunning-strike-lock", false);
+                if(!isLocked) settings_to_change["rogue-cunning-strike"] = false;
             }
             const sneak_attack = sneakDieCount > 0 ? `${sneakDieCount}d6` : "0";
             if (name.includes("Sneak Attack")) {

--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -265,15 +265,23 @@ async function buildAttackRoll(character, attack_source, name, description, prop
         }
 
         // TODO: refactor into a method and remove it from build attack roll 
-        if (character.hasClass("Rogue") && character.hasClassFeature("Sneak Attack 2024") && 
-            (character.getSetting("rogue-sneak-attack", false) || 
-            name.includes("Sneak Attack") && !character.getSetting("rogue-sneak-attack", false) && character.getSetting("rogue-cunning-strike", false)) && 
-            !name.includes("Psionic Power: Psychic Whispers") && 
-            (properties["Attack Type"] == "Ranged" ||
-            (properties["Properties"] && properties["Properties"].includes("Finesse")) ||
-            name.includes("Psychic Blade") ||
-            name.includes("Shadow Blade") ||
-            name.includes("Sneak Attack"))) {
+        if (character.hasClass("Rogue") &&
+            character.hasClassFeature("Sneak Attack 2024") &&
+            !name.includes("Psionic Power: Psychic Whispers") &&
+            (
+                character.getSetting("rogue-sneak-attack", false) ||
+                (
+                    name.includes("Sneak Attack") &&
+                    character.getSetting("rogue-cunning-strike", false)
+                )
+            ) && (
+                properties["Attack Type"] === "Ranged" ||
+                (properties["Properties"] && properties["Properties"].includes("Finesse")) ||
+                name.includes("Psychic Blade") ||
+                name.includes("Shadow Blade") ||
+                name.includes("Sneak Attack")
+            )
+        ) {
             let sneakDieCount = Math.ceil(character._classes["Rogue"] / 2);
             // Rogue: Sneak Attack
             if (character.hasClassFeature("Cunning Strike") && character.getSetting("rogue-cunning-strike", false)) {

--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -304,6 +304,9 @@ async function buildAttackRoll(character, attack_source, name, description, prop
                 damages.push(sneak_attack);
                 damage_types.push("Sneak Attack");
             }
+
+            const isLocked = character.getSetting("rogue-sneak-attack-lock", false);
+            if(!isLocked) settings_to_change["rogue-sneak-attack"] = false;
         }
         const crits = damagesToCrits(character, damages, damage_types);
         const crit_damages = [];

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -482,7 +482,9 @@ function handleSpecialMeleeAttacks(damages=[], damage_types=[], properties, sett
         character.getSetting("charger-feat")) {
         damages.push("+5");
         damage_types.push("Charger Feat");
-        settings_to_change["charger-feat"] = false;
+
+        const isLocked = character.getSetting("charger-feat-lock", false);
+        if(!isLocked) settings_to_change["charger-feat"] = false;
     } else if (character.hasFeat("Charger 2024") &&
         character.getSetting("charger-feat")) {
             let charge_dmg = "1d8";
@@ -500,7 +502,9 @@ function handleSpecialMeleeAttacks(damages=[], damage_types=[], properties, sett
 
             damages.push(charge_dmg);
             damage_types.push("Charger Feat");
-            settings_to_change["charger-feat"] = false;
+
+            const isLocked = character.getSetting("charger-feat-lock", false);
+            if(!isLocked) settings_to_change["charger-feat"] = false;            
     }
     
     return to_hit;

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -1078,7 +1078,10 @@ async function rollItem(force_display = false, force_to_hit_only = false, force_
             character.getSetting("rogue-assassinate", false)) {
             roll_properties["critical-limit"] = 1;
             roll_properties["advantage"] = RollType.OVERRIDE_ADVANTAGE;
-            settings_to_change["rogue-assassinate"] = false;
+
+            const isLocked = character.getSetting("rogue-assassinate-lock", false);
+            if(!isLocked) settings_to_change["rogue-assassinate"] = false;
+            
         }
         // Sorcerer: Clockwork Soul - Trance of Order
         if (character.hasClassFeature("Trance of Order") && character.getSetting("sorcerer-trance-of-order", false))
@@ -1327,7 +1330,9 @@ async function rollAction(paneClass, force_to_hit_only = false, force_damages_on
             character.getSetting("rogue-assassinate", false)) {
             roll_properties["critical-limit"] = 1;
             roll_properties["advantage"] = RollType.OVERRIDE_ADVANTAGE;
-            settings_to_change["rogue-assassinate"] = false;
+            
+            const isLocked = character.getSetting("rogue-assassinate-lock", false);
+            if(!isLocked) settings_to_change["rogue-assassinate"] = false;
         }
         // Sorcerer: Clockwork Soul - Trance of Order
         if (character.hasClassFeature("Trance of Order") && character.getSetting("sorcerer-trance-of-order", false))
@@ -1715,7 +1720,9 @@ async function rollSpell(force_display = false, force_to_hit_only = false, force
             character.getSetting("rogue-assassinate", false)) {
             roll_properties["critical-limit"] = 1;
             roll_properties["advantage"] = RollType.OVERRIDE_ADVANTAGE;
-            settings_to_change["rogue-assassinate"] = false;
+            
+            const isLocked = character.getSetting("rogue-assassinate-lock", false);
+            if(!isLocked) settings_to_change["rogue-assassinate"] = false;
         }
         // Sorcerer: Clockwork Soul - Trance of Order
         if (character.hasClassFeature("Trance of Order") && character.getSetting("sorcerer-trance-of-order", false))

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -682,7 +682,8 @@ function handleSpecialWeaponAttacks(damages=[], damage_types=[], properties, set
                 blades_dmg = "8d6"
             damages.push(blades_dmg);
             damage_types.push("Psychic Blades");
-            settings_to_change["bard-psychic-blades"] = false;
+            const isLocked = character.getSetting("bard-psychic-blades-lock", false);
+            if(!isLocked) settings_to_change["bard-psychic-blades"] = false;
         }
     }
 

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -810,6 +810,9 @@ function handleSpecialWeaponAttacks(damages=[], damage_types=[], properties, set
             const sneak_attack = `${sneakDieCount}d6`;
             damages.push(sneak_attack);
             damage_types.push("Sneak Attack");
+
+            const isLocked = character.getSetting("rogue-sneak-attack-lock", false);
+            if(!isLocked) settings_to_change["rogue-sneak-attack"] = false;
         }
     }
 

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -752,7 +752,8 @@ function handleSpecialWeaponAttacks(damages=[], damage_types=[], properties, set
                         : (character.hasClassFeature("Stalker’s Flurry 2024") ? "2d8" : "2d6")
                 );
                 damage_types.push("Dread Ambusher");
-                settings_to_change["ranger-dread-ambusher"] = false;
+                const isLocked = character.getSetting("ranger-dread-ambusher-lock", false);
+                if(!isLocked) settings_to_change["ranger-dread-ambusher"] = false;
             }
         }
         

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -531,7 +531,8 @@ function handleSpecialRangedAttacks(damages=[], damage_types=[], properties, set
         to_hit += " - 5";
         damages.push("10");
         damage_types.push("Sharpshooter");
-        settings_to_change["sharpshooter"] = false;
+        const isLocked = character.getSetting("sharpshooter-lock", false);
+        if(!isLocked) settings_to_change["sharpshooter"] = false;
     }
 
     // Feats

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -457,7 +457,8 @@ function handleSpecialMeleeAttacks(damages=[], damage_types=[], properties, sett
         to_hit += " - 5";
         damages.push("10");
         damage_types.push("Great Weapon Master");
-        settings_to_change["great-weapon-master"] = false;
+        const isLocked = character.getSetting("great-weapon-master-lock", false);
+        if(!isLocked) settings_to_change["great-weapon-master"] = false;
     }
 
     if (to_hit !== null && 
@@ -468,6 +469,8 @@ function handleSpecialMeleeAttacks(damages=[], damage_types=[], properties, sett
         const proficiency = parseInt(character._proficiency);
         damages.push(proficiency.toString());
         damage_types.push("Great Weapon Master");
+        const isLocked = character.getSetting("great-weapon-master-2024-lock", false);
+        if(!isLocked) settings_to_change["great-weapon-master-2024"] = false;
     }
     
     // enhanced unarmed strike
@@ -540,6 +543,8 @@ function handleSpecialRangedAttacks(damages=[], damage_types=[], properties, set
         const proficiency = parseInt(character._proficiency);
         damages.push(proficiency.toString());
         damage_types.push("Great Weapon Master");
+        const isLocked = character.getSetting("great-weapon-master-2024-lock", false);
+        if(!isLocked) settings_to_change["great-weapon-master-2024"] = false;
     }
     
     return to_hit;


### PR DESCRIPTION
> [!WARNING]
> Hi @kakaroto what do you think about this? I made it as separate setting because i didnt want to have to deal with merging of settings from stored character settings already etc, and i didnt want to create another setting type, so i opted to add the "lock" setting to the bool option types as a reference to another setting that is not displayed separately. see this ticket as reference for the feature - https://github.com/kakaroto/Beyond20/issues/1241

> [!IMPORTANT]
> Code is not optimized yet just wanted to get you to give an eyeball at it

# Feature

> Padlock for options, adds a padlock to certain settings that tells beyond 20 to ignore the reverting of the settings after an action was taken, example SNEAK ATTACK

# Sneak Attack

> Some users suggested that they would like to use the sneak attack action and apply cunning strike to it, without having to have the sneak attack option turned on for all attacks.

# Padlock

> For Cunning strike there is not a padlock next to it that will tell the extension NOT to turn off cunning strike when it is used. this will work for normal attacks and sneak attack action.

> [!NOTE]
> Padlock will override the reverting of the setting on all uses including when cunning strike is set by a hotkey 

![image](https://github.com/user-attachments/assets/a1ef16d0-cdf7-47b4-983a-b240dcd6c1c4)
![image](https://github.com/user-attachments/assets/70e6c8e4-bb85-46be-8f99-cb98381c60a7)
![image](https://github.com/user-attachments/assets/b753ab45-3286-4567-b1f2-0ebbea3168f5)
