### PR TITLE
fix: updated browser dectection to use the user agent

### DIFF
--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -36,7 +36,8 @@ function getBrowser() {
     const ua = navigator.userAgent;
 
     if (/Firefox\//.test(ua)) return "Firefox";
-    if (/Edge\//.test(ua)) return "Edge";
+    // 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36 Edg/143.0.0.0'
+    if (/Edg\//.test(ua)) return "Edge";
     if (
         (/Brave\//.test(ua) || (navigator.brave && typeof navigator.brave.isBrave === "function")) ||
         (/OPR\//.test(ua)) ||


### PR DESCRIPTION
> [!NOTE]
> Previous dectection logic no longer works with newest version of chrome: fixes https://github.com/kakaroto/Beyond20/issues/1329

Previous browser detection no longer works with chrome latest version.

I changed the code to use navigator.userAgent instead, and I test it for regex of each user agent.

All Brave, Opera, Safari will return Chrome
Firefox, firefix and edge will retiurn edge to keep in line with all the code that looks at firefox and chrome on the extension.

I have tested all browsers beside safari and digital dice, monster rolling etc work properly with the change.

