### PR TITLE
Foundry v13 deprecation errors

### DIFF
--- a/FVTT-module/beyond20/beyond20.css
+++ b/FVTT-module/beyond20/beyond20.css
@@ -8,6 +8,12 @@
     padding: 0px 5px;
 }
 
+/* Ensure hover tooltips aren't clipped by surrounding elements */
+.beyond20-message,
+.beyond20-tooltip {
+    overflow: visible;
+}
+
 .beyond20-total-damage {
     font-size: 1.05em;
     font-weight: bold;

--- a/FVTT-module/beyond20/beyond20.css
+++ b/FVTT-module/beyond20/beyond20.css
@@ -14,6 +14,11 @@
     overflow: visible;
 }
 
+/* Foundry sets overflow:hidden which clips tooltips */
+.beyond20-message .message-content {
+    overflow: visible;
+}
+
 .beyond20-total-damage {
     font-size: 1.05em;
     font-weight: bold;

--- a/FVTT-module/beyond20/beyond20.css
+++ b/FVTT-module/beyond20/beyond20.css
@@ -4,6 +4,7 @@
 .beyond20-roll-result,
 .beyond20-roller-error {
     position: relative;
+    overflow: visible;
     padding: 0px 5px;
 }
 

--- a/FVTT-module/beyond20/beyond20.js
+++ b/FVTT-module/beyond20/beyond20.js
@@ -1,6 +1,8 @@
 
 
 const fvtt_isNewer = foundry && foundry.utils && foundry.utils.isNewerVersion ? foundry.utils.isNewerVersion : isNewerVersion;
+const fvtt_Die = foundry && foundry.dice && foundry.dice.terms && foundry.dice.terms.Die ? foundry.dice.terms.Die : Die;
+const fvtt_PoolTerm = foundry && foundry.dice && foundry.dice.terms && foundry.dice.terms.PoolTerm ? foundry.dice.terms.PoolTerm : PoolTerm;
 
 class Beyond20 {
     static getMyActor() {

--- a/FVTT-module/beyond20/beyond20.js
+++ b/FVTT-module/beyond20/beyond20.js
@@ -643,7 +643,13 @@ class Beyond20 {
 
     static handleBeyond20Request(action, request) {
         if (action !== "roll") return;
-        if (!game.settings.get("beyond20", "nativeRolls")) return;
+        let nativeRolls = false;
+        try {
+            nativeRolls = game.settings.get("beyond20", "nativeRolls");
+        } catch (err) {
+            nativeRolls = false;
+        }
+        if (!nativeRolls) return;
         // return false to interrupt the beyond20 
         switch (request.type) {
             case "skill":
@@ -670,7 +676,13 @@ class Beyond20 {
      * Add Chat Damage buttons to Beyond20 chat messages;
      */
     static handleChatMessage(message, html, data) {
-        if (!game.settings.get("beyond20", "damageButtons")) return;
+        let showButtons = false;
+        try {
+            showButtons = game.settings.get("beyond20", "damageButtons");
+        } catch (err) {
+            showButtons = false;
+        }
+        if (!showButtons) return;
         if (!(html instanceof jQuery)) html = $(html);
         const damages = html.find(".beyond20-message .beyond20-roll-damage, .beyond20-message .beyond20-total-damage");
         if (damages.length === 0) return;

--- a/FVTT-module/beyond20/beyond20.js
+++ b/FVTT-module/beyond20/beyond20.js
@@ -182,7 +182,7 @@ class Beyond20 {
         let token = null;
         if (request.character.name) {
             const name = request.character.name.toLowerCase().trim();
-            token = canvas.tokens.placeables.find((t) => t.owner && t.name.toLowerCase().trim() == name);
+            token = canvas.tokens.placeables.find((t) => ('isOwner' in t ? t.isOwner : t.owner) && t.name.toLowerCase().trim() == name);
         }
         return token || canvas.tokens.controlled[0];
     }
@@ -435,7 +435,7 @@ class Beyond20 {
 
     static async rollInitiative(request) {
         const characterName = request.character.name.toLowerCase().trim();
-        const characterTokens = canvas.tokens.placeables.filter((t) => t.owner && t.name.toLowerCase().trim() == characterName);
+        const characterTokens = canvas.tokens.placeables.filter((t) => ('isOwner' in t ? t.isOwner : t.owner) && t.name.toLowerCase().trim() == characterName);
         const tokens = characterTokens.length > 0 ? characterTokens : canvas.tokens.controlled;
         if (tokens.length === 0) {
             ui.notifications.warn("Beyond20: No tokens found to roll initiative for");

--- a/FVTT-module/beyond20/beyond20.js
+++ b/FVTT-module/beyond20/beyond20.js
@@ -1,5 +1,7 @@
 
 
+const fvtt_isNewer = foundry && foundry.utils && foundry.utils.isNewerVersion ? foundry.utils.isNewerVersion : isNewerVersion;
+
 class Beyond20 {
     static getMyActor() {
         return game.actors.find(a => a.isOwner && a.getFlag("beyond20", "user") === (game.user?.id || game.userId));
@@ -38,7 +40,7 @@ class Beyond20 {
             },
         };
         // In v10, permission field was changed into ownership
-        if (isNewerVersion(game.version || game.data.version, "10")) {
+        if (fvtt_isNewer(game.version || game.data.version, "10")) {
             baseAttributes["ownership"] = {
                 [game.user?.id || game.userId]: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER
             }
@@ -760,7 +762,7 @@ class Beyond20CreateNativeActorsApplication extends FormApplication {
                     }
                 }
                 // In v10, permission field was changed into ownership
-                if (isNewerVersion(game.version || game.data.version, "10")) {
+                if (fvtt_isNewer(game.version || game.data.version, "10")) {
                     actorData["ownership"] = {
                         [user.id]: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER
                     }
@@ -778,7 +780,7 @@ class Beyond20CreateNativeActorsApplication extends FormApplication {
 }
 
 Hooks.on('beyond20Request', (action, request) => Beyond20.handleBeyond20Request(action, request))
-const chatHook = isNewerVersion(game.version || game.data.version, "13") ? "renderChatMessageHTML" : "renderChatMessage";
+const chatHook = fvtt_isNewer(game.version || game.data.version, "13") ? "renderChatMessageHTML" : "renderChatMessage";
 Hooks.on(chatHook, (message, html, data) => Beyond20.handleChatMessage(message, html, data));
 
 Hooks.on('init', function () {
@@ -811,7 +813,7 @@ Hooks.on('init', function () {
         type: Boolean,
         onChange: async (v) => {
             if (!v) return;
-            if (!isNewerVersion(foundryVersion, "10")) {
+            if (!fvtt_isNewer(foundryVersion, "10")) {
                 ui.notifications.warn(`Cannot enable Beyond20 native rolls on Foundry VTT v${foundryVersion}. Please upgrade to version 10 or newer.`);
                 return game.settings.set("beyond20", "nativeRolls", false);
             }
@@ -841,7 +843,7 @@ Hooks.on('ready', function () {
         }
     }
     // Disable native rolls if Foundry is pre v10
-    if (game.settings.get("beyond20", "nativeRolls") && !isNewerVersion(foundryVersion, "10")) {
+    if (game.settings.get("beyond20", "nativeRolls") && !fvtt_isNewer(foundryVersion, "10")) {
         ui.notifications.warn(`Disabled Beyond20 native rolls feature as it is incompatible with Foundry VTT v${foundryVersion}. Please upgrade to version 10 or newer.`, {permanent: true});
         game.settings.set("beyond20", "nativeRolls", false);
     }

--- a/FVTT-module/beyond20/beyond20.js
+++ b/FVTT-module/beyond20/beyond20.js
@@ -667,6 +667,7 @@ class Beyond20 {
      */
     static handleChatMessage(message, html, data) {
         if (!game.settings.get("beyond20", "damageButtons")) return;
+        if (!(html instanceof jQuery)) html = $(html);
         const damages = html.find(".beyond20-message .beyond20-roll-damage, .beyond20-message .beyond20-total-damage");
         if (damages.length === 0) return;
         for (let i = 0; i < damages.length; i++) {
@@ -777,7 +778,8 @@ class Beyond20CreateNativeActorsApplication extends FormApplication {
 }
 
 Hooks.on('beyond20Request', (action, request) => Beyond20.handleBeyond20Request(action, request))
-Hooks.on("renderChatMessage", (message, html, data) => Beyond20.handleChatMessage(message, html, data));
+const chatHook = isNewerVersion(game.version || game.data.version, "13") ? "renderChatMessageHTML" : "renderChatMessage";
+Hooks.on(chatHook, (message, html, data) => Beyond20.handleChatMessage(message, html, data));
 
 Hooks.on('init', function () {
     const foundryVersion = game.version || game.data.version;

--- a/src/extension/beyond20.css
+++ b/src/extension/beyond20.css
@@ -47,6 +47,12 @@
     padding: 0px 5px;
 }
 
+/* Ensure hover tooltips aren't clipped by surrounding elements */
+.beyond20-message,
+.beyond20-tooltip {
+    overflow: visible;
+}
+
 .beyond20-total-damage {
     font-size: 1.05em;
     font-weight: bold;

--- a/src/extension/beyond20.css
+++ b/src/extension/beyond20.css
@@ -53,6 +53,11 @@
     overflow: visible;
 }
 
+/* Foundry sets overflow:hidden which clips tooltips */
+.beyond20-message .message-content {
+    overflow: visible;
+}
+
 .beyond20-total-damage {
     font-size: 1.05em;
     font-weight: bold;

--- a/src/extension/beyond20.css
+++ b/src/extension/beyond20.css
@@ -43,6 +43,7 @@
 .beyond20-roll-result,
 .beyond20-roller-error {
     position: relative;
+    overflow: visible;
     padding: 0px 5px;
 }
 

--- a/src/fvtt/page-script.js
+++ b/src/fvtt/page-script.js
@@ -14,7 +14,9 @@ const docIsOwner = (doc) => {
 
 class FVTTDisplayer {
     postHTML(request, title, html, character, whisper, play_sound, source, attributes, description, attack_rolls, roll_info, damage_rolls, total_damages, open) {
-        Hooks.once('renderChatMessage', (chat_message, html, data) => {
+        const hookName = fvtt_isNewer(fvttVersion, "13") ? 'renderChatMessageHTML' : 'renderChatMessage';
+        Hooks.once(hookName, (chat_message, html, data) => {
+            if (!(html instanceof jQuery)) html = $(html);
             const icon = extension_url + "images/icons/badges/custom20.png";
             html.find(".ct-beyond20-custom-icon").attr('src', icon);
             html.find(".ct-beyond20-custom-roll").on('click', (event) => {

--- a/src/fvtt/page-script.js
+++ b/src/fvtt/page-script.js
@@ -3,6 +3,8 @@ var extension_url = "/modules/beyond20/";
 var fvttVersion = game.version || game.data?.version;
 //isNewerVersion is deprecated in Foundry 12
 const fvtt_isNewer = window.foundry && foundry.utils && foundry.utils.isNewerVersion ? (v1, v0) => foundry.utils.isNewerVersion(v1, v0) : isNewerVersion;
+// getProperty is deprecated in Foundry 13
+const fvtt_getProperty = window.foundry && foundry.utils && foundry.utils.getProperty ? (obj, path) => foundry.utils.getProperty(obj, path) : getProperty;
 // v10 uses .document for Placeables (tokens), or the Base object itself, instead of .data field
 // We use the new fields to avoid spamming the log with deprecation warnings
 const docData = (doc) => fvtt_isNewer(fvttVersion, "10") ? doc.document || doc : doc.data;
@@ -471,18 +473,18 @@ function updateHP(name, current, total, temp) {
         const actors = game.actors?.contents || game.actors?.entities || game.actors; // v13 compatibility
         const actor = actors.find((a) => docIsOwner(a) && a.name.toLowerCase().trim() == name);
         const systemData = fvtt_isNewer(fvttVersion, "10") ? actor?.system : actor?.data?.data;
-        if (actor && getProperty(systemData, "attributes.hp") !== undefined) {
+        if (actor && fvtt_getProperty(systemData, "attributes.hp") !== undefined) {
             actor.update(dnd5e_data);
-        } else if (actor && getProperty(systemData, "health") !== undefined) {
+        } else if (actor && fvtt_getProperty(systemData, "health") !== undefined) {
             actor.update(sws_data);
         }
     }
 
     for (let token of tokens) {
         const systemData = fvtt_isNewer(fvttVersion, "10") ? token.actor?.system : token.actor?.data?.data;
-        if (token.actor && getProperty(systemData, "attributes.hp") !== undefined) {
+        if (token.actor && fvtt_getProperty(systemData, "attributes.hp") !== undefined) {
             token.actor.update(dnd5e_data);
-        } else if (token.actor && getProperty(systemData, "health") !== undefined) {
+        } else if (token.actor && fvtt_getProperty(systemData, "health") !== undefined) {
             token.actor.update(sws_data);
         }
     }

--- a/src/fvtt/page-script.js
+++ b/src/fvtt/page-script.js
@@ -39,7 +39,8 @@ class FVTTDisplayer {
     }
 
     _postChatMessage(message, character, whisper, play_sound = false, attack_rolls, damage_rolls) {
-        const MESSAGE_TYPES = CONST.CHAT_MESSAGE_TYPES || CHAT_MESSAGE_TYPES;
+        const MESSAGE_STYLES = CONST.CHAT_MESSAGE_STYLES || CONST.CHAT_MESSAGE_TYPES || CHAT_MESSAGE_STYLES || CHAT_MESSAGE_TYPES;
+        const styleProp = fvtt_isNewer(fvttVersion, "13") ? "style" : "type";
         const data = {
             "content": message,
             "user": game.user?.id || game.user?._id,
@@ -48,11 +49,11 @@ class FVTTDisplayer {
         const rollMode = this._whisperToRollMode(whisper);
         if (["gmroll", "blindroll"].includes(rollMode)) {
             data["whisper"] = (ChatMessage.getWhisperRecipients || ChatMessage.getWhisperIDs).call(ChatMessage, "GM");
-            data['type'] = MESSAGE_TYPES.WHISPER;
+            data[styleProp] = MESSAGE_STYLES.WHISPER;
             if (rollMode == "blindroll")
                 data["blind"] = true;
         } else {
-            data['type'] = MESSAGE_TYPES.OOC;
+            data[styleProp] = MESSAGE_STYLES.OOC;
         }
         if (play_sound)
             data["sound"] = CONFIG.sounds.dice;
@@ -179,7 +180,7 @@ class FVTTDisplayer {
                 pool_roll._rolled = true;
                 data.roll = pool_roll;
             }
-            data.type = MESSAGE_TYPES.ROLL;
+            data[styleProp] = MESSAGE_STYLES.ROLL;
         }
         return ChatMessage.create(data, {rollMode});
     }
@@ -500,12 +501,13 @@ function updateConditions(request, name, conditions, exhaustion) {
     if (exhaustion > 0)
         display_conditions = conditions.concat(["Exhausted (Level " + exhaustion + ")"]);
     const message = name + (display_conditions.length == 0 ? " has no active condition" : " is : " + display_conditions.join(", "));
-    const MESSAGE_TYPES = CONST.CHAT_MESSAGE_TYPES || CHAT_MESSAGE_TYPES;
+    const MESSAGE_STYLES = CONST.CHAT_MESSAGE_STYLES || CONST.CHAT_MESSAGE_TYPES || CHAT_MESSAGE_STYLES || CHAT_MESSAGE_TYPES;
+    const styleProp = fvtt_isNewer(fvttVersion, "13") ? "style" : "type";
     ChatMessage.create({
         "content": message,
         "user": game.user?.id || game.user?._id,
         "speaker": roll_renderer._displayer._getSpeakerByName(name),
-        "type": MESSAGE_TYPES.EMOTE
+        [styleProp]: MESSAGE_STYLES.EMOTE
     });
 
     // Check for the beyond20 module, if (it's there, we can use its status effects.;

--- a/src/fvtt/page-script.js
+++ b/src/fvtt/page-script.js
@@ -5,6 +5,9 @@ var fvttVersion = game.version || game.data?.version;
 const fvtt_isNewer = window.foundry && foundry.utils && foundry.utils.isNewerVersion ? (v1, v0) => foundry.utils.isNewerVersion(v1, v0) : isNewerVersion;
 // getProperty is deprecated in Foundry 13
 const fvtt_getProperty = window.foundry && foundry.utils && foundry.utils.getProperty ? (obj, path) => foundry.utils.getProperty(obj, path) : getProperty;
+// Die and PoolTerm moved under foundry.dice.terms in Foundry 13
+const fvtt_Die = window.foundry && foundry.dice?.terms?.Die ? foundry.dice.terms.Die : Die;
+const fvtt_PoolTerm = window.foundry && foundry.dice?.terms?.PoolTerm ? foundry.dice.terms.PoolTerm : PoolTerm;
 // v10 uses .document for Placeables (tokens), or the Base object itself, instead of .data field
 // We use the new fields to avoid spamming the log with deprecation warnings
 const docData = (doc) => fvtt_isNewer(fvttVersion, "10") ? doc.document || doc : doc.data;
@@ -152,7 +155,7 @@ class FVTTDisplayer {
             } else if (fvtt_isNewer(fvttVersion, "0.8")) {
                 // Foundry 0.8.x API
                 // This will accept backware compatible fvttRolls format
-                const pool = PoolTerm.fromRolls(fvttRolls);
+                const pool = fvtt_PoolTerm.fromRolls(fvttRolls);
                 data.roll = Roll.fromTerms([pool]);
             } else if (fvtt_isNewer(fvttVersion, "0.7")) {
                 // Foundry 0.7.x API
@@ -244,7 +247,7 @@ class FVTTRoll extends Beyond20BaseRoll {
         // 0.7.x Dice Roll API is different
         if (fvtt_isNewer(fvttVersion, "0.8")) {
             return this._roll.terms.map(t => {
-                if (t instanceof Die) {
+                if (t instanceof fvtt_Die) {
                     return {
                         amount: t.amount || t.number,
                         faces: t.faces,
@@ -252,7 +255,7 @@ class FVTTRoll extends Beyond20BaseRoll {
                         total: t.total,
                         rolls: t.results.map(r => ({discarded: r.discarded || r.rerolled, roll: r.result}))
                     }
-                } else if (t instanceof PoolTerm) {
+                } else if (t instanceof fvtt_PoolTerm) {
                     const dice = t.rolls[0]?.dice[0];
                     // A DicePool means a "minX", so don't include it in the roll results
                     const results = t.results.slice(0, t.results.length - 1);
@@ -270,7 +273,7 @@ class FVTTRoll extends Beyond20BaseRoll {
             });
         } else if (fvtt_isNewer(fvttVersion, "0.7")) {
             return this._roll.terms.map(t => {
-                if (t instanceof Die) {
+                if (t instanceof fvtt_Die) {
                     return {
                         amount: t.amount || t.number,
                         faces: t.faces,

--- a/src/fvtt/page-script.js
+++ b/src/fvtt/page-script.js
@@ -180,7 +180,9 @@ class FVTTDisplayer {
                 pool_roll._rolled = true;
                 data.roll = pool_roll;
             }
-            data[styleProp] = MESSAGE_STYLES.ROLL;
+            if (!fvtt_isNewer(fvttVersion, "13")) {
+                data[styleProp] = MESSAGE_STYLES.ROLL;
+            }
         }
         return ChatMessage.create(data, {rollMode});
     }


### PR DESCRIPTION
This pull request incorporates the changes from the foundry-v13-fix branch.

All deprecated API (I found) calls have been replaced with their modern Foundry equivalents and adjusted as needed.
To preserve backward-compatibility wherever possible, I’ve declared a few globals.

Known issue: Tooltips in chat combat messages are still being clipped.