### PR TITLE
fix: Highjack fix for dndbeyond rolls 

### DIFF
--- a/src/dndbeyond/base/message-broker.js
+++ b/src/dndbeyond/base/message-broker.js
@@ -4,30 +4,39 @@ class DDBMessageBroker {
         this._mb = null;
         this._messageQueue = [];
         this._blockMessages = [];
+        this._registered = false;
         this._hooks = {};
         this._characterId = (window.location.pathname.match(/\/characters\/([0-9]+)/) || [])[1];
         this.saveMessages = false;
         this._debug = false;
     }
     register() {
-        if (this._mb) return;
-        const key = Symbol.for('@dndbeyond/message-broker-lib')
-        if (key)
-            this._mb = window[key];
+        if (this._registered) return;
+
+        const key = Symbol.for('@dndbeyond/message-broker-lib');
+        if (key) this._mb = window[key];
         if (!this._mb) return;
-        this._mb.subscribe(this._onMessage.bind(this));
+
+        this._onMessageBound = this._onMessageBound || this._onMessage.bind(this);
+        this._onDispatchBound = this._onDispatchBound || this._onDispatchMessage.bind(this);
+
+        this._mb.subscribe(this._onMessageBound);
         this._mbDispatch = this._mb.dispatch.bind(this._mb);
-        this._mb.dispatch = this._onDispatchMessage.bind(this);
+        this._mb.dispatch = this._onDispatchBound;
+        this._registered = true;
     }
     unregister() {
-        if (!this._mb) return;
+        if (!this._registered || !this._mb) return;
+
         if (this._mbDispatch) {
             this._mb.dispatch = this._mbDispatch;
             this._mbDispatch = null;
         }
-        // We can't unsubscribe from the _onMessage
+
+        this._registered = false;
         this._mb = null;
     }
+
     /**
      * Hook on events from the message broker of a particular type
      */

--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -612,7 +612,6 @@ async function sendRoll(character, rollType, fallback, args) {
     } else {
         console.log("Sending message: ", req);
         chrome.runtime.sendMessage(req, (resp) => beyond20SendMessageFailure(character, resp));
-        sendRollRequestToDOM(req);
     }
 }
 

--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -40,6 +40,26 @@ function abbreviationToAbility(abbr) {
     return abbr;
 }
 
+function normalizeAbilityName(value = "") {
+    const token = value.trim().split(/\s+/)[0].toLowerCase();
+
+    const map = {
+        strength: "STR",
+        dexterity: "DEX",
+        constitution: "CON",
+        intelligence: "INT",
+        wisdom: "WIS",
+        charisma: "CHA",
+        str: "STR",
+        dex: "DEX",
+        con: "CON",
+        int: "INT",
+        wis: "WIS",
+        cha: "CHA"
+    };
+
+    return map[token];
+}
 
 function propertyListToDict(propList) {
     const properties = {}

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -231,11 +231,13 @@ function applyAbilityOrSavingThrowEffects({ rollType, ability_name, ability, mod
             ["STR", "DEX", "CON"].includes(ability)
         ) {
             mod += Math.ceil(character._proficiency / 2);
+            addEffect(roll_properties, "Remarkable Athlete");
         } else if (
             character.hasClassFeature("Jack of All Trades") &&
             character.getSetting("bard-joat", false)
         ) {
             mod += Math.floor(character._proficiency / 2);
+            addEffect(roll_properties, "Jack of All Trades");
         }
 
         if (character.getSetting("custom-ability-modifier", "")) {
@@ -251,6 +253,7 @@ function applyAbilityOrSavingThrowEffects({ rollType, ability_name, ability, mod
             ability === "CHA"
         ) {
             mod += Math.max(character.getAbility("WIS").mod, 1);
+            addEffect(roll_properties, "Otherworldly Glamour");
         }
 
         modifier = mod >= 0 ? `+${mod}` : `${mod}`;
@@ -271,6 +274,7 @@ function applyAbilityOrSavingThrowEffects({ rollType, ability_name, ability, mod
     if (character.hasClassFeature("Indomitable Might") && ability === "STR") {
         const min = character.getAbility("STR").score - parseInt(modifier);
         roll_properties.d20 = `1d20min${min}`;
+        addEffect(roll_properties, "Indomitable Might");
     }
 
     // Concentration checks
@@ -292,10 +296,12 @@ function applyAbilityOrSavingThrowEffects({ rollType, ability_name, ability, mod
                     mod = parseInt(modifier) + bladesongMod;
                     modifier = mod >= 0 ? `+${mod}` : `${mod}`;
                     roll_properties.modifier = modifier;
+                    addEffect(roll_properties, "Bladesong");
                 }
 
                 if (has_warcaster) {
                     roll_properties["advantage"] = RollType.OVERRIDE_ADVANTAGE;
+                    addEffect(roll_properties, "Warcaster");
                 }
             }
         }
@@ -310,6 +316,7 @@ function applyAbilityOrSavingThrowEffects({ rollType, ability_name, ability, mod
         mod = parseInt(roll_properties.modifier) + 2;
         modifier = mod >= 0 ? `+${mod}` : `${mod}`;
         roll_properties.modifier = modifier;
+        addEffect(roll_properties, "Durable Magic");
     }
 
     // Sorcerer: Clockwork Soul - Trance of Order
@@ -318,6 +325,7 @@ function applyAbilityOrSavingThrowEffects({ rollType, ability_name, ability, mod
         character.getSetting("sorcerer-trance-of-order", false)
     ) {
         roll_properties.d20 = "1d20min10";
+        addEffect(roll_properties, "Trance of Order");
     }
 
     return sendRollWithCharacter(rollType, "1d20" + roll_properties.modifier, roll_properties);

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -2964,9 +2964,156 @@ function handleMessage(request, sender, sendResponse) {
     }
 }
 
+let ddbRollHijackInstalled = false;
+
+function swallowRollEvent(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    if (typeof event.stopImmediatePropagation === "function") {
+        event.stopImmediatePropagation();
+    }
+}
+
+function handleCombatAttackIntegratedDie(button) {
+    const row = button.closest(".ct-combat-attack, .ddbc-combat-attack");
+    if (!row) return false;
+
+    const isToHit = !!button.closest(".ct-combat-attack__tohit, .ddbc-combat-attack__tohit");
+    const damageCell = button.closest(".ct-combat-attack__damage, .ddbc-combat-attack__damage");
+    const isDamage = !!damageCell;
+    const forceVersatile = !!(damageCell && damageCell.previousElementSibling);
+
+    const name = $(row)
+        .find(".ct-combat-attack__name .ct-combat-attack__label, .ddbc-combat-attack__name .ddbc-combat-attack__label")
+        .first()
+        .text()
+        .trim();
+
+    let pane = null;
+    let paneClass = null;
+
+    for (paneClass of ["b20-item-pane", "b20-action-pane", "ct-custom-action-pane", "b20-custom-action-pane", "ct-spell-pane"]) {
+        pane = $("." + paneClass);
+        if (pane.length > 0) break;
+    }
+
+    const paneName = pane && pane.length
+        ? pane.find(".ct-sidebar__heading").text().trim()
+        : "";
+
+    if (name && paneName === name && paneClass) {
+        execute(paneClass, {
+            force_to_hit_only: isToHit,
+            force_damages_only: isDamage,
+            force_versatile: forceVersatile
+        });
+    } else {
+        quick_roll_force_attack = isToHit;
+        quick_roll_force_damage = isDamage;
+        quick_roll_force_versatile = forceVersatile;
+        quick_roll = true;
+
+        $(row)
+            .find(".ct-combat-attack__name .ct-combat-attack__label, .ddbc-combat-attack__name .ddbc-combat-attack__label")
+            .first()
+            .trigger("click");
+    }
+
+    return true;
+}
+
+function handleSpellIntegratedDie(button) {
+    const row = button.closest(".ct-spells-spell, .ddbc-spells-spell");
+    if (!row) return false;
+
+    const isToHit = !!button.closest(".ct-spells-spell__tohit, .ddbc-spells-spell__tohit");
+    const isDamage = !!button.closest(".ct-spells-spell__damage, .ddbc-spells-spell__damage");
+
+    const nameElement = $(row)
+        .find(".ct-spell-name, .ddbc-spell-name, span[class*='styles_spellName']")
+        .first();
+
+    const spellName = nameElement.text().trim();
+    const paneName = $(".ct-spell-pane .ct-sidebar__heading .ct-spell-name, .ct-spell-pane .ct-sidebar__heading .ddbc-spell-name, .ct-spell-pane .ct-sidebar__heading span[class*='styles_spellName']")
+        .text()
+        .trim();
+
+    if (spellName && spellName === paneName) {
+        const castas = $(".ct-spell-caster__casting-level-current").text();
+        const level = $(row).closest(".ct-content-group").find(".ct-content-group__header-content").text();
+        const paneLevel = castas === "" ? "Cantrip" : `${castas} Level`;
+
+        if (paneLevel.toLowerCase() === level.toLowerCase()) {
+            execute("ct-spell-pane", {
+                force_to_hit_only: isToHit,
+                force_damages_only: isDamage
+            });
+        } else {
+            $(".ddbc-character-tidbits__menu-callout").trigger("click");
+            nameElement.trigger("click");
+
+            quick_roll_force_attack = isToHit;
+            quick_roll_force_damage = isDamage;
+            quick_roll_force_versatile = false;
+            quick_roll = true;
+        }
+    } else {
+        quick_roll_force_attack = isToHit;
+        quick_roll_force_damage = isDamage;
+        quick_roll_force_versatile = false;
+        quick_roll = true;
+
+        nameElement.trigger("click");
+    }
+
+    return true;
+}
+
+function installDDBRollHijack() {
+    if (ddbRollHijackInstalled) return;
+    ddbRollHijackInstalled = true;
+
+    const selector = "button.integrated-dice__container.beyond20-quick-roll-area";
+
+    const intercept = (event) => {
+        const button = event.target.closest(selector);
+        if (!button) return;
+
+        // limit interception to the places you actually want to own
+        const isAttackButton = !!button.closest(".ct-combat-attack, .ddbc-combat-attack");
+        const isSpellButton = !!button.closest(".ct-spells-spell, .ddbc-spells-spell");
+
+        if (!isAttackButton && !isSpellButton) return;
+
+        swallowRollEvent(event);
+
+        if (handleCombatAttackIntegratedDie(button)) return;
+        if (handleSpellIntegratedDie(button)) return;
+    };
+
+    ["pointerdown", "mousedown", "mouseup", "click"].forEach((type) => {
+        document.addEventListener(type, intercept, true);
+    });
+
+    document.addEventListener("keydown", (event) => {
+        if (event.key !== "Enter" && event.key !== " ") return;
+
+        const button = event.target.closest(selector);
+        if (!button) return;
+
+        swallowRollEvent(event);
+
+        if (handleCombatAttackIntegratedDie(button)) return;
+        if (handleSpellIntegratedDie(button)) return;
+    }, true);
+
+    console.log("Beyond20: DDB integrated dice hijack installed.");
+}
+
 var settings = getDefaultSettings();
 var character = new Character(settings);
 var creature = null;
+installDDBRollHijack();
 updateSettings();
 chrome.runtime.onMessage.addListener(handleMessage);
 observer = new window.MutationObserver(documentModified);

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -61,7 +61,7 @@ async function rollSkillCheck(paneClass) {
             if (modifier != "--" && modifier != "+0")
                 mod += parseInt(modifier);
             modifier = mod >= 0 ? `+${mod}` : `${mod}`;
-        }
+        } else { return; } // cancel roll
     }
     //console.log("Skill " + skill_name + " (" + ability + ") : " + modifier);
     const roll_properties = {

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -199,19 +199,8 @@ async function rollSkillCheck(paneClass) {
     return sendRollWithCharacter("skill", "1d20" + modifier, roll_properties);
 }
 
-function rollAbilityOrSavingThrow(paneClass, rollType) {
-    const ability_string = $("." + paneClass + " .ct-sidebar__heading").text().trim();
-    const ability_name = ability_string.split(/\s+/)[0] || "";
-    const ability =
-        (typeof ability_abbreviations !== "undefined" && ability_abbreviations[ability_name]) ||
-        normalizeAbilityName(ability_name);
-
-    let modifier = $(
-        `.${paneClass}__modifier .ct-signed-number,` +
-        `.${paneClass}__modifier .ddbc-signed-number,` +
-        ` .${paneClass} span[class*='styles_modifier'] span[class*='styles_numberDisplay']`
-    ).text().replace(/\s+/g, "");
-
+function applyAbilityOrSavingThrowEffects({ rollType, ability_name, ability, modifier, proficiency }) {
+    let mod = parseInt(modifier);
     const roll_properties = {
         name: ability_name,
         ability: ability,
@@ -219,34 +208,156 @@ function rollAbilityOrSavingThrow(paneClass, rollType) {
     };
 
     if (rollType === "saving-throw") {
-        let proficiency;
-
-        if (ability) {
-            proficiency = $(
-                `.ddbc-saving-throws-summary__ability--${ability.toLowerCase()} ` +
-                `.ddbc-saving-throws-summary__ability-proficiency .ddbc-tooltip`
-            ).attr("data-original-title");
-        }
-
         roll_properties.proficiency = proficiency;
     }
 
     if (!ability) {
         console.warn("Beyond20: could not resolve ability", {
-            paneClass,
             rollType,
-            ability_string,
-            ability_name
+            ability_name,
+            ability,
+            modifier,
+            proficiency
         });
         return;
     }
 
-    return sendRollWithCharacter(rollType, "1d20" + modifier, roll_properties);
+    if (rollType === "ability") {
+        // Remarkable Athlete and Jack of All Trades don't stack.
+        // Give priority to Remarkable Athlete because it rounds up.
+        if (
+            character.hasClassFeature("Remarkable Athlete") &&
+            character.getSetting("champion-remarkable-athlete", false) &&
+            ["STR", "DEX", "CON"].includes(ability)
+        ) {
+            mod += Math.ceil(character._proficiency / 2);
+        } else if (
+            character.hasClassFeature("Jack of All Trades") &&
+            character.getSetting("bard-joat", false)
+        ) {
+            mod += Math.floor(character._proficiency / 2);
+        }
+
+        if (character.getSetting("custom-ability-modifier", "")) {
+            const custom = parseInt(character.getSetting("custom-ability-modifier", "0")) || 0;
+            if (custom !== 0) {
+                mod += custom;
+            }
+        }
+
+        // Fey Wanderer Ranger - Otherworldly Glamour
+        if (
+            character.hasClassFeature("Otherworldly Glamour") &&
+            ability === "CHA"
+        ) {
+            mod += Math.max(character.getAbility("WIS").mod, 1);
+        }
+
+        modifier = mod >= 0 ? `+${mod}` : `${mod}`;
+        roll_properties.modifier = modifier;
+    }
+
+    if (
+        ability === "STR" &&
+        (
+            (character.hasClassFeature("Rage") && character.getSetting("barbarian-rage", false)) ||
+            (character.hasClassFeature("Giant’s Might") && character.getSetting("fighter-giant-might", false))
+        )
+    ) {
+        roll_properties["advantage"] = RollType.OVERRIDE_ADVANTAGE;
+        addEffect(roll_properties, "Rage");
+    }
+
+    if (character.hasClassFeature("Indomitable Might") && ability === "STR") {
+        const min = character.getAbility("STR").score - parseInt(modifier);
+        roll_properties.d20 = `1d20min${min}`;
+    }
+
+    // Concentration checks
+    if (rollType === "saving-throw" && ability === "CON") {
+        const has_warcaster = character.hasFeat("War Caster");
+        const has_bladesong =
+            character.hasClassFeature("Bladesong") &&
+            character.getSetting("wizard-bladesong", false);
+
+        if (has_warcaster || has_bladesong) {
+            const confirmation = has_bladesong
+                ? 'Your Bladesong whispers: "Is this a Concentration Check?"'
+                : "Is this a Concentration Check?";
+
+            if (confirm(confirmation)) {
+                if (has_bladesong) {
+                    const intelligence = character.getAbility("INT") || { mod: 0 };
+                    const bladesongMod = Math.max((parseInt(intelligence.mod) || 0), 1);
+                    mod = parseInt(modifier) + bladesongMod;
+                    modifier = mod >= 0 ? `+${mod}` : `${mod}`;
+                    roll_properties.modifier = modifier;
+                }
+
+                if (has_warcaster) {
+                    roll_properties["advantage"] = RollType.OVERRIDE_ADVANTAGE;
+                }
+            }
+        }
+    }
+
+    // Wizard - War Magic - Durable Magic
+    if (
+        rollType === "saving-throw" &&
+        character.hasClassFeature("Durable Magic") &&
+        character.getSetting("wizard-durable-magic", false)
+    ) {
+        mod = parseInt(roll_properties.modifier) + 2;
+        modifier = mod >= 0 ? `+${mod}` : `${mod}`;
+        roll_properties.modifier = modifier;
+    }
+
+    // Sorcerer: Clockwork Soul - Trance of Order
+    if (
+        character.hasClassFeature("Trance of Order") &&
+        character.getSetting("sorcerer-trance-of-order", false)
+    ) {
+        roll_properties.d20 = "1d20min10";
+    }
+
+    return sendRollWithCharacter(rollType, "1d20" + roll_properties.modifier, roll_properties);
+}
+
+function rollAbilityOrSavingThrow(paneClass, rollType) {
+    const ability_string = $("." + paneClass + " .ct-sidebar__heading").text().trim();
+    const ability_name = ability_string.split(/\s+/)[0] || "";
+    const ability =
+        (typeof ability_abbreviations !== "undefined" && ability_abbreviations[ability_name]) ||
+        normalizeAbilityName(ability_name);
+
+    const modifier = $(
+        `.${paneClass}__modifier .ct-signed-number,` +
+        `.${paneClass}__modifier .ddbc-signed-number,` +
+        ` .${paneClass} span[class*='styles_modifier'] span[class*='styles_numberDisplay']`
+    ).text().replace(/\s+/g, "");
+
+    let proficiency;
+    if (rollType === "saving-throw" && ability) {
+        proficiency = $(
+            `.ddbc-saving-throws-summary__ability--${ability.toLowerCase()} ` +
+            `.ddbc-saving-throws-summary__ability-proficiency .ddbc-tooltip`
+        ).attr("data-original-title");
+    }
+
+    return applyAbilityOrSavingThrowEffects({
+        rollType,
+        ability_name,
+        ability,
+        modifier,
+        proficiency
+    });
 }
 
 async function rollSavingThrowFromRow(row) {
     const $row = $(row);
-    const abbr = $row.find(".ct-saving-throws-summary__ability-name abbr, .ddbc-saving-throws-summary__ability-name abbr").first();
+    const abbr = $row
+        .find(".ct-saving-throws-summary__ability-name abbr, .ddbc-saving-throws-summary__ability-name abbr")
+        .first();
 
     let ability_name = (abbr.attr("title") || "").trim();
     let ability = (abbr.text() || "").trim().toUpperCase();
@@ -267,7 +378,7 @@ async function rollSavingThrowFromRow(row) {
         ability = normalizeAbilityName(ability_name);
     }
 
-    let modifier = $row.find(
+    const modifier = $row.find(
         ".ct-saving-throws-summary__ability-modifier .ct-signed-number, " +
         ".ct-saving-throws-summary__ability-modifier .ddbc-signed-number, " +
         ".ddbc-saving-throws-summary__ability-modifier .ct-signed-number, " +
@@ -283,75 +394,13 @@ async function rollSavingThrowFromRow(row) {
         ".ddbc-saving-throws-summary__ability-proficiency .ddbc-tooltip"
     ).attr("data-original-title");
 
-    if (!ability) {
-        console.warn("Beyond20: could not resolve saving throw from row", {
-            ability_name,
-            ability,
-            modifier,
-            proficiency,
-            row
-        });
-        return;
-    }
-
-    const roll_properties = {
-        name: ability_name,
-        ability: ability,
-        modifier: modifier,
-        proficiency: proficiency
-    };
-
-    if (
-        ability === "STR" &&
-        (
-            (character.hasClassFeature("Rage") && character.getSetting("barbarian-rage", false)) ||
-            (character.hasClassFeature("Giant’s Might") && character.getSetting("fighter-giant-might", false))
-        )
-    ) {
-        roll_properties["advantage"] = RollType.OVERRIDE_ADVANTAGE;
-        addEffect(roll_properties, "Rage");
-    }
-
-    if (character.hasClassFeature("Indomitable Might") && ability === "STR") {
-        const min = character.getAbility("STR").score - parseInt(modifier);
-        roll_properties.d20 = `1d20min${min}`;
-    }
-
-    if (ability === "CON") {
-        const has_warcaster = character.hasFeat("War Caster");
-        const has_bladesong = character.hasClassFeature("Bladesong") && character.getSetting("wizard-bladesong", false);
-
-        if (has_warcaster || has_bladesong) {
-            const confirmation = has_bladesong
-                ? 'Your Bladesong whispers: "Is this a Concentration Check?"'
-                : "Is this a Concentration Check?";
-
-            if (confirm(confirmation)) {
-                if (has_bladesong) {
-                    const intelligence = character.getAbility("INT") || { mod: 0 };
-                    const mod = Math.max((parseInt(intelligence.mod) || 0), 1);
-                    modifier = parseInt(modifier) + mod;
-                    modifier = modifier >= 0 ? `+${modifier}` : `${modifier}`;
-                    roll_properties["modifier"] = modifier;
-                }
-                if (has_warcaster) {
-                    roll_properties["advantage"] = RollType.OVERRIDE_ADVANTAGE;
-                }
-            }
-        }
-    }
-
-    if (character.hasClassFeature("Durable Magic") && character.getSetting("wizard-durable-magic", false)) {
-        modifier = parseInt(modifier) + 2;
-        modifier = modifier >= 0 ? `+${modifier}` : `${modifier}`;
-        roll_properties["modifier"] = modifier;
-    }
-
-    if (character.hasClassFeature("Trance of Order") && character.getSetting("sorcerer-trance-of-order", false)) {
-        roll_properties.d20 = "1d20min10";
-    }
-
-    return sendRollWithCharacter("saving-throw", "1d20" + modifier, roll_properties);
+    return applyAbilityOrSavingThrowEffects({
+        rollType: "saving-throw",
+        ability_name,
+        ability,
+        modifier,
+        proficiency
+    });
 }
 
 function rollAbilityCheck() {

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -200,98 +200,158 @@ async function rollSkillCheck(paneClass) {
 }
 
 function rollAbilityOrSavingThrow(paneClass, rollType) {
-    const ability_string = $("." + paneClass + " .ct-sidebar__heading").text();
-    const ability_name = ability_string.split(" ")[0];
-    const ability = ability_abbreviations[ability_name];
-    let modifier = $(`.${paneClass}__modifier .ct-signed-number,.${paneClass}__modifier .ddbc-signed-number, .${paneClass} span[class*='styles_modifier'] span[class*='styles_numberDisplay']`).text();
+    const ability_string = $("." + paneClass + " .ct-sidebar__heading").text().trim();
+    const ability_name = ability_string.split(/\s+/)[0] || "";
+    const ability =
+        (typeof ability_abbreviations !== "undefined" && ability_abbreviations[ability_name]) ||
+        normalizeAbilityName(ability_name);
 
-    if (rollType == "ability") {
-        // Remarkable Athelete and Jack of All Trades don't stack, we give priority to RA instead of JoaT because
-        // it's rounded up instead of rounded down.
-        if (character.hasClassFeature("Remarkable Athlete") && character.getSetting("champion-remarkable-athlete", false) &&
-            ["STR","DEX", "CON"].includes(ability)) {
-            const remarkable_athlete_mod = Math.ceil(character._proficiency / 2);
-            modifier = parseInt(modifier) + remarkable_athlete_mod;
-            modifier = modifier >= 0 ? `+${modifier}` : `${modifier}`;
-        } else if (character.hasClassFeature("Jack of All Trades") && character.getSetting("bard-joat", false)) {
-            const JoaT = Math.floor(character._proficiency / 2);
-            modifier = parseInt(modifier) + JoaT;
-            modifier = modifier >= 0 ? `+${modifier}` : `${modifier}`;
+    let modifier = $(
+        `.${paneClass}__modifier .ct-signed-number,` +
+        `.${paneClass}__modifier .ddbc-signed-number,` +
+        ` .${paneClass} span[class*='styles_modifier'] span[class*='styles_numberDisplay']`
+    ).text().replace(/\s+/g, "");
+
+    const roll_properties = {
+        name: ability_name,
+        ability: ability,
+        modifier: modifier
+    };
+
+    if (rollType === "saving-throw") {
+        let proficiency;
+
+        if (ability) {
+            proficiency = $(
+                `.ddbc-saving-throws-summary__ability--${ability.toLowerCase()} ` +
+                `.ddbc-saving-throws-summary__ability-proficiency .ddbc-tooltip`
+            ).attr("data-original-title");
         }
-        if (character.getSetting("custom-ability-modifier", "")) {
-            const custom = parseInt(character.getSetting("custom-ability-modifier", "0")) || 0;
-            if (custom != 0)  {
-                modifier = parseInt(modifier) + custom;
-                modifier = modifier >= 0 ? `+${modifier}` : `${modifier}`;
-            }
-        }
+
+        roll_properties.proficiency = proficiency;
+    }
+
+    if (!ability) {
+        console.warn("Beyond20: could not resolve ability", {
+            paneClass,
+            rollType,
+            ability_string,
+            ability_name
+        });
+        return;
+    }
+
+    return sendRollWithCharacter(rollType, "1d20" + modifier, roll_properties);
+}
+
+async function rollSavingThrowFromRow(row) {
+    const $row = $(row);
+    const abbr = $row.find(".ct-saving-throws-summary__ability-name abbr, .ddbc-saving-throws-summary__ability-name abbr").first();
+
+    let ability_name = (abbr.attr("title") || "").trim();
+    let ability = (abbr.text() || "").trim().toUpperCase();
+
+    if (!ability_name && ability) {
+        const fullNames = {
+            STR: "Strength",
+            DEX: "Dexterity",
+            CON: "Constitution",
+            INT: "Intelligence",
+            WIS: "Wisdom",
+            CHA: "Charisma"
+        };
+        ability_name = fullNames[ability] || ability;
+    }
+
+    if (!ability) {
+        ability = normalizeAbilityName(ability_name);
+    }
+
+    let modifier = $row.find(
+        ".ct-saving-throws-summary__ability-modifier .ct-signed-number, " +
+        ".ct-saving-throws-summary__ability-modifier .ddbc-signed-number, " +
+        ".ddbc-saving-throws-summary__ability-modifier .ct-signed-number, " +
+        ".ddbc-saving-throws-summary__ability-modifier .ddbc-signed-number, " +
+        ".ct-saving-throws-summary__ability-modifier span[class*='styles_numberDisplay'], " +
+        ".ddbc-saving-throws-summary__ability-modifier span[class*='styles_numberDisplay']"
+    ).text().replace(/\s+/g, "");
+
+    const proficiency = $row.find(
+        ".ct-saving-throws-summary__ability-proficiency .ct-tooltip, " +
+        ".ct-saving-throws-summary__ability-proficiency .ddbc-tooltip, " +
+        ".ddbc-saving-throws-summary__ability-proficiency .ct-tooltip, " +
+        ".ddbc-saving-throws-summary__ability-proficiency .ddbc-tooltip"
+    ).attr("data-original-title");
+
+    if (!ability) {
+        console.warn("Beyond20: could not resolve saving throw from row", {
+            ability_name,
+            ability,
+            modifier,
+            proficiency,
+            row
+        });
+        return;
     }
 
     const roll_properties = {
-        "name": ability_name,
-        "ability": ability,
-        "modifier": modifier
-    }
+        name: ability_name,
+        ability: ability,
+        modifier: modifier,
+        proficiency: proficiency
+    };
 
-    if (rollType === "saving-throw") {
-        const proficiency = $(`.ddbc-saving-throws-summary__ability--${ability.toLowerCase()}
-                                .ddbc-saving-throws-summary__ability-proficiency .ddbc-tooltip`).attr("data-original-title");
-        roll_properties["proficiency"] = proficiency;
-    }
-
-    if (ability == "STR" &&
-        ((character.hasClassFeature("Rage") && character.getSetting("barbarian-rage", false)) ||
-            (character.hasClassFeature("Giant’s Might") && character.getSetting("fighter-giant-might", false)))) {
+    if (
+        ability === "STR" &&
+        (
+            (character.hasClassFeature("Rage") && character.getSetting("barbarian-rage", false)) ||
+            (character.hasClassFeature("Giant’s Might") && character.getSetting("fighter-giant-might", false))
+        )
+    ) {
         roll_properties["advantage"] = RollType.OVERRIDE_ADVANTAGE;
         addEffect(roll_properties, "Rage");
     }
-    if (character.hasClassFeature("Indomitable Might") && ability == "STR") {
+
+    if (character.hasClassFeature("Indomitable Might") && ability === "STR") {
         const min = character.getAbility("STR").score - parseInt(modifier);
-        roll_properties.d20 = `1d20min${min}`
+        roll_properties.d20 = `1d20min${min}`;
     }
 
-    // Concentration checks
-    if (rollType == "saving-throw" && ability == "CON") {
+    if (ability === "CON") {
         const has_warcaster = character.hasFeat("War Caster");
         const has_bladesong = character.hasClassFeature("Bladesong") && character.getSetting("wizard-bladesong", false);
+
         if (has_warcaster || has_bladesong) {
-            const confirmation = has_bladesong ? 'Your Bladesong whispers: "Is this a Concentration Check?"' : 'Is this a Concentration Check?';
-            // Using confirm because the parent function is not async
+            const confirmation = has_bladesong
+                ? 'Your Bladesong whispers: "Is this a Concentration Check?"'
+                : "Is this a Concentration Check?";
+
             if (confirm(confirmation)) {
-                // Wizard Bladesong Concentration Check Bonus
                 if (has_bladesong) {
-                    const intelligence = character.getAbility("INT") || {mod: 0};
+                    const intelligence = character.getAbility("INT") || { mod: 0 };
                     const mod = Math.max((parseInt(intelligence.mod) || 0), 1);
                     modifier = parseInt(modifier) + mod;
                     modifier = modifier >= 0 ? `+${modifier}` : `${modifier}`;
                     roll_properties["modifier"] = modifier;
                 }
-                // Feat - War Caster - Concentration Check Bonus
                 if (has_warcaster) {
                     roll_properties["advantage"] = RollType.OVERRIDE_ADVANTAGE;
                 }
             }
         }
     }
-    
-    // Wizard - War Magic - Saving Throw Bonus
-    if (character.hasClassFeature("Durable Magic") && character.getSetting("wizard-durable-magic", false) &&
-        rollType == "saving-throw") {
+
+    if (character.hasClassFeature("Durable Magic") && character.getSetting("wizard-durable-magic", false)) {
         modifier = parseInt(modifier) + 2;
         modifier = modifier >= 0 ? `+${modifier}` : `${modifier}`;
         roll_properties["modifier"] = modifier;
     }
-    // Fey Wanderer Ranger - Otherworldly Glamour
-    if (rollType == "ability" && character.hasClassFeature("Otherworldly Glamour") && ability == "CHA") {
-        modifier = parseInt(modifier) + Math.max(character.getAbility("WIS").mod,1);
-        modifier = modifier >= 0 ? `+${modifier}` : `${modifier}`;
-        roll_properties["modifier"] = modifier;
+
+    if (character.hasClassFeature("Trance of Order") && character.getSetting("sorcerer-trance-of-order", false)) {
+        roll_properties.d20 = "1d20min10";
     }
-    // Sorcerer: Clockwork Soul - Trance of Order
-    if (character.hasClassFeature("Trance of Order") && character.getSetting("sorcerer-trance-of-order", false))
-            roll_properties.d20 = "1d20min10";
-   
-    return sendRollWithCharacter(rollType, "1d20" + modifier, roll_properties);
+
+    return sendRollWithCharacter("saving-throw", "1d20" + modifier, roll_properties);
 }
 
 function rollAbilityCheck() {
@@ -299,7 +359,12 @@ function rollAbilityCheck() {
 }
 
 function rollSavingThrow() {
-    rollAbilityOrSavingThrow("b20-ability-saving-throws-pane", "saving-throw");
+    const row = $(".ct-saving-throws-summary__ability.beyond20-active-roll, .ddbc-saving-throws-summary__ability.beyond20-active-roll").first();
+    if (row.length) {
+        return rollSavingThrowFromRow(row[0]);
+    }
+
+    return rollAbilityOrSavingThrow("b20-ability-saving-throws-pane", "saving-throw");
 }
 
 function rollInitiative() {
@@ -3069,52 +3134,210 @@ function handleSpellIntegratedDie(button) {
     return true;
 }
 
+function handleAbilityIntegratedDie(target) {
+    const row = target.closest(".ct-ability-summary, .ddbc-ability-summary");
+    if (!row) return false;
+
+    const label = $(row)
+        .find(".ct-ability-summary__heading .ct-ability-summary__label, .ddbc-ability-summary__heading .ddbc-ability-summary__label")
+        .first();
+
+    const name = label.text().trim();
+    const paneName = $(".b20-ability-pane .ct-sidebar__heading").text().trim();
+
+    if (name && paneName && name === paneName) {
+        resetHijackQuickRollState();
+        execute("b20-ability-pane");
+    } else {
+        resetHijackQuickRollState();
+        quick_roll = true;
+        label.trigger("click");
+    }
+
+    return true;
+}
+
+function handleSavingThrowIntegratedDie(target) {
+    const row = target.closest(".ct-saving-throws-summary__ability, .ddbc-saving-throws-summary__ability");
+    if (!row) return false;
+
+    resetHijackQuickRollState();
+
+    $(".ct-saving-throws-summary__ability.beyond20-active-roll, .ddbc-saving-throws-summary__ability.beyond20-active-roll")
+        .removeClass("beyond20-active-roll");
+
+    $(row).addClass("beyond20-active-roll");
+
+    rollSavingThrowFromRow(row);
+    return true;
+}
+
+function handleSkillIntegratedDie(target) {
+    const row = target.closest(".ct-skills__item, .ddbc-skills__item");
+    if (!row) return false;
+
+    const label = $(row)
+        .find(".ct-skills__col--skill, .ddbc-skills__col--skill")
+        .first();
+
+    const name = label.text().trim();
+
+    let pane = null;
+    let paneClass = null;
+
+    for (const cls of ["ct-skill-pane", "ct-custom-skill-pane"]) {
+        const found = $("." + cls);
+        if (found.length > 0) {
+            pane = found;
+            paneClass = cls;
+            break;
+        }
+    }
+
+    const paneName = pane && paneClass
+        ? pane.find(".ct-sidebar__heading ." + paneClass + "__header-name").text().trim()
+        : "";
+
+    if (name && paneName && name === paneName && paneClass) {
+        resetHijackQuickRollState();
+        execute(paneClass);
+    } else {
+        resetHijackQuickRollState();
+        quick_roll = true;
+        label.trigger("click");
+    }
+
+    return true;
+}
+
+function handleInitiativeIntegratedDie(target) {
+    const row = target.closest(
+        ".ct-combat__summary-group--initiative, " +
+        ".ct-combat-tablet__extra--initiative, " +
+        ".ct-combat-mobile__extras > section[class*='styles_boxMobile']"
+    );
+    if (!row) return false;
+
+    if ($(".b20-initiative-pane").length) {
+        resetHijackQuickRollState();
+        execute("b20-initiative-pane");
+    } else {
+        resetHijackQuickRollState();
+        quick_roll = true;
+
+        const valueContainer = target.closest("div[class*='styles_value']");
+        if (valueContainer) {
+            $(valueContainer).trigger("click");
+        } else {
+            $(target).trigger("click");
+        }
+    }
+
+    return true;
+}
+
+function resetHijackQuickRollState() {
+    quick_roll = false;
+    quick_roll_force_attack = false;
+    quick_roll_force_damage = false;
+    quick_roll_force_versatile = false;
+
+    if (quick_roll_timeout > 0) {
+        clearTimeout(quick_roll_timeout);
+        quick_roll_timeout = 0;
+    }
+}
+
+let ddbHijackPointerHandled = false;
+
 function installDDBRollHijack() {
     if (ddbRollHijackInstalled) return;
     ddbRollHijackInstalled = true;
 
-    const selector = "button.integrated-dice__container.beyond20-quick-roll-area";
+    const selector = [
+        "button.integrated-dice__container.beyond20-quick-roll-area",
+        "button.integrated-dice__container",
 
-    const intercept = (event) => {
-        const button = event.target.closest(selector);
-        if (!button) return;
+        ".ct-saving-throws-summary__ability .ct-saving-throws-summary__ability-modifier",
+        ".ddbc-saving-throws-summary__ability .ddbc-saving-throws-summary__ability-modifier",
 
-        // limit interception to the places you actually want to own
-        const isAttackButton = !!button.closest(".ct-combat-attack, .ddbc-combat-attack");
-        const isSpellButton = !!button.closest(".ct-spells-spell, .ddbc-spells-spell");
+        ".ct-skills .ct-skills__list .ct-skills__col--modifier",
+        ".ddbc-skills .ddbc-skills__list .ddbc-skills__col--modifier",
 
-        if (!isAttackButton && !isSpellButton) return;
+        ".ct-combat__summary-group--initiative .integrated-dice__container",
+        ".ct-combat__summary-group--initiative span[class*='styles_numberDisplay']",
+        ".ct-combat-tablet__extra--initiative .integrated-dice__container",
+        ".ct-combat-tablet__extra--initiative span[class*='styles_numberDisplay']",
+        ".ct-combat-mobile__extras > section[class*='styles_boxMobile'] .integrated-dice__container",
+        ".ct-combat-mobile__extras > section[class*='styles_boxMobile'] span[class*='styles_numberDisplay']",
 
-        swallowRollEvent(event);
+        ".ddbc-ability-summary .ddbc-ability-summary__primary .integrated-dice__container",
+        ".ct-quick-info__abilities .ddbc-ability-summary .ddbc-ability-summary__secondary .ddbc-signed-number",
+        ".ct-quick-info__abilities .ddbc-ability-summary .ddbc-ability-summary__primary .ddbc-signed-number",
+        ".ct-quick-info__abilities .ddbc-ability-summary .ddbc-ability-summary__secondary span[class*='styles_numberDisplay']",
+        ".ct-quick-info__abilities .ddbc-ability-summary .ddbc-ability-summary__primary span[class*='styles_numberDisplay']"
+    ].join(", ");
 
-        if (handleCombatAttackIntegratedDie(button)) return;
-        if (handleSpellIntegratedDie(button)) return;
+    const routeTarget = (target) => {
+        if (!target) return false;
+        if (handleCombatAttackIntegratedDie(target)) return true;
+        if (handleSpellIntegratedDie(target)) return true;
+        if (handleInitiativeIntegratedDie(target)) return true;
+        if (handleAbilityIntegratedDie(target)) return true;
+        if (handleSavingThrowIntegratedDie(target)) return true;
+        if (handleSkillIntegratedDie(target)) return true;
+        return false;
     };
 
-    ["pointerdown", "mousedown", "mouseup", "click"].forEach((type) => {
-        document.addEventListener(type, intercept, true);
-    });
+    const interceptPointer = (event) => {
+        const target = event.target.closest(selector);
+        if (!target) return;
 
-    document.addEventListener("keydown", (event) => {
-        if (event.key !== "Enter" && event.key !== " ") return;
-
-        const button = event.target.closest(selector);
-        if (!button) return;
-
+        ddbHijackPointerHandled = true;
         swallowRollEvent(event);
 
-        if (handleCombatAttackIntegratedDie(button)) return;
-        if (handleSpellIntegratedDie(button)) return;
+        const handled = routeTarget(target);
+        if (!handled) {
+            ddbHijackPointerHandled = false;
+        }
+    };
+
+    const interceptClick = (event) => {
+        const target = event.target.closest(selector);
+        if (!target) return;
+
+        if (ddbHijackPointerHandled) {
+            swallowRollEvent(event);
+            ddbHijackPointerHandled = false;
+            return;
+        }
+
+        swallowRollEvent(event);
+        routeTarget(target);
+    };
+
+    window.addEventListener("pointerdown", interceptPointer, true);
+
+    window.addEventListener("click", interceptClick, true);
+
+    window.addEventListener("keydown", (event) => {
+        if (event.key !== "Enter" && event.key !== " ") return;
+
+        const target = event.target.closest(selector);
+        if (!target) return;
+
+        swallowRollEvent(event);
+        routeTarget(target);
     }, true);
 
-    console.log("Beyond20: DDB integrated dice hijack installed.");
+    console.log("Beyond20: DDB roll hijack installed.");
 }
 
 var settings = getDefaultSettings();
 var character = new Character(settings);
 var creature = null;
-installDDBRollHijack();
 updateSettings();
+installDDBRollHijack();
 chrome.runtime.onMessage.addListener(handleMessage);
 observer = new window.MutationObserver(documentModified);
 observer.observe(document, { subtree: true, childList: true, characterData: true });

--- a/src/dndbeyond/page-scripts/message-broker.js
+++ b/src/dndbeyond/page-scripts/message-broker.js
@@ -1,190 +1,242 @@
-const messageBroker = new DDBMessageBroker();
-messageBroker.register();
-console.log("Registered Beyond20 message broker");
+if (!window.__beyond20_mb2_initialized__) {
+    window.__beyond20_mb2_initialized__ = true;
 
-let lastCharacter = null;
-function sendRollToGameLog(request) {
-	const message = {
-        persist: false,
-    };
-    if (request.action === "roll") {
-        message.eventType = "custom/beyond20/request";
-        message.data = {
-            'request': request
-        }
-        // Save the character to be used when creating the default roll data context
-        lastCharacter = request.character;
-    } else if (request.action === "rendered-roll") {
-        message.eventType = "custom/beyond20/roll";
-        message.data = {
-            'request': request.request,
-            'render': request.html
-        }
-        // Save the character to be used when creating the default roll data context
-        lastCharacter = request.character;
-	} else {
-        // Unknown action type
-        return;
+    const BROKER_KEY = "__beyond20_message_broker__";
+    const EVENTS_KEY = "__beyond20_mb2_registered_events__";
+
+    const messageBroker =
+        window[BROKER_KEY] || (window[BROKER_KEY] = new DDBMessageBroker());
+
+    if (!messageBroker._registeredOnce) {
+        messageBroker.register();
+        messageBroker._registeredOnce = true;
+        console.log("Registered Beyond20 message broker");
     }
-	messageBroker.postMessage(message);
-}
 
-function rollToDDBRoll(roll, forceResults=false) {
-    let constant = 0;
-    let lastOperation = '+';
-    const sets = [];
-    const results = [];
-    // constant, total, count, dieValue and result.values must be ints so it doesn't crash the mobile app
-    for (const part of roll.parts) {
-        const signMultiplier = (lastOperation === "+" ? 1 : -1);
-        if (['-', '+'].includes(part)) {
-            lastOperation = part;
-        } else if (typeof(part) === "number") {
-            constant = constant + parseInt(part) * signMultiplier;
-        } else if (part.formula) {
-            let operation = 0; // sum
-            if (part.modifiers.includes("kl") || part.modifiers.includes("dh"))
-                operation = 1; // min
-            else if (part.modifiers.includes("kh") || part.modifiers.includes("dl"))
-                operation = 2; // max
-            // the game log will crash if a message is posted with a dieType that isn't supported
-            const dieType = [4, 6, 8, 10, 12, 20, 100].includes(part.faces) ? `d${part.faces}` : 'd100';
-            sets.push({
-                count: parseInt(part.amount) * signMultiplier,
-                dieType,
-                operation,
-                dice: part.rolls.filter(r => !r.discarded).map(r => ({dieType, dieValue: r.roll || 0}))
-            });
-            if (part.total !== undefined) {
-                results.push(...part.rolls.filter(r => !r.discarded).map(r => (parseInt(r.roll) || 0) * signMultiplier));
+    let lastCharacter = null;
+    let lastMessage = null;
+
+    function sendRollToGameLog(request) {
+        const message = {
+            persist: false,
+        };
+
+        if (request.action === "roll") {
+            message.eventType = "custom/beyond20/request";
+            message.data = {
+                request: request
+            };
+            lastCharacter = request.character;
+        } else if (request.action === "rendered-roll") {
+            message.eventType = "custom/beyond20/roll";
+            message.data = {
+                request: request.request,
+                render: request.html
+            };
+            lastCharacter = request.character;
+        } else {
+            return;
+        }
+
+        messageBroker.postMessage(message);
+    }
+
+    function rollToDDBRoll(roll, forceResults = false) {
+        let constant = 0;
+        let lastOperation = "+";
+        const sets = [];
+        const results = [];
+
+        // constant, total, count, dieValue and result.values must be ints so it doesn't crash the mobile app
+        for (const part of roll.parts) {
+            const signMultiplier = (lastOperation === "+" ? 1 : -1);
+
+            if (["-", "+"].includes(part)) {
+                lastOperation = part;
+            } else if (typeof part === "number") {
+                constant = constant + parseInt(part) * signMultiplier;
+            } else if (part.formula) {
+                let operation = 0; // sum
+                if (part.modifiers.includes("kl") || part.modifiers.includes("dh")) {
+                    operation = 1; // min
+                } else if (part.modifiers.includes("kh") || part.modifiers.includes("dl")) {
+                    operation = 2; // max
+                }
+
+                // the game log will crash if a message is posted with a dieType that isn't supported
+                const dieType = [4, 6, 8, 10, 12, 20, 100].includes(part.faces) ? `d${part.faces}` : "d100";
+
+                sets.push({
+                    count: parseInt(part.amount) * signMultiplier,
+                    dieType,
+                    operation,
+                    dice: part.rolls
+                        .filter((r) => !r.discarded)
+                        .map((r) => ({ dieType, dieValue: r.roll || 0 }))
+                });
+
+                if (part.total !== undefined) {
+                    results.push(
+                        ...part.rolls
+                            .filter((r) => !r.discarded)
+                            .map((r) => (parseInt(r.roll) || 0) * signMultiplier)
+                    );
+                }
             }
         }
-    }
-    const rollToKind = {
-        "critical-damage": "critical hit"
-    }
-    const rollToType = {
-        "to-hit": "to hit",
-        "damage": "damage",
-        "critical-damage": "damage",
-        "skill-check": "check",
-        "ability-check": "check",
-        "initiative": "check",
-        "saving-throw": "save",
-        "death-save": "save",
 
-    }
-
-    const data = {
-        diceNotation: {
-            constant,
-            set: sets
-        },
-        diceNotationStr: roll.formula,
-        rollKind: rollToKind[roll.type] || "",
-        rollType: rollToType[roll.type] || "roll"
-    }
-    // diceOperation options: 0 = sum, 1 = min, 2 = max
-    // rollKind options : "" = none, advantage, disadvantage, critical hit
-    // rollType options : roll, to hit, damage, heal, spell, save, check
-    if (forceResults || results.length > 0) {
-        data.result = {
-            constant,
-            text: roll.parts.map(p => {
-                if (p.total === undefined) return String(p);
-                const rolls = p.rolls.filter(r => !r.discarded && !Number.isNaN(parseInt(r.roll))).map(r => parseInt(r.roll));
-                if (rolls.length === 0) return String(p.total);
-                return rolls.join("+");
-            }).join(""),
-            total: parseInt(roll.total),
-            values: results
+        const rollToKind = {
+            "critical-damage": "critical hit"
         };
-    }
-    return data;
-}
 
-function isWhispered(rollData) {
-    if (!rollData.request) return false;
-    // Fallback messages to the roll renderer will set whisper to 0 but
-    // will store the original whisper setting under 'original-whisper' field
-    const whisper = rollData.request["original-whisper"] === undefined
+        const rollToType = {
+            "to-hit": "to hit",
+            "damage": "damage",
+            "critical-damage": "damage",
+            "skill-check": "check",
+            "ability-check": "check",
+            "initiative": "check",
+            "saving-throw": "save",
+            "death-save": "save",
+        };
+
+        const data = {
+            diceNotation: {
+                constant,
+                set: sets
+            },
+            diceNotationStr: roll.formula,
+            rollKind: rollToKind[roll.type] || "",
+            rollType: rollToType[roll.type] || "roll"
+        };
+
+        // diceOperation options: 0 = sum, 1 = min, 2 = max
+        // rollKind options : "" = none, advantage, disadvantage, critical hit
+        // rollType options : roll, to hit, damage, heal, spell, save, check
+        if (forceResults || results.length > 0) {
+            data.result = {
+                constant,
+                text: roll.parts.map((p) => {
+                    if (p.total === undefined) return String(p);
+                    const rolls = p.rolls
+                        .filter((r) => !r.discarded && !Number.isNaN(parseInt(r.roll)))
+                        .map((r) => parseInt(r.roll));
+                    if (rolls.length === 0) return String(p.total);
+                    return rolls.join("+");
+                }).join(""),
+                total: parseInt(roll.total),
+                values: results
+            };
+        }
+
+        return data;
+    }
+
+    function isWhispered(rollData) {
+        if (!rollData.request) return false;
+
+        // Fallback messages to the roll renderer will set whisper to 0 but
+        // will store the original whisper setting under 'original-whisper' field
+        const whisper = rollData.request["original-whisper"] === undefined
             ? rollData.request.whisper
             : rollData.request["original-whisper"];
-    return whisper !== 0;
-}
-let lastMessage = null;
-function pendingRoll(rollData) {
-    //console.log("rolling ", rollData);
-    const toSelf = isWhispered(rollData);
-    messageBroker.on("dice/roll/pending", (message) => {
-        lastMessage = message;
-        // If no roll data, then simply stop propagation but don't replace it
-        if (!rollData) return false;
-        messageBroker.postMessage({
-            persist: false,
-            eventType: "dice/roll/pending",
-            entityType: message.entityType,
-            entityId: message.entityId,
-            gameId: message.gameId,
-            messageScope: toSelf ? "userId" : "gameId",
-            messageTarget: toSelf ?  message.userId : message.gameId,
-            userId: message.userId,
+
+        return whisper !== 0;
+    }
+
+    function pendingRoll(rollData) {
+        const toSelf = isWhispered(rollData);
+
+        messageBroker.on("dice/roll/pending", (message) => {
+            lastMessage = message;
+
+            // If no roll data, then simply stop propagation but don't replace it
+            if (!rollData) return false;
+
+            messageBroker.postMessage({
+                persist: false,
+                eventType: "dice/roll/pending",
+                entityType: message.entityType,
+                entityId: message.entityId,
+                gameId: message.gameId,
+                messageScope: toSelf ? "userId" : "gameId",
+                messageTarget: toSelf ? message.userId : message.gameId,
+                userId: message.userId,
+                data: {
+                    action: rollData.name,
+                    context: message.data.context,
+                    rollId: message.data.rollId,
+                    rolls: rollData.rolls.map((r) => rollToDDBRoll(r)),
+                    setId: message.data.setId
+                }
+            });
+
+            // Stop propagation
+            return false;
+        }, { once: true, send: true, recv: false });
+
+        messageBroker.blockMessages({ type: "dice/roll/fulfilled", once: true });
+    }
+
+    function fulfilledRoll(rollData) {
+        // In case digital dice are disabled, and we have no previous pending roll message
+        // we need to construct a valid one for DDB to parse
+        lastMessage = lastMessage || {
             data: {
-                action: rollData.name,
-                context: message.data.context,
-                rollId: message.data.rollId,
-                rolls: rollData.rolls.map(r => rollToDDBRoll(r)),
-                setId: message.data.setId
+                context: messageBroker.getContext(lastCharacter),
+                rollId: uuidv4()
+            }
+        };
+
+        const toSelf = isWhispered(rollData);
+
+        // For initiative to work in the Encounter builder, it needs to have the action name
+        // "Initiative" and not "Initiative(+x)" that B20 sends
+        const action = /^Initiative/.test(rollData.name) ? "Initiative" : rollData.name;
+
+        messageBroker.postMessage({
+            persist: true,
+            eventType: "dice/roll/fulfilled",
+            entityType: lastMessage.entityType,
+            entityId: lastMessage.entityId,
+            gameId: lastMessage.gameId,
+            messageScope: toSelf ? "userId" : "gameId",
+            messageTarget: toSelf ? lastMessage.userId : lastMessage.gameId,
+            userId: lastMessage.userId,
+            data: {
+                action,
+                rolls: rollData.rolls.map((r) => rollToDDBRoll(r, true)),
+                context: lastMessage.data.context,
+                rollId: lastMessage.data.rollId,
+                setId: lastMessage.data.setId || "8201337" // invalid is better than defaulting to Basic Black
             }
         });
-        // Stop propagation
-        return false;
-    }, {once: true, send: true, recv: false});
-    messageBroker.blockMessages({type: "dice/roll/fulfilled", once: true});
-}
-function fulfilledRoll(rollData) {
-    //console.log("fulfilled roll ", rollData);
-    // In case digital dice are disabled, and we have no previous pending roll message
-    // we need to construct a valid one for DDB to parse
-    lastMessage = lastMessage || {
-        data: {
-            context: messageBroker.getContext(lastCharacter),
-            rollId: uuidv4()
-        }
-    };
-    const toSelf = isWhispered(rollData);
-    // For initiative to work in the Encounter builder, it needs to have the action name "Initiative" and not "Initiative(+x)" that B20 sends
-    const action = /^Initiative/.test(rollData.name) ? "Initiative" : rollData.name;
-    messageBroker.postMessage({
-        persist: true,
-        eventType: "dice/roll/fulfilled",
-        entityType: lastMessage.entityType,
-        entityId: lastMessage.entityId,
-        gameId: lastMessage.gameId,
-        messageScope: toSelf ? "userId" : "gameId",
-        messageTarget: toSelf ? lastMessage.userId : lastMessage.gameId,
-        userId: lastMessage.userId,
-        data: {
-            action,
-            rolls: rollData.rolls.map(r => rollToDDBRoll(r, true)),
-            context: lastMessage.data.context,
-            rollId: lastMessage.data.rollId,
-            setId: lastMessage.data.setId || "8201337" // Not setting it makes it use "Basic Black" by default. Using an invalid value is better
-        }
-    });
-    // Avoid overwriting the old roll in case a roll generates multiple fulfilled rolls (critical hit)
-    lastMessage.data.rollId = uuidv4();
-}
 
-function disconnectAllEvents() {
-    for (let event of registered_events)
-        document.removeEventListener(...event);
-    messageBroker.unregister();
-}
+        // Avoid overwriting the old roll in case a roll generates multiple fulfilled rolls (critical hit)
+        lastMessage.data.rollId = uuidv4();
+    }
 
-var registered_events = [];
-registered_events.push(addCustomEventListener("rendered-roll", sendRollToGameLog));
-registered_events.push(addCustomEventListener("roll", sendRollToGameLog));
-registered_events.push(addCustomEventListener("MBPendingRoll", pendingRoll));
-registered_events.push(addCustomEventListener("MBFulfilledRoll", fulfilledRoll));
-registered_events.push(addCustomEventListener("disconnect", disconnectAllEvents));
+    function disconnectAllEvents() {
+        const registeredEvents = window[EVENTS_KEY] || [];
+
+        for (const event of registeredEvents) {
+            document.removeEventListener(...event);
+        }
+
+        window[EVENTS_KEY] = [];
+        window.__beyond20_mb2_initialized__ = false;
+
+        // This only restores dispatch monkey-patching on the singleton broker.
+        // It still does not truly unsubscribe _onMessage inside message-broker.js.
+        messageBroker.unregister();
+    }
+
+    const registered_events = [];
+    registered_events.push(addCustomEventListener("rendered-roll", sendRollToGameLog));
+    registered_events.push(addCustomEventListener("roll", sendRollToGameLog));
+    registered_events.push(addCustomEventListener("MBPendingRoll", pendingRoll));
+    registered_events.push(addCustomEventListener("MBFulfilledRoll", fulfilledRoll));
+    registered_events.push(addCustomEventListener("disconnect", disconnectAllEvents));
+
+    window[EVENTS_KEY] = registered_events;
+}


### PR DESCRIPTION
## Summary
Improves the D&D Beyond roll hijack so Beyond20 handles the roll without the native D&D Beyond roll also firing.

## Type of change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Tests (adds or updates tests)
- [ ] 📝 Documentation
- [ ] 🔧 Build/CI
- [ ] 🚨 Breaking change

## ⚠️ AI usage disclosure (required)

- [ ] I did **not** use AI for this PR.
- [x] I **did** use AI for this PR (describe below).

Used AI to help inspect the injected page flow, debug event handling, and shape the interception changes. Final code was reviewed and adjusted by me.

## Motivation & context
- Related issue(s): #
- Context:
Some D&D Beyond roll buttons were still triggering native digital dice. In some cases this also caused duplicate roll handling.

## What changed?
- Expanded the hijack to cover more roll types like saves, skills, abilities, and initiative
- Moved save handling to use the clicked row as the source of truth
- Improved event interception so native D&D Beyond roll handlers are blocked earlier
- Reduced duplicate roll paths between direct execution and quick roll flow

## How to test
1. Open a D&D Beyond sheet with the extension enabled
2. Click attack, save, skill, ability, and initiative rolls
3. Confirm Beyond20 handles the roll
4. Confirm native D&D Beyond digital dice does not also roll
5. Confirm rolls are not duplicated

## Reviewer notes
- Main area to check is event timing and quick roll interaction
- Saving throws now use row data instead of relying on the sidebar pane