### PR TITLE
Per-Character VTT Setting

### DIFF
--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -481,6 +481,13 @@ const character_settings = {
             "two": "Use weapon Two-handed"
         }
     },
+    "use-vtt": {
+        "short": "Use VTT",
+        "title": "Use VTT",
+        "description": "Send rolls to the default VTT.",
+        "type": "bool",
+        "default": true
+    },
     "custom-roll-dice": {
         "title": "Custom Roll dice formula bonus",
         "description": "Add custom formula to d20 rolls (Bless, Guidance, Bane, Magic Weapon, etc..)",

--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -213,7 +213,7 @@ function onMessage(request, sender, sendResponse) {
                 }
             }
         }
-        if (request.character?.settings["use-vtt"] == false || request.request?.character?.settings["use-vtt"] == false) {
+        if (request.character?.settings?.["use-vtt"] == false || request.request?.character?.settings?.["use-vtt"] == false) {
             sendResponse({ "success": true, "vtt": [], "error": null, "request": request })
             return true;
         }

--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -213,6 +213,10 @@ function onMessage(request, sender, sendResponse) {
                 }
             }
         }
+        if (request.character?.settings["use-vtt"] == false || request.request?.character?.settings["use-vtt"] == false) {
+            sendResponse({ "success": true, "vtt": [], "error": null, "request": request })
+            return true;
+        }
         const trackFailure = { "roll20": null, "fvtt": null, "custom": null }
         if (settings["vtt-tab"] && settings["vtt-tab"].vtt === "dndbeyond") {
             sendResponse({ "success": false, "vtt": ["dndbeyond"], "error": null, "request": request })

--- a/src/extension/popup.js
+++ b/src/extension/popup.js
@@ -143,6 +143,8 @@ function populateCharacter(response) {
 
         e = createHTMLOption("versatile-choice", false, character_settings);
         options.append(e);
+        e = createHTMLOption("use-vtt", false, character_settings);
+        options.append(e);
 
         if (response["racial-traits"].includes("Lucky") ||
             response["racial-traits"].includes("Luck")) {


### PR DESCRIPTION
Beyond20 works great for us when using Roll20, but a few DMs are starting to experiment with D&D Beyond's Maps.

In those cases, the extension keeps popping up a dialog with the final roll result when it can't find a VTT. I understand this is useful for Discord users, but when we're just using Maps, it becomes a bit repetitive. We could have our players enable or disable the extension based on whose campaign we're playing that night, but I thought it might be easier to have a character-specific setting that enables or disables the VTT for that particular character.

Please take a look at my changes and let me know what you think.

Thanks for all your hard work on this great extension!