### PR TITLE
fix: added hidden flag to lock settings

### DIFF
--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -33,6 +33,7 @@ class CriticalRules {
 // combobox extra options:;
 //                        choices: {value: string}
 // special extra options:;
+//                        hidden: boolean; // hides options from hotkeys dialogs;
 //                        createHTMLElement: function;
 //                        set: function;
 //                        get: function;


### PR DESCRIPTION
> [!NOTE]
> fixes: https://github.com/kakaroto/Beyond20/issues/1339 Added hidden setting to lock settings so they dont show on the hotkeys page. 