### PR TITLE
fix: added cunning strike to description in roll20

### DIFF
--- a/src/roll20/content-script.js
+++ b/src/roll20/content-script.js
@@ -606,6 +606,9 @@ function displayExtraInfo(request) {
     if (Array.isArray(request["effects"]) && request["effects"].length > 0) {
         extra += "Effects: " + request["effects"].join(", ") + "\n";
     }
+    if (request["cunning-strike-effects"]) {
+        extra += "Cunning Strike: " + request["cunning-strike-effects"] + "\n";
+    }
     if (extra != "") {
         return "\n" + template(request, "desc", { desc: extra });
     }


### PR DESCRIPTION
> [!NOTE]
> Added the ability to display cunning strike used in roll20
 
<img width="327" height="323" alt="image" src="https://github.com/user-attachments/assets/141a9935-ebe3-4940-ae53-65c53745a36d" />

Will add the same to Foundry on another ticket