### PR TITLE
fix: sorcerous burst custom dmg

### DIFF
--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -278,9 +278,15 @@ async function buildAttackRoll(character, attack_source, name, description, prop
             if (choice === null) return null; // Query was cancelled;
         } else if (roll_properties.name === "Sorcerous Burst") {
             // HACK ALERT: temporarily use acid damage....
-            damages = damages.map(m => damages[0]); // set everything to the correct acid dmg
+            const KNOWN_TYPES = new Set(["Acid","Cold","Fire","Lightning","Poison","Psychic","Thunder"]);
+            const desired = damages[0]; // e.g., match Acid’s current damage
+            damages = damages.map((dmg, i) => {
+                const t = damage_types[i];
+                return (t && t !== "Custom" && KNOWN_TYPES.has(t)) ? desired : dmg;
+            });
+
             roll_properties["damages"] = damages; // reset roll_properties
-            const choice = await queryDamageTypeFromArray(roll_properties.name, damages, damage_types, ["Acid", "Cold", "Fire", "Lightning", "Poison", "Psychic", "Thunder"]);
+            const choice = await queryDamageTypeFromArray(roll_properties.name, damages, damage_types, KNOWN_TYPES);
             if (choice === null) return null; // Query was cancelled;
         } else if (roll_properties.name === "Dragon's Breath") {
             const choice = await queryDamageTypeFromArray(roll_properties.name, damages, damage_types, ["Acid", "Cold", "Fire", "Lightning", "Poison"]);


### PR DESCRIPTION
> [!NOTE]
> fixes  https://github.com/kakaroto/Beyond20/issues/1290

# fixes support for custom dices it will only "fix" damages from the spell and not custom items

<img width="479" height="302" alt="image" src="https://github.com/user-attachments/assets/0083c822-ce5a-4e2a-9834-875fdcec6eff" />
<img width="477" height="149" alt="image" src="https://github.com/user-attachments/assets/a0b49a5c-d1fa-400e-a633-1e6086bab3b0" />
<img width="466" height="131" alt="image" src="https://github.com/user-attachments/assets/b78473c4-8992-48c9-af67-d9a9d221d31f" />
<img width="487" height="88" alt="image" src="https://github.com/user-attachments/assets/7f46f05e-7903-473b-bc91-b8e05dc75dec" />
<img width="727" height="124" alt="image" src="https://github.com/user-attachments/assets/939247f8-d95b-4094-902e-9e5afa24be91" />
