### PR TITLE
fix: Psionic skills

### DIFF
--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -393,6 +393,15 @@ async function buildAttackRoll(character, attack_source, name, description, prop
     return roll_properties;
 }
 
+function ensureModifier(damageStr, modValue) {
+    const hasMod = /\d+d\d+\s*[+-]\s*\d+/.test(damageStr);
+    if (hasMod) return damageStr;
+
+    // If mod is positive, add '+' explicitly
+    const sign = modValue >= 0 ? "+" : "";
+    return `${damageStr}${sign}${modValue}`;
+}
+
 function applyGWFIfRequired(action_name, properties, damage) {
     if((properties["Attack Type"] == "Melee" && 
         ((properties["Properties"].includes("Versatile") && character.getSetting("versatile-choice") != "one") || 

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -570,14 +570,17 @@ function handleSpecialGeneralAttacks(damages=[], damage_types=[], properties, se
     // Class Specific
     if (character.hasClass("Fighter")) {
         if(character.hasClassFeature("Psionic Power")) {
-            // HACK ALERT: fixes dndbeyond missing mods but incase they are added in the future we ensure the mdo is applied if not present if it is present it is not applied
+            // HACK ALERT: fixes dndbeyond missing mods but incase they are added in the future we ensure the mod is applied if not present if it is present it is not applied
             const intelligence = character.getAbility("INT") || {mod: 0};
             const mod = parseInt(intelligence.mod) || 0;
             const psychic_action = action_name.toLocaleLowerCase();
             if(["psionic power: psionic strike"].includes(psychic_action)) {
+                // Use full modifier, even if deeply negative
                 damages[0] = ensureModifier(damages[0], mod);
             } else if(["psionic power: protective field"].includes(psychic_action)) {
-                damages[0] = ensureModifier(damages[0], mod).replace(/[0-9]*d[0-9]+/g, "$&min1");
+                // Clamp the modifier to minimum of -1, not below that
+                const cappedMod = mod < -1 ? -1 : mod;
+                damages[0] = ensureModifier(damages[0], cappedMod);
             }
         } 
     }

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -422,7 +422,7 @@ function handleSpecialMeleeAttacks(damages=[], damage_types=[], properties, sett
                 damage_types.push("Symbiotic Entity");
         }
     }
-
+    
     if (character.hasClass("Paladin")) {
         // Paladin: Improved Divine Smite
         // Radiant Strikes works on melee and unarmed strikes, while Improved Divine Smite
@@ -568,6 +568,20 @@ function handleSpecialGeneralAttacks(damages=[], damage_types=[], properties, se
     }
 
     // Class Specific
+    if (character.hasClass("Fighter")) {
+        if(character.hasClassFeature("Psionic Power")) {
+            // HACK ALERT: fixes dndbeyond missing mods but incase they are added in the future we ensure the mdo is applied if not present if it is present it is not applied
+            const intelligence = character.getAbility("INT") || {mod: 0};
+            const mod = parseInt(intelligence.mod) || 0;
+            const psychic_action = action_name.toLocaleLowerCase();
+            if(["psionic power: psionic strike"].includes(psychic_action)) {
+                damages[0] = ensureModifier(damages[0], mod);
+            } else if(["psionic power: protective field"].includes(psychic_action)) {
+                damages[0] = ensureModifier(damages[0], mod).replace(/[0-9]*d[0-9]+/g, "$&min1");
+            }
+        } 
+    }
+
     if (character.hasClass("Cleric")) {
         // Cleric: Blessed Strikes
         if ((((item_name || action_name) && to_hit != null) || (spell_name && spell_level.includes("Cantrip"))) &&

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -574,13 +574,15 @@ function handleSpecialGeneralAttacks(damages=[], damage_types=[], properties, se
             const intelligence = character.getAbility("INT") || {mod: 0};
             const mod = parseInt(intelligence.mod) || 0;
             const psychic_action = action_name.toLocaleLowerCase();
-            if(["psionic power: psionic strike"].includes(psychic_action)) {
+            if(["psionic power: psionic strike", "psionic power: protective field"].includes(psychic_action)) {
                 // Use full modifier, even if deeply negative
                 damages[0] = ensureModifier(damages[0], mod);
-            } else if(["psionic power: protective field"].includes(psychic_action)) {
-                // Clamp the modifier to minimum of -1, not below that
-                const cappedMod = mod < -1 ? -1 : mod;
-                damages[0] = ensureModifier(damages[0], cappedMod);
+
+                if(mod < 0 && ["psionic power: protective field"].includes(psychic_action)) {
+                    // Set the min value to 1 + (negative mod) ensures that the results are never negative
+                    const minValue = 1 + Math.abs(mod);
+                    damages[0] = damages[0].replace(/[0-9]*d[0-9]+/g, match => `${match}min${minValue}`);
+                }
             }
         } 
     }


### PR DESCRIPTION
> [!NOTE]
> Fixes: https://github.com/kakaroto/Beyond20/issues/1251 

# added mod to the Psionic warrior actions

> Added the int mod protective field is a min of 1 roll

## Psionic Power: Psionic Strike
![image](https://github.com/user-attachments/assets/6fe69b6e-094a-42d4-b674-c1e4da6dd2af)

## Psionic Power: Protective Field
![image](https://github.com/user-attachments/assets/596e1235-9de2-475f-8279-9ad9980452a3)
