### PR TITLE
fix: dndbeyond actions and sneak

### DIFF
--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -168,7 +168,7 @@ async function applyRogueSneakAttack(character, name, properties, damages,
                                      damage_types, roll_properties,
                                      settings_to_change) {
     if (!(character.hasClass("Rogue") &&
-          character.hasClassFeature("Sneak Attack 2024") &&
+          (character.hasClassFeature("Sneak Attack 2024") || character.hasClassFeature("Sneak Attack")) &&
           !name.includes("Psionic Power: Psychic Whispers") &&
           (
               character.getSetting("rogue-sneak-attack", false) ||

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -540,7 +540,7 @@ function IsHeavy(properties) {
     return ((properties["Properties"] && properties["Properties"].includes("Heavy")) && properties["Proficient"] == "Yes");
 }
 
-function handleSpecialRangedAttacks(damages=[], damage_types=[], properties, settings_to_change={}, { to_hit, action_name="", effects=[] }={}) {
+function handleSpecialRangedAttacks(damages=[], damage_types=[], properties, settings_to_change={}, { to_hit, action_name="", effects=[]}={}) {
     // Feats
     // Sharpshooter Feat
     if (to_hit !== null && 
@@ -570,7 +570,7 @@ function handleSpecialRangedAttacks(damages=[], damage_types=[], properties, set
     return to_hit;
 }
 
-function handleSpecialGeneralAttacks(damages=[], damage_types=[], properties, settings_to_change={}, {to_hit, action_name, item_name, spell_name, spell_level}={}) {
+function handleSpecialGeneralAttacks(damages=[], damage_types=[], properties, settings_to_change={}, {to_hit, action_name, item_name, spell_name, spell_level, effects=[]}={}) {
     // Racial Traits
     //Protector Aasimar: Radiant Soul Damage
     if (character.hasRacialTrait("Radiant Soul") &&
@@ -2844,7 +2844,7 @@ function documentModified(mutations, observer) {
                 const paneClass = SPECIAL_PANES.initiative;
                 markPane(sidebar, paneClass);
                 handlePane(paneClass);
-            } else if (sidebar.find("span[class*='ddbc-action-name']").length > 0) {
+            } else if (sidebar.find("span[class*='ddbc-action-name']").length > 0 || sidebar.parent().find("div[class*='ct-item-detail']").length > 0) {
                 const paneClass = SPECIAL_PANES.action;
                 markPane(sidebar, paneClass);
                 handlePane(paneClass);

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -1243,8 +1243,12 @@ async function rollAction(paneClass, force_to_hit_only = false, force_damages_on
     //console.log("Properties are : " + String(properties));
     const action_name = $(".ct-sidebar__heading").text();
     const action_parent = $(".ct-sidebar__header-parent").text();
-    const description = descriptionToString(`.ct-action-detail__description, .${paneClass} div[class*='styles_description']`);
+    const description = descriptionToString(`.ct-action-detail__description, .${paneClass} div[class*='styles_description'], .${paneClass} .ct-item-detail__description`);
     let to_hit = properties["To Hit"] !== undefined && properties["To Hit"] !== "--" ? properties["To Hit"] : null;
+
+    if (!to_hit) {
+        to_hit = findToHit(action_name, ".ct-combat-attack--item,.ddbc-combat-attack--item", ".ct-item-name,.ddbc-item-name,span[class*='styles_itemName']", ".ct-combat-attack__tohit,.ddbc-combat-attack__tohit");
+    }
 
     if (action_name == "Superiority Dice" || action_parent == "Maneuvers") {
         const fighter_level = character.getClassLevel("Fighter");


### PR DESCRIPTION
> [!NOTE]
> Fix for the sidebar for actions, fixes  https://github.com/kakaroto/Beyond20/issues/1285

> [!IMPORTANT]
> Sneak attack for 2014 rogues was not working - they did change around this that made 2014 sneak not roll.

# Sneak
<img width="536" height="347" alt="image" src="https://github.com/user-attachments/assets/0e35c5b5-08a4-4e58-8a01-22722bb9c6eb" />
<img width="534" height="406" alt="image" src="https://github.com/user-attachments/assets/cea6a292-8ef2-4025-9024-732bb6406f78" />

# Normal attacks
<img width="530" height="280" alt="image" src="https://github.com/user-attachments/assets/45d3046a-25de-4df9-8ea6-90bddd5c39fb" />

# spells
<img width="557" height="423" alt="image" src="https://github.com/user-attachments/assets/9d12cb73-81bd-4098-b79e-732a324166db" />

# other actions
<img width="524" height="392" alt="image" src="https://github.com/user-attachments/assets/9e6aa34f-140b-4f86-a554-f3e5cd0e0858" />
