### PR TITLE
Fix Sacred Weapon

### DIFF
--- a/src/extension/popup.js
+++ b/src/extension/popup.js
@@ -283,7 +283,7 @@ function populateCharacter(response) {
             e = createHTMLOption("wildfire-spirit-enhanced-bond", false, character_settings);
             options.append(e);
         }
-        if (response["actions"].includes("Channel Divinity: Sacred Weapon")) {
+        if (response["class-features"].includes("Channel Divinity: Channel Divinity: Sacred Weapon")) {
             e = createHTMLOption("paladin-sacred-weapon", false, character_settings);
             options.append(e);
         }


### PR DESCRIPTION
Devotion Paladin's Sacred Weapon is not populating in the options window.
![Screenshot 2025-04-14 at 8 28 59 AM](https://github.com/user-attachments/assets/7f3482b6-bc19-4aea-ac04-515f8e9df676)



This is because it's coming through as a Class Feature and as "Channel Divinity: Channel Divinity: Sacred Weapon"
![Screenshot 2025-04-13 at 10 48 58 PM](https://github.com/user-attachments/assets/9c36894f-4c28-464d-87dc-0aff8fc8a9d0)

This change listens for that instead.

Testing with the change...it now shows.
![Screenshot 2025-04-13 at 10 55 44 PM](https://github.com/user-attachments/assets/d7061200-7cf9-46f5-ab79-a52e6ff6dd32)
