### PR TITLE
fix: added tavern brawler 2024 to all unarmed strike actions from mon…

### DIFF
--- a/docs/support.md
+++ b/docs/support.md
@@ -26,7 +26,7 @@ If however, you do not want to use Patreon or Github Sponsors or don't want to p
 
 Oh, I misunderstood, you're the ones in need of support! Well, fear not, I am here to help!
 
-If you want to ask for help, give feedaback or discuss an issue, you can join our [discord server](https://discord.gg/ZAasSVS).
+If you want to ask for help, give feedback or discuss an issue, you can join our [discord server](https://discord.gg/ZAasSVS).
 
 [![Discord](/images/discord-logo.png){:width="400px"}](https://discord.gg/ZAasSVS)
 

--- a/src/common/dice.js
+++ b/src/common/dice.js
@@ -247,7 +247,7 @@ class DNDBDice {
                 return r;
             });
         }
-        // Restore drop/keep case.includes(amount) of rerolls;
+        // Restore drop/keep count for rerolls;
         this._dk.amount = dk_amount;
 
         return this.calculateTotal();

--- a/src/common/roll_renderer.js
+++ b/src/common/roll_renderer.js
@@ -48,7 +48,7 @@ class Beyond20RollRenderer {
             const value = choices[option] || option;
             html += `<option value="${option}"${isSelected ? " selected" : ""}>${value}</option>`;
         }
-        html += `;</select></div></form>`;
+        html += `</select></div></form>`;
         return new Promise((resolve) => {
             this._prompter.prompt(title, html, "Roll").then((html) => {
                 if (html) {
@@ -76,7 +76,7 @@ class Beyond20RollRenderer {
             const value = choices[option] || option;
             html += `<option value="${option}"${isSelected ? " selected" : ""}>${value}</option>`;
         }
-        html += `;</select></div>`;
+        html += `</select></div>`;
 
         // query two
         html += `<div class="beyond20-form-row"><label>${question2}</label><select id="${select_id}-two" name="${select_id}-two">`;
@@ -87,7 +87,7 @@ class Beyond20RollRenderer {
             const value = choices2[option] || option;
             html += `<option value="${option}"${isSelected ? " selected" : ""}>${value}</option>`;
         }
-        html += `;</select></div>`;
+        html += `</select></div>`;
         
         html += `</form>`;
         return new Promise((resolve) => {

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -1,3 +1,5 @@
+const DICE_REGEXP = /(^|[^\w])(?:(?:(?:(\d*[dD]\d+(?:ro(?:=|<|<=|>|>=)[0-9]+)?(?:min[0-9]+)?)((?:(?:\s*[-−+]\s*\d+)|(?:\s*[0+]\s*\d*[dD]\d+))*))|((?:[-−+]\s*\d+)+)))($|[^\w])/gm;
+
 function replaceRollsCallback(match, replaceCB) {
     let dice = match[2];
     let modifiers = match[3];
@@ -16,9 +18,7 @@ function replaceRollsCallback(match, replaceCB) {
 }
 
 function replaceRolls(text, replaceCB) {
-    // TODO: Cache the value so we don't recompile the regexp every time
-    const dice_regexp = new RegExp(/(^|[^\w])(?:(?:(?:(\d*[dD]\d+(?:ro(?:=|<|<=|>|>=)[0-9]+)?(?:min[0-9]+)?)((?:(?:\s*[-−+]\s*\d+)|(?:\s*[0+]\s*\d*[dD]\d+))*))|((?:[-−+]\s*\d+)+)))($|[^\w])/, "gm");
-    return text.replace(dice_regexp, (...match) => replaceRollsCallback(match, replaceCB));
+    return text.replace(DICE_REGEXP, (...match) => replaceRollsCallback(match, replaceCB));
 }
 
 // Used to clean various dice.includes(imperfections) roll strings;

--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -401,6 +401,15 @@ async function buildAttackRoll(character, attack_source, name, description, prop
     return roll_properties;
 }
 
+function ensureModifier(damageStr, modValue) {
+    const hasMod = /\d+d\d+\s*[+-]\s*\d+/.test(damageStr);
+    if (hasMod) return damageStr;
+
+    // If mod is positive, add '+' explicitly
+    const sign = modValue >= 0 ? "+" : "";
+    return `${damageStr}${sign}${modValue}`;
+}
+
 function applyGWFIfRequired(action_name, properties, damage) {
     if((properties["Attack Type"] == "Melee" && 
         ((properties["Properties"].includes("Versatile") && character.getSetting("versatile-choice") != "one") || 

--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -164,6 +164,55 @@ async function queryCunningStrike() {
     return selection;
 }
 
+async function applyRogueSneakAttack(character, name, properties, damages,
+                                     damage_types, roll_properties,
+                                     settings_to_change) {
+    if (!(character.hasClass("Rogue") &&
+          character.hasClassFeature("Sneak Attack 2024") &&
+          !name.includes("Psionic Power: Psychic Whispers") &&
+          (
+              character.getSetting("rogue-sneak-attack", false) ||
+              (
+                  name.includes("Sneak Attack") &&
+                  character.getSetting("rogue-cunning-strike", false)
+              )
+          ) && (
+              properties["Attack Type"] === "Ranged" ||
+              (properties["Properties"] && properties["Properties"].includes("Finesse")) ||
+              name.includes("Psychic Blade") ||
+              name.includes("Shadow Blade") ||
+              name.includes("Sneak Attack")
+          ))) {
+        return;
+    }
+
+    let sneakDieCount = Math.ceil(character._classes["Rogue"] / 2);
+    if (character.hasClassFeature("Cunning Strike") && character.getSetting("rogue-cunning-strike", false)) {
+        const choices = await queryCunningStrike();
+        const validChoices = [];
+        for (const choice of choices) {
+            if (choice.action === "None") continue;
+            if (choice["die"] > sneakDieCount) continue;
+            sneakDieCount -= choice["die"];
+            validChoices.push(choice);
+        }
+        roll_properties["cunning-strike-effects"] = validChoices.map(m => m.action).join(", ") || undefined;
+        const isLocked = character.getSetting("rogue-cunning-strike-lock", false);
+        if(!isLocked) settings_to_change["rogue-cunning-strike"] = false;
+    }
+
+    const sneak_attack = sneakDieCount > 0 ? `${sneakDieCount}d6` : "0";
+    if (name.includes("Sneak Attack")) {
+        damages[0] = sneak_attack;
+    } else {
+        damages.push(sneak_attack);
+        damage_types.push("Sneak Attack");
+    }
+
+    const isLocked = character.getSetting("rogue-sneak-attack-lock", false);
+    if(!isLocked) settings_to_change["rogue-sneak-attack"] = false;
+}
+
 async function buildAttackRoll(character, attack_source, name, description, properties,
                          damages = [], damage_types = [], to_hit = null,
                          brutal = 0, force_to_hit_only = false, force_damages_only = false, {weapon_damage_length=0}={}, settings_to_change = []) {
@@ -264,50 +313,9 @@ async function buildAttackRoll(character, attack_source, name, description, prop
             if (choice === null) return null; // Query was cancelled;
         }
 
-        // TODO: refactor into a method and remove it from build attack roll 
-        if (character.hasClass("Rogue") &&
-            character.hasClassFeature("Sneak Attack 2024") &&
-            !name.includes("Psionic Power: Psychic Whispers") &&
-            (
-                character.getSetting("rogue-sneak-attack", false) ||
-                (
-                    name.includes("Sneak Attack") &&
-                    character.getSetting("rogue-cunning-strike", false)
-                )
-            ) && (
-                properties["Attack Type"] === "Ranged" ||
-                (properties["Properties"] && properties["Properties"].includes("Finesse")) ||
-                name.includes("Psychic Blade") ||
-                name.includes("Shadow Blade") ||
-                name.includes("Sneak Attack")
-            )
-        ) {
-            let sneakDieCount = Math.ceil(character._classes["Rogue"] / 2);
-            // Rogue: Sneak Attack
-            if (character.hasClassFeature("Cunning Strike") && character.getSetting("rogue-cunning-strike", false)) {
-                const choices = await queryCunningStrike();
-                const validChoices = [];
-                for (const choice of choices) {
-                    if (choice.action === "None") continue;
-                    if (choice["die"] > sneakDieCount) continue;
-                    sneakDieCount -= choice["die"];
-                    validChoices.push(choice);
-                }
-                roll_properties["cunning-strike-effects"] = validChoices.map(m => m.action).join(", ") || undefined;
-                const isLocked = character.getSetting("rogue-cunning-strike-lock", false);
-                if(!isLocked) settings_to_change["rogue-cunning-strike"] = false;
-            }
-            const sneak_attack = sneakDieCount > 0 ? `${sneakDieCount}d6` : "0";
-            if (name.includes("Sneak Attack")) {
-                damages[0] = sneak_attack;
-            } else {
-                damages.push(sneak_attack);
-                damage_types.push("Sneak Attack");
-            }
-
-            const isLocked = character.getSetting("rogue-sneak-attack-lock", false);
-            if(!isLocked) settings_to_change["rogue-sneak-attack"] = false;
-        }
+        await applyRogueSneakAttack(character, name, properties, damages,
+                                   damage_types, roll_properties,
+                                   settings_to_change);
         const crits = damagesToCrits(character, damages, damage_types);
         const crit_damages = [];
         const crit_damage_types = [];

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -575,13 +575,15 @@ function handleSpecialGeneralAttacks(damages=[], damage_types=[], properties, se
             const intelligence = character.getAbility("INT") || {mod: 0};
             const mod = parseInt(intelligence.mod) || 0;
             const psychic_action = action_name.toLocaleLowerCase();
-            if(["psionic power: psionic strike"].includes(psychic_action)) {
+            if(["psionic power: psionic strike", "psionic power: protective field"].includes(psychic_action)) {
                 // Use full modifier, even if deeply negative
                 damages[0] = ensureModifier(damages[0], mod);
-            } else if(["psionic power: protective field"].includes(psychic_action)) {
-                // Clamp the modifier to minimum of -1, not below that
-                const cappedMod = mod < -1 ? -1 : mod;
-                damages[0] = ensureModifier(damages[0], cappedMod);
+
+                if(mod < 0 && ["psionic power: protective field"].includes(psychic_action)) {
+                    // Set the min value to 1 + (negative mod) ensures that the results are never negative
+                    const minValue = 1 + Math.abs(mod);
+                    damages[0] = damages[0].replace(/[0-9]*d[0-9]+/g, match => `${match}min${minValue}`);
+                }
             }
         } 
     }

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -1303,7 +1303,7 @@ async function rollAction(paneClass, force_to_hit_only = false, force_damages_on
             "predatory strike",
             "enhanced unarmed strike",
             "flurry of blows"
-        ].includes(action_name.toLocaleLowerCase());
+        ].some(action => action_name.toLocaleLowerCase().includes(action));
         
         const isRangedAttack = action_name.includes("Lightning Launcher");
 

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -422,7 +422,7 @@ function handleSpecialMeleeAttacks(damages=[], damage_types=[], properties, sett
                 damage_types.push("Symbiotic Entity");
         }
     }
-
+    
     if (character.hasClass("Paladin")) {
         // Paladin: Improved Divine Smite
         // Radiant Strikes works on melee and unarmed strikes, while Improved Divine Smite
@@ -569,6 +569,20 @@ function handleSpecialGeneralAttacks(damages=[], damage_types=[], properties, se
     }
 
     // Class Specific
+    if (character.hasClass("Fighter")) {
+        if(character.hasClassFeature("Psionic Power")) {
+            // HACK ALERT: fixes dndbeyond missing mods but incase they are added in the future we ensure the mdo is applied if not present if it is present it is not applied
+            const intelligence = character.getAbility("INT") || {mod: 0};
+            const mod = parseInt(intelligence.mod) || 0;
+            const psychic_action = action_name.toLocaleLowerCase();
+            if(["psionic power: psionic strike"].includes(psychic_action)) {
+                damages[0] = ensureModifier(damages[0], mod);
+            } else if(["psionic power: protective field"].includes(psychic_action)) {
+                damages[0] = ensureModifier(damages[0], mod).replace(/[0-9]*d[0-9]+/g, "$&min1");
+            }
+        } 
+    }
+
     if (character.hasClass("Cleric")) {
         // Cleric: Blessed Strikes
         if ((((item_name || action_name) && to_hit != null) || (spell_name && spell_level.includes("Cantrip"))) &&

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -315,7 +315,7 @@ function rollInitiative() {
     //console.log("Initiative " + ("with" if (advantage else "without") + " advantage ) { " + initiative);
 
     if (character.getGlobalSetting("initiative-tiebreaker", false)) {
-        // Set the tiebreaker to the dexterity score but default to case.includes(0) abilities arrary is empty;
+        // Set the tiebreaker to the dexterity score, defaulting to 0 if the abilities array is empty;
         const tiebreaker = character.getAbility("DEX").score;
 
         // Add tiebreaker as a decimal;

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -476,8 +476,9 @@ function handleSpecialMeleeAttacks(damages=[], damage_types=[], properties, sett
     // enhanced unarmed strike
     if(to_hit !== null && 
         character.hasFeat("Tavern Brawler 2024") &&
-        action_name.toLocaleLowerCase() === "enhanced unarmed strike") {
+        ["enhanced unarmed strike", "unarmed strike", "flurry of blows"].includes(action_name.toLocaleLowerCase())) {
         damages[0] = damages[0].replace(/[0-9]*d[0-9]+/g, "$&ro<=1");
+        effects.push("Tavern Brawler");
     }
 
     // Charger Feat
@@ -1263,11 +1264,27 @@ async function rollAction(paneClass, force_to_hit_only = false, force_damages_on
             damages[0] = applyGWFIfRequired(action_name, properties, damages[0]);
         }
 
-        const isMeleeAttack = action_name.includes("Polearm Master") || action_name.includes("Pole Strike") || action_name.includes("Unarmed Strike") || action_name.includes("Tavern Brawler Strike")
-        || action_name.includes("Psychic Blade") || action_name.includes("Bite") || action_name.includes("Claws") || action_name.includes("Tail")
-        || action_name.includes("Ram") || action_name.includes("Horns") || action_name.includes("Hooves") || action_name.includes("Talons") 
-        || action_name.includes("Thunder Gauntlets") || action_name.includes("Unarmed Fighting") || action_name.includes("Arms of the Astral Self")
-        || action_name.includes("Shadow Blade") || action_name.includes("Predatory Strike");
+        const isMeleeAttack = [
+            "polearm master",
+            "pole strike",
+            "unarmed strike",
+            "tavern brawler strike",
+            "psychic blade",
+            "bite",
+            "claws",
+            "tail",
+            "ram",
+            "horns",
+            "hooves",
+            "talons",
+            "thunder gauntlets",
+            "unarmed fighting",
+            "arms of the astral self",
+            "shadow blade",
+            "predatory strike",
+            "enhanced unarmed strike",
+            "flurry of blows"
+        ].includes(action_name.toLocaleLowerCase());
         
         const isRangedAttack = action_name.includes("Lightning Launcher");
 

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -571,14 +571,17 @@ function handleSpecialGeneralAttacks(damages=[], damage_types=[], properties, se
     // Class Specific
     if (character.hasClass("Fighter")) {
         if(character.hasClassFeature("Psionic Power")) {
-            // HACK ALERT: fixes dndbeyond missing mods but incase they are added in the future we ensure the mdo is applied if not present if it is present it is not applied
+            // HACK ALERT: fixes dndbeyond missing mods but incase they are added in the future we ensure the mod is applied if not present if it is present it is not applied
             const intelligence = character.getAbility("INT") || {mod: 0};
             const mod = parseInt(intelligence.mod) || 0;
             const psychic_action = action_name.toLocaleLowerCase();
             if(["psionic power: psionic strike"].includes(psychic_action)) {
+                // Use full modifier, even if deeply negative
                 damages[0] = ensureModifier(damages[0], mod);
             } else if(["psionic power: protective field"].includes(psychic_action)) {
-                damages[0] = ensureModifier(damages[0], mod).replace(/[0-9]*d[0-9]+/g, "$&min1");
+                // Clamp the modifier to minimum of -1, not below that
+                const cappedMod = mod < -1 ? -1 : mod;
+                damages[0] = ensureModifier(damages[0], cappedMod);
             }
         } 
     }

--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -56,14 +56,14 @@ function sendMessageToRoll20(request, limit = null, failure = null) {
         const vtt = limit.vtt || "roll20"
         if (vtt == "roll20") {
             chrome.tabs.query({ "url": ROLL20_URL }, (tabs) => {
-                found = filterVTTTab(request, limit, tabs, roll20Title)
+                let found = filterVTTTab(request, limit, tabs, roll20Title)
                 if (failure)
                     failure(!found)
             })
         } else {
             failure(true)
         }
-    } else { 
+    } else {
         sendMessageTo(ROLL20_URL, request, failure);
     }
 }
@@ -73,7 +73,7 @@ function sendMessageToFVTT(request, limit, failure = null) {
     if (limit) {
         const vtt = limit.vtt || "fvtt"
         if (vtt == "fvtt") {
-            found = filterVTTTab(request, limit, fvtt_tabs, fvttTitle)
+            let found = filterVTTTab(request, limit, fvtt_tabs, fvttTitle)
             if (failure)
                 failure(!found)
         } else {


### PR DESCRIPTION
I have added tot he tavern brawler 2024 feat

> [!NOTE]
> Fixes: https://github.com/kakaroto/Beyond20/issues/1252 

> Now all unarmed strike have the r<=1 also made a few smaller changes, these attacked were not being recognised as melee so other feats were not being applied to them. The attacks were, "enhanced unarmed strike", "flurry of blows" and "unarmed strike".

> [!IMPORTANT]
> This has highlighted also that the flurry of blows was not taking advantage of other feats that affect melee attacks.

# tavern brawler effect now will show in the attacks
![Image](https://github.com/user-attachments/assets/de95bc62-5ae9-4d5f-be5d-3c75bf2fc5c6)

# Unarmed Strike
![Image](https://github.com/user-attachments/assets/c683cdf6-ccec-4a88-b6cc-5a21b82240af)

# Enhanced Unarmed Strike
![Image](https://github.com/user-attachments/assets/f3670c20-e778-4e28-9b49-e779ef6f67f3)

# Bonus action Unarmed Strike
![Image](https://github.com/user-attachments/assets/d0c1917e-386f-4e57-8eb5-9f9f04a2cc32)

# Flurry of Blows
![Image](https://github.com/user-attachments/assets/17c13f8c-fff0-4be7-bf9f-ae88389d12ad)