### PR TITLE
fix: allow reckless to be use outside of rage, minor fixs on feature …

### DIFF
--- a/src/dndbeyond/base/character.js
+++ b/src/dndbeyond/base/character.js
@@ -298,7 +298,8 @@ class Character extends CharacterBase {
                 feat_name.toLowerCase() === "fighting style" ||
                 feat_name.toLowerCase() === "additional fighting style" ||
                 feat_name.toLowerCase() === "great weapon fighting" ||
-                feat_name.toLowerCase() === "sneak attack"       
+                feat_name.toLowerCase() === "sneak attack" ||
+                feat_name.toLowerCase() === "frenzy"
             ) && ( 
                 feat_reference.toLowerCase().includes("2024")) ||
                 feat_reference.toLowerCase().includes("free-rules")

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -404,23 +404,23 @@ function isItemAnInstruction(item_name, item_tags) {
 function handleSpecialMeleeAttacks(damages=[], damage_types=[], properties, settings_to_change={}, { to_hit, action_name="", effects=[] }={}) {
     if (character.hasClass("Barbarian")) {
         // Barbarian: Rage
+        const barbarian_level = character.getClassLevel("Barbarian");
+        const rage_damage = barbarian_level < 9 ? 2 : (barbarian_level < 16 ? 3 : 4);
         if (character.hasClassFeature("Rage") &&
             character.getSetting("barbarian-rage", false)) {
-            const barbarian_level = character.getClassLevel("Barbarian");
-            const rage_damage = barbarian_level < 9 ? 2 : (barbarian_level < 16 ? 3 : 4);
             damages.push(String(rage_damage));
             damage_types.push("Rage");
             effects.push("Rage");
-            if (character.getSetting("barbarian-reckless", false)) {
-                effects.push("Reckless Attack");
-                const isLocked = character.getSetting("barbarian-reckless-lock", false);
-                if(!isLocked) settings_to_change["barbarian-reckless"] = false;
-                if (character.hasClassFeature("Frenzy")) {
-                    damages.push(`${rage_damage}d6`);
-                    damage_types.push("Frenzy");
-                    effects.push("Frenzy");
-                }
-
+        }
+        if (character.getSetting("barbarian-reckless", false)) {
+            effects.push("Reckless Attack");
+            const isLocked = character.getSetting("barbarian-reckless-lock", false);
+            if(!isLocked) settings_to_change["barbarian-reckless"] = false;
+            if (character.hasClassFeature("Rage") && character.getSetting("barbarian-rage", false) && 
+                character.hasClassFeature("Frenzy 2024")) {
+                damages.push(`${rage_damage}d6`);
+                damage_types.push("Frenzy");
+                effects.push("Frenzy");
             }
         }
     }


### PR DESCRIPTION
…selection

> [!NOTE]
> Fixes https://github.com/kakaroto/Beyond20/issues/1275

# Changes

Made reckless usable outside of rage and also made sure frenzy from 2024 is only ever applied for 2024 characters. 