### PR TITLE
fix: stop custom damages being added twice and tiding up code

### DIFF
--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -938,6 +938,12 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+    "druid-circle-of-mutation-circle-forms": {
+        "title": "Druid: Circle of Mutation - Circle Forms",
+        "description": "Predator's Strike. When you hit a creature with an attack roll using a Beast form's attack in Wild Shape, you add +2 to the damage dealt.",
+        "type": "bool",
+        "default": false
+    },
     "discord-target": {
         "title": "Discord Destination",
         "description": "Send rolls to a character specific Discord channel",

--- a/src/dndbeyond/base/extras.js
+++ b/src/dndbeyond/base/extras.js
@@ -563,11 +563,21 @@ class MonsterExtras extends CharacterBase {
                                 addEffect(roll_properties, "Rage");
                             }
 
-                            if(this._parent_character.hasClass("Druid") && this._parent_character.hasClassFeature("Improved Lunar Radiance", true) && this._parent_character.getSetting("druid-improved-lunar-radiance", false))
-                            {
-                                roll_properties["damages"].push(String("2d10"));
-                                roll_properties["damage-types"].push("Lunar Radiance");
+                            if(this._parent_character.hasClass("Druid")) {
+                                if(this._parent_character.hasClassFeature("Improved Lunar Radiance", true) && this._parent_character.getSetting("druid-improved-lunar-radiance", false))
+                                {
+                                    roll_properties["damages"].push(String("2d10"));
+                                    roll_properties["damage-types"].push("Lunar Radiance");
+                                }
+                                if(this._parent_character.hasClassFeature("Druid Subclass: Circle of Mutation", true) 
+                                    && this._parent_character.hasClassFeature("Circle Forms", true) 
+                                    && this._parent_character.getSetting("druid-circle-of-mutation-circle-forms", false))
+                                {
+                                    roll_properties["damages"].push(String("2"));
+                                    roll_properties["damage-types"].push("Predator's Strike");
+                                }
                             }
+
                             // Add custom damages to wild shape attacks
                             addCustomDamages(character, roll_properties["damages"], roll_properties["damage-types"]);
                         } else if (roll_properties["damages"] && roll_properties["damages"].length > 0) {

--- a/src/dndbeyond/base/monster.js
+++ b/src/dndbeyond/base/monster.js
@@ -625,6 +625,22 @@ class Monster extends CharacterBase {
                                 roll_properties["damage-types"].push("Rage");
                                 addEffect(roll_properties, "Rage");
                             }
+
+                            if(this._parent_character.hasClass("Druid")) {
+                                if(this._parent_character.hasClassFeature("Improved Lunar Radiance", true) && this._parent_character.getSetting("druid-improved-lunar-radiance", false))
+                                {
+                                    roll_properties["damages"].push(String("2d10"));
+                                    roll_properties["damage-types"].push("Lunar Radiance");
+                                }
+                                if(this._parent_character.hasClassFeature("Druid Subclass: Circle of Mutation", true) 
+                                    && this._parent_character.hasClassFeature("Circle Forms", true) 
+                                    && this._parent_character.getSetting("druid-circle-of-mutation-circle-forms", false))
+                                {
+                                    roll_properties["damages"].push(String("2"));
+                                    roll_properties["damage-types"].push("Predator's Strike");
+                                }
+                            }
+
                             // Add custom damages to wild shape attacks
                             addCustomDamages(character, roll_properties["damages"], roll_properties["damage-types"]);
                         } else if (roll_properties["damages"] && roll_properties["damages"].length > 0) {

--- a/src/extension/popup.js
+++ b/src/extension/popup.js
@@ -362,6 +362,10 @@ function populateCharacter(response) {
             e = createHTMLOption("druid-improved-lunar-radiance", false, character_settings);
             options.append(e);
         }
+        if (response["class-features"].includes("Druid Subclass: Circle of Mutation") && response["class-features"].includes("Circle Forms")) {
+            e = createHTMLOption("druid-circle-of-mutation-circle-forms", false, character_settings);
+            options.append(e);
+        }
     }
     $('.beyond20-option-input').off('change', save_settings);
     $('.beyond20-option-input').change(save_settings);


### PR DESCRIPTION
> [!NOTE]
> Fixes:  https://github.com/kakaroto/Beyond20/issues/1301

The code was adding the custom damages twice once for wild shape and then again if it was a attack which it is.

I consolidated the code again to use the util function instead and added the if statement to an else if

tested it both normal attacks and wild shape attacked and all is working

> [!IMPORTANT]
> Added a new feature to capture the Circle of Mutation class feature Circle Forms: Predatory Strike that adds extra damage to the wild shape form. includes setting (turned off by default) to enable it and disable it

<img width="509" height="361" alt="image" src="https://github.com/user-attachments/assets/0d52acef-7305-4a73-8f7d-4f05ede41052" />

<img width="737" height="649" alt="image" src="https://github.com/user-attachments/assets/d8042c05-c657-4886-b301-afbd42e122f4" />

 