### PR TITLE
fix: unknown combatant issue

### DIFF
--- a/src/fvtt/page-script.js
+++ b/src/fvtt/page-script.js
@@ -414,7 +414,7 @@ async function addInitiativeToCombat(roll) {
                         if (combatant) {
                             await game.combat.updateEmbeddedDocuments("Combatant", [{ "_id": docData(combatant)._id, "initiative": roll.total }]);
                         } else {
-                            await game.combat.createEmbeddedDocuments("Combatant", [{ "tokenId": token.id, "hidden": docData(token).hidden, "initiative": roll.total }]);
+                            await game.combat.createEmbeddedDocuments("Combatant", [{ "tokenId": token.id, "hidden": docData(token).hidden, "initiative": roll.total, "actorId": token.actor.id, "sceneId": token.scene.id, "img": token.actor.img }]);
                         }
                     } else {
                         if (combatant) {


### PR DESCRIPTION
> [!NOTE]
> Fixes issues an issue with Foundry where the token is not linked properly, Leaving it called "Unknown Combatant" 
<img width="406" height="232" alt="image" src="https://github.com/user-attachments/assets/ce93a7ee-f6eb-4a2c-b3a3-eac97de580f3" />
