### PR TITLE
fix: roll20 genroll fix for min value rolls in roll20

### DIFF
--- a/src/roll20/content-script.js
+++ b/src/roll20/content-script.js
@@ -46,7 +46,8 @@ function escapeRoll20Macro(text) {
 
 function genRoll(dice, modifiers = {}) {
     dice = dice.replace(/ro<=([0-9]+)/, "ro<$1");
-    dice = dice.replace(/(^|\s)+([^\s]+)min([0-9]+)([^\s]*)/g, "$1{$2$4, 0d0 + $3}kh1");
+    dice = dice.replace(/(^|\s)+([^\s]+)min([0-9]+)([^\s]*)/g, "$1{$2, 0d0 + $3}kh1$4");
+  
     let roll = "[[" + dice;
     for (let m in modifiers) {
         let mod = modifiers[m].trim();


### PR DESCRIPTION
> [!NOTE]
> Fixes -> https://github.com/kakaroto/Beyond20/issues/1299

Moved the modifier to the outside of the roll for any roll with min value

like **"1d4min3+9"** becomes **"{1d4, 0d0 + 3}kh1+9"** 

> [!WARNING]
> if the roll has 1d4min3 - 1 and you roll 1, the die should be min3 but the mod will turn it to 2. 