### PR TITLE
fix: change reference check for 2024 features

### DIFF
--- a/src/dndbeyond/base/character.js
+++ b/src/dndbeyond/base/character.js
@@ -286,21 +286,24 @@ class Character extends CharacterBase {
     getFeatureVersionName(feat_name, feat_reference) {
         if (!feat_reference) return feat_name;
         let is2024 = false;
-        if((feat_name.toLowerCase() === "great weapon master" ||
-            feat_name.toLowerCase() === "sharpshooter" ||
-            feat_name.toLowerCase() === "dread ambusher" ||
-            feat_name.toLowerCase() === "stalker’s flurry" ||            
-            feat_name.toLowerCase() === "charger" ||
-            feat_name.toLowerCase() === "tavern brawler" ||
-            feat_name.toLowerCase() === "polearm master") && 
-            feat_reference.toLowerCase().includes("2024")) {
-                is2024 = true;
-        } else if ((feat_name.toLowerCase() === "fighting style" ||
-            feat_name.toLowerCase() === "additional fighting style" ||
-            feat_name.toLowerCase() === "great weapon fighting" ||
-            feat_name.toLowerCase() === "sneak attack") &&
-            feat_reference.toLowerCase().includes("free-rules")) {
-                is2024 = true;
+        if (
+            (
+                feat_name.toLowerCase() === "great weapon master" ||
+                feat_name.toLowerCase() === "sharpshooter" ||
+                feat_name.toLowerCase() === "dread ambusher" ||
+                feat_name.toLowerCase() === "stalker’s flurry" ||            
+                feat_name.toLowerCase() === "charger" ||
+                feat_name.toLowerCase() === "tavern brawler" ||
+                feat_name.toLowerCase() === "polearm master" ||
+                feat_name.toLowerCase() === "fighting style" ||
+                feat_name.toLowerCase() === "additional fighting style" ||
+                feat_name.toLowerCase() === "great weapon fighting" ||
+                feat_name.toLowerCase() === "sneak attack"       
+            ) && ( 
+                feat_reference.toLowerCase().includes("2024")) ||
+                feat_reference.toLowerCase().includes("free-rules")
+         ) {
+            is2024 = true;
         }
 
         if (is2024) {


### PR DESCRIPTION
# feature reference changes

> DNDBEYOND changed all the reference names for the 2024 books, they no longer make use of free-rules, features have been split between br-2024 (basic rules) and PHB-2024 etc

> [!IMPORTANT]
> This broke few features that we have 2014 versions and 2024 ones - like gwf

## Changes now work

> testing character -> https://www.dndbeyond.com/characters/140676629

![image](https://github.com/user-attachments/assets/07fba3f8-e1b1-423b-bf38-a9ef285442e7)
 