### PR TITLE
dndbeyond: Game Log Fixes

### DIFF
--- a/src/dndbeyond/base/message-broker.js
+++ b/src/dndbeyond/base/message-broker.js
@@ -8,7 +8,7 @@ class DDBMessageBroker {
         this._hooks = {};
         this._characterId = (window.location.pathname.match(/\/characters\/([0-9]+)/) || [])[1];
         this.saveMessages = false;
-        this._debug = true;
+        this._debug = false;
 
         // Bridge flag used by window.postMessage so content scripts can receive dice roll events
         this.B20_DDB_DICE_MB_BRIDGE = "__b20_ddb_dice_mb_bridge__";

--- a/src/dndbeyond/base/message-broker.js
+++ b/src/dndbeyond/base/message-broker.js
@@ -8,7 +8,7 @@ class DDBMessageBroker {
         this._hooks = {};
         this._characterId = (window.location.pathname.match(/\/characters\/([0-9]+)/) || [])[1];
         this.saveMessages = false;
-        this._debug = false;
+        this._debug = true;
 
         // Bridge flag used by window.postMessage so content scripts can receive dice roll events
         this.B20_DDB_DICE_MB_BRIDGE = "__b20_ddb_dice_mb_bridge__";

--- a/src/dndbeyond/page-scripts/message-broker.js
+++ b/src/dndbeyond/page-scripts/message-broker.js
@@ -54,7 +54,7 @@ if (!window.__beyond20_mb2_initialized__) {
         messageBroker.postMessage(message);
     }
 
-    function rollToDDBRoll(roll, forceResults = false) {
+    function rollToDDBRoll(roll, forceResults = false, damageType = null) {
         let constant = 0;
         let lastOperation = "+";
         const sets = [];
@@ -117,6 +117,11 @@ if (!window.__beyond20_mb2_initialized__) {
             "death-save": "save",
         };
 
+        let rollType = rollToType[roll.type] || "roll";
+        if (damageType && (roll.type === "damage" || roll.type === "critical-damage")) {
+            rollType = damageType;
+        }
+
         const data = {
             diceNotation: {
                 constant,
@@ -124,7 +129,7 @@ if (!window.__beyond20_mb2_initialized__) {
             },
             diceNotationStr: roll.formula,
             rollKind: rollToKind[roll.type] || "",
-            rollType: rollToType[roll.type] || "roll"
+            rollType: rollType
         };
 
         if (forceResults || results.length > 0) {
@@ -156,9 +161,16 @@ if (!window.__beyond20_mb2_initialized__) {
         const isDisadvantage = advantage === 4;
         const isSuperAdvantage = advantage === 6;
         const isSuperDisadvantage = advantage === 7;
+        
+        const damageTypes = request["damage-types"] || [];
 
         if (!isAdvantage && !isDisadvantage && !isSuperAdvantage && !isSuperDisadvantage) {
-            return rolls.map(r => rollToDDBRoll(r, true));
+            let damageTypeIndex = 0;
+            return rolls.map((r) => {
+                const isDamageRoll = r.type === "damage" || r.type === "critical-damage";
+                const dt = isDamageRoll ? damageTypes[damageTypeIndex++] : null;
+                return rollToDDBRoll(r, true, dt);
+            });
         }
 
         const [d20Rolls, otherRolls] = [[], []];
@@ -167,9 +179,14 @@ if (!window.__beyond20_mb2_initialized__) {
         }
 
         const isAdv = isAdvantage || isSuperAdvantage;
+        let damageTypeIndex = 0;
         return [
             ...(d20Rolls.length ? [combineD20Rolls(d20Rolls, isAdv, isSuperAdvantage || isSuperDisadvantage)] : []),
-            ...otherRolls.map(r => rollToDDBRoll(r, true))
+            ...otherRolls.map((r) => {
+                const isDamageRoll = r.type === "damage" || r.type === "critical-damage";
+                const dt = isDamageRoll ? damageTypes[damageTypeIndex++] : null;
+                return rollToDDBRoll(r, true, dt);
+            })
         ];
     }
 

--- a/src/dndbeyond/page-scripts/message-broker.js
+++ b/src/dndbeyond/page-scripts/message-broker.js
@@ -398,45 +398,47 @@ if (!window.__beyond20_mb2_initialized__) {
         messageBroker.on("dice/roll/pending", bindRollIdIfNeeded, { once: false, send: true, recv: false });
 
         // Intercept fulfilled BEFORE it reaches the DDB game log.
-        // We manually forward it to the digital-dice bridge first so dice parsing still works.
+        // Block raw DDB messages, allow our modified messages through.
         messageBroker.on("dice/roll/fulfilled", (message) => {
-            if (!b20OverrideQueue.length) return;
-            if (message?.data && message.data[B20_OVERRIDE_MARKER]) return;
+            // Allow Beyond20 override messages through
+            if (message?.data && message.data[B20_OVERRIDE_MARKER]) {
+                return;
+            }
 
-            const rid = message?.data?.rollId;
-            let idx = (rid ? b20OverrideQueue.findIndex(e => e.rollId === rid) : -1);
-            if (idx === -1) idx = 0;
-
-            const entry = b20OverrideQueue[idx];
-            if (!entry) return;
-
-            entry.ddbFulfilled = message;
-            if (!entry.rollId && rid) entry.rollId = rid;
-
-            // Preserve digital dice result parsing even though we suppress the native fulfilled
-            try {
-                if (typeof messageBroker._forwardDiceRollEvent === "function") {
-                    messageBroker._forwardDiceRollEvent(message);
+            // If we have a queue entry with rollData, dispatch our override
+            if (b20OverrideQueue.length) {
+                const entry = b20OverrideQueue[0];
+                const rid = message?.data?.rollId;
+                
+                // Preserve digital dice result parsing
+                try {
+                    if (typeof messageBroker._forwardDiceRollEvent === "function") {
+                        messageBroker._forwardDiceRollEvent(message);
+                    }
+                } catch (e) {
+                    console.warn("Beyond20: failed to forward fulfilled message to dice bridge", e);
                 }
-            } catch (e) {
-                console.warn("Beyond20: failed to forward fulfilled message to dice bridge", e);
+
+                if (!entry.rollId && rid) entry.rollId = rid;
+                entry.ddbFulfilled = message;
+
+                if (entry.rollData) {
+                    _dispatchOverrideFulfilled(entry, 0);
+                    return false;
+                }
+
+                // No rollData yet, start fallback timer
+                if (!entry.fallbackTimer) {
+                    entry.fallbackTimer = setTimeout(() => {
+                        entry.fallbackTimer = null;
+                        _dispatchOriginalFulfilled(entry, 0);
+                    }, 2000);
+                }
             }
 
-            if (entry.rollData) {
-                _dispatchOverrideFulfilled(entry, idx);
-                return false;
-            }
-
-            if (!entry.fallbackTimer) {
-                entry.fallbackTimer = setTimeout(() => {
-                    entry.fallbackTimer = null;
-                    _dispatchOriginalFulfilled(entry, idx);
-                }, 2000);
-            }
-
-            // Always suppress the native fulfilled from reaching the DDB game log directly
+            // Block all other messages (raw DDB messages from other players)
             return false;
-        }, { once: false, send: true, recv: false });
+        }, { once: false, send: true, recv: true });
     }
 
     function pendingRoll(rollData) {
@@ -500,4 +502,7 @@ if (!window.__beyond20_mb2_initialized__) {
     registered_events.push(addCustomEventListener("disconnect", disconnectAllEvents));
 
     window[EVENTS_KEY] = registered_events;
+    
+    // Install hooks immediately so we can intercept messages from other players
+    _installB20OverrideHooksOnce();
 }

--- a/src/dndbeyond/page-scripts/message-broker.js
+++ b/src/dndbeyond/page-scripts/message-broker.js
@@ -415,45 +415,54 @@ if (!window.__beyond20_mb2_initialized__) {
         messageBroker.on("dice/roll/pending", bindRollIdIfNeeded, { once: false, send: true, recv: false });
 
         // Intercept fulfilled BEFORE it reaches the DDB game log.
-        // Block raw DDB messages, allow our modified messages through.
+        // Block rolls we initiated (we have queue entry), allow dice toolbox rolls through.
         messageBroker.on("dice/roll/fulfilled", (message) => {
             // Allow Beyond20 override messages through
             if (message?.data && message.data[B20_OVERRIDE_MARKER]) {
                 return;
             }
 
-            // If we have a queue entry with rollData, dispatch our override
-            if (b20OverrideQueue.length) {
-                const entry = b20OverrideQueue[0];
-                const rid = message?.data?.rollId;
-                
-                // Preserve digital dice result parsing
-                try {
-                    if (typeof messageBroker._forwardDiceRollEvent === "function") {
-                        messageBroker._forwardDiceRollEvent(message);
-                    }
-                } catch (e) {
-                    console.warn("Beyond20: failed to forward fulfilled message to dice bridge", e);
+            const rid = message?.data?.rollId;
+            
+            // Check if this rollId matches any of our queue entries
+            let queueIdx = -1;
+            if (rid && b20OverrideQueue.length) {
+                queueIdx = b20OverrideQueue.findIndex(e => e.rollId === rid);
+            }
+            
+            // If no matching queue entry, this is a dice toolbox roll - allow through
+            if (queueIdx === -1) {
+                return;
+            }
+            
+            const entry = b20OverrideQueue[queueIdx];
+            
+            // Preserve digital dice result parsing
+            try {
+                if (typeof messageBroker._forwardDiceRollEvent === "function") {
+                    messageBroker._forwardDiceRollEvent(message);
                 }
-
-                if (!entry.rollId && rid) entry.rollId = rid;
-                entry.ddbFulfilled = message;
-
-                if (entry.rollData) {
-                    _dispatchOverrideFulfilled(entry, 0);
-                    return false;
-                }
-
-                // No rollData yet, start fallback timer
-                if (!entry.fallbackTimer) {
-                    entry.fallbackTimer = setTimeout(() => {
-                        entry.fallbackTimer = null;
-                        _dispatchOriginalFulfilled(entry, 0);
-                    }, 2000);
-                }
+            } catch (e) {
+                console.warn("Beyond20: failed to forward fulfilled message to dice bridge", e);
             }
 
-            // Block all other messages (raw DDB messages from other players)
+            if (!entry.rollId && rid) entry.rollId = rid;
+            entry.ddbFulfilled = message;
+
+            if (entry.rollData) {
+                _dispatchOverrideFulfilled(entry, queueIdx);
+                return false;
+            }
+
+            // No rollData yet, start fallback timer
+            if (!entry.fallbackTimer) {
+                entry.fallbackTimer = setTimeout(() => {
+                    entry.fallbackTimer = null;
+                    _dispatchOriginalFulfilled(entry, queueIdx);
+                }, 2000);
+            }
+            
+            // Block while we wait for rollData
             return false;
         }, { once: false, send: true, recv: true });
     }

--- a/src/dndbeyond/page-scripts/message-broker.js
+++ b/src/dndbeyond/page-scripts/message-broker.js
@@ -173,36 +173,169 @@ if (!window.__beyond20_mb2_initialized__) {
         ];
     }
 
-    function combineD20Rolls(d20Rolls, isAdvantage, isSuper = false) {
-        let constant = 0;
-        const allDice = [];
+    function combineD20Rolls(d20Rolls, isAdvantage, isSuper = false, options = {}) {
+        const {
+            rollType = "to hit",   // "to hit" | "save" | "check"
+            includeDebug = false
+        } = options;
 
-        for (let i = 0; i < d20Rolls.length; i++) {
-            for (const part of (d20Rolls[i]?.parts || [])) {
-                if (typeof part === "number") {
-                    if (i === 0) constant += part;
-                } else if (part?.faces === 20) {
-                    allDice.push(...(part.rolls || []).map(r => ({ dieType: "d20", dieValue: r.roll || 0 })));
-                }
-            }
+        const keepHighest = !!isAdvantage;
+        const operation = keepHighest ? 2 : 1;
+
+        function formatSigned(value) {
+            if (!value) return "";
+            return value > 0 ? `+${value}` : `${value}`;
         }
 
-        const keepHighest = isAdvantage;
-        const operation = keepHighest ? 2 : 1;
-        const count = allDice.length;
+        function parseRoll(roll) {
+            let sign = 1;
 
-        return {
-            diceNotation: { constant, set: [{ count, dieType: "d20", operation, dice: allDice }] },
-            diceNotationStr: `${count}d20${keepHighest ? "kh" : "kl"}${isSuper ? "1" : ""}`,
+            let numericConstant = 0;   // only literal numbers like -1, +3
+            let d20Total = 0;          // sum of d20s in this branch
+            let extraDiceTotal = 0;    // sum of non-d20 dice in this branch
+
+            const d20Values = [];
+
+            for (const part of roll?.parts || []) {
+                if (typeof part === "string") {
+                    const op = part.trim();
+                    if (op === "+") sign = 1;
+                    else if (op === "-") sign = -1;
+                    continue;
+                }
+
+                if (typeof part === "number") {
+                    numericConstant += sign * part;
+                    sign = 1;
+                    continue;
+                }
+
+                if (part && typeof part === "object" && Array.isArray(part.rolls)) {
+                    const values = (part.rolls || []).map(r => Number(r?.roll) || 0);
+                    const subtotal = values.reduce((sum, v) => sum + v, 0);
+
+                    if (part.faces === 20) {
+                        d20Values.push(...values);
+                        d20Total += sign * subtotal;
+                    } else {
+                        extraDiceTotal += sign * subtotal;
+                    }
+
+                    sign = 1;
+                }
+            }
+
+            const reconstructedTotal = d20Total + extraDiceTotal + numericConstant;
+            const total = typeof roll?.total === "number" ? roll.total : reconstructedTotal;
+
+            // This is the branch value WITHOUT the flat numeric modifier.
+            // It still includes bless/bane/etc, because those are rolled per branch for the extension.
+            const displayValue = total - numericConstant;
+
+            return {
+                raw: roll,
+                total,
+                numericConstant,
+                d20Total,
+                extraDiceTotal,
+                d20Values,
+                displayValue
+            };
+        }
+
+        function buildDiceNotationStr(d20Count, flatConstant, keepHighest) {
+            const base = `${d20Count}d20${keepHighest ? "kh1" : "kl1"}`;
+            return `${base}${formatSigned(flatConstant)}`;
+        }
+
+        if (!Array.isArray(d20Rolls) || d20Rolls.length === 0) {
+            return {
+                diceNotation: {
+                    constant: 0,
+                    set: []
+                },
+                diceNotationStr: "",
+                rollKind: keepHighest ? "advantage" : "disadvantage",
+                rollType,
+                result: {
+                    constant: 0,
+                    text: "",
+                    total: 0,
+                    values: []
+                }
+            };
+        }
+
+        const parsedRolls = d20Rolls.map(parseRoll);
+        const allD20Values = parsedRolls.flatMap(r => r.d20Values);
+
+        // Pick the winning FULL branch total.
+        const selectedRoll = parsedRolls.reduce((best, current) => {
+            if (!best) return current;
+            return keepHighest
+                ? current.total > best.total ? current : best
+                : current.total < best.total ? current : best;
+        }, null);
+
+        // In normal use these should all match, since the formula is the same for each branch.
+        // We keep the selected branch's numeric constant to stay safe.
+        const flatConstant = selectedRoll?.numericConstant ?? 0;
+
+        // Show values WITHOUT the flat numeric constant, but WITH per-branch rolled dice like bless.
+        const displayValues = parsedRolls.map(r => r.total - flatConstant);
+
+        const resultText = `(${displayValues.join(",")})${formatSigned(flatConstant)}`;
+        const resultSummary = `${resultText} = ${selectedRoll?.total ?? 0}`;
+
+        const payload = {
+            diceNotation: {
+                constant: flatConstant,
+                set: [
+                    {
+                        count: allD20Values.length,
+                        dieType: "d20",
+                        operation,
+                        dice: allD20Values.map(v => ({
+                            dieType: "d20",
+                            dieValue: v
+                        }))
+                    }
+                ]
+            },
+
+            // Helpful for debugging/other consumers.
+            // DDB itself seems to rebuild from diceNotation, not this string.
+            diceNotationStr: buildDiceNotationStr(
+                allD20Values.length,
+                flatConstant,
+                keepHighest
+            ),
+
+            // Keep native wording even for super advantage/disadvantage.
+            // The 3d20 visual comes from count, not a different rollKind.
             rollKind: keepHighest ? "advantage" : "disadvantage",
-            rollType: "to hit",
+            rollType,
+
             result: {
-                constant,
-                text: `(${allDice.map(d => d.dieValue).join(",")})+${constant}`,
-                total: constant + Math[keepHighest ? "max" : "min"](...allDice.map(d => d.dieValue)),
-                values: allDice.map(d => d.dieValue)
+                constant: flatConstant,
+                text: resultText,
+                summary: resultSummary,
+                total: selectedRoll?.total ?? 0,
+                values: displayValues
             }
         };
+
+        if (includeDebug) {
+            payload.__nativeDowngrade__ = true;
+            payload.__isSuper__ = !!isSuper;
+            payload.__rawD20Values__ = allD20Values;
+            payload.__branchTotals__ = parsedRolls.map(r => r.total);
+            payload.__branchDisplayValues__ = displayValues;
+            payload.__selectedBranchTotal__ = selectedRoll?.total ?? 0;
+            payload.__selectedFlatConstant__ = flatConstant;
+        }
+
+        return payload;
     }
 
     function _dispatchOriginalFulfilled(entry, idx) {

--- a/src/roll20/content-script.js
+++ b/src/roll20/content-script.js
@@ -561,8 +561,8 @@ async function rollRollTable(request) {
     return createTable(request, `${request.name}: [[${table.total} [${request.formula}]]]`, results);
 }
 
-function convertRollToText(whisper, roll, standout=false) {
-    if (typeof (roll) === "string")
+function convertRollToText(whisper, roll, standout = false) {
+    if (typeof roll === "string")
         return roll;
     const total = roll.total || 0;
     const prefix = (standout && !roll.discarded) ? '{' : '';
@@ -571,36 +571,45 @@ function convertRollToText(whisper, roll, standout=false) {
     const formula = roll.formula || "";
     const parts = roll.parts || [];
     let critfail = "";
-    if (roll['critical-success'] || roll['critical-failure'])
-        critfail = ` + 1d0cs>${roll['critical-success'] ? '0' : '1'}cf>${roll['critical-failure'] ? '0' : '1'}`
+    if (roll['critical-success'] || roll['critical-failure']) {
+        critfail = ` + 1d0cs>${roll['critical-success'] ? '0' : '1'}cf>${roll['critical-failure'] ? '0' : '1'}`;
+    }
+
     let result = `${prefix}[[ ${total}${critfail} [${formula}] = `;
     let plus = '';
     for (let part of parts) {
         if (part.rolls) {
-            result += `${plus}(`
+            result += `${plus}(`;
             let part_plus = '';
             for (let die of part.rolls) {
-                result += die.discarded ? `~${part_plus}${die.roll}~` : `${part_plus}${die.roll}`;
+                result += die.discarded
+                    ? `~${part_plus}${die.roll}~`
+                    : `${part_plus}${die.roll}`;
                 part_plus = ' + ';
             }
-            result += ')';
-        } else {
-            if (['+', '-'].includes(String(part).trim())) {
-                plus = ` ${part} `;
-            } else {
-                part = isNaN(part) ? part : Number(part);
-                if (part < 0) {
-                    part = -1 * part;
-                    plus = ' - ';
-                }
-                result += `${plus}${part}`;
-            }
+            result += `)`;
+            plus = ' + ';
+            continue;
         }
+
+        const token = String(part).trim();
+        if (token === '+' || token === '-') {
+            plus = ` ${token} `;
+            continue;
+        }
+
+        part = isNaN(part) ? part : Number(part);
+        if (typeof part === "number" && part < 0) {
+            part = -part;
+            plus = ' - ';
+        }
+
+        result += `${plus}${part}`;
         plus = ' + ';
     }
     result += `]]${suffix}`;
     return result;
-};
+}
 
 function displayExtraInfo(request) {
     let extra = "";


### PR DESCRIPTION
## Summary
Fixes DDB game log rendering for custom d20 rolls with branch modifiers.
ALSO
Fixes game log rendering so Beyond20 rolls appear correctly for all players. Previously, raw DDB messages would appear instead of Beyond20-enhanced messages.
ALSO
Fix for the roll operator '-' for tooltip in roll20, so it shows the correct modifier.

## Type of change
<!-- Mark the relevant option(s) -->
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## ⚠️ AI usage disclosure (required)

> ⚠️ If you used AI tools (e.g., ChatGPT, Copilot, Claude, etc.) to generate or substantially modify **code, tests, documentation, or review comments**, you **must** disclose it here and describe what was AI-assisted.

- [x] I **did** use AI for this PR (describe below).

Used AI to help review DDB broker payloads, compare native roll shapes, and draft the downgrade logic for custom d20 rolls in the game log.

## Motivation & context
- Related issue(s): https://github.com/kakaroto/Beyond20/issues/1361, https://github.com/kakaroto/Beyond20/issues/1367
- Context: DDB game log was rendering custom advantage/disadvantage rolls incorrectly when extra branch dice were present (for example Bless). It was showing invalid formulas and applying modifiers in confusing ways.
- Game log was showing raw DDB messages instead of Beyond20-enhanced messages when other players rolled.
- Roll20 was showing the incorrect math on rolls with negative modifiers on the roll tooltip.

## What changed?
- Flatten custom d20 branch rolls into a DDB-safe payload shape for checks, saves, and to-hit rolls.
- Preserve correct final totals while simplifying branch display to `(branch total without flat mod, branch total without flat mod) +/- mod`.
- Keep support for super advantage/disadvantage by showing `3d20` while still using native advantage/disadvantage semantics.
- Hook installs immediately at startup, not just when `pendingRoll` fires.
- Hook now intercepts **received** messages (`recv: true`) in addition to sent messages.
- Hook blocks all `dice/roll/fulfilled` messages **without** the `__b20Override__` marker.
- Our modified messages (with marker) are allowed through.
- This ensures only Beyond20 messages reach the game log.
- roll20 operator fix for roll tooltip for negative rolls now shows the correct math.

## How to test
> [!NOTE]
> Modifier Changes

1. Roll a normal advantage/disadvantage check/save/attack and confirm the game log still renders correctly.
2. Roll with branch modifiers like `1d20 - 1 + 1d4` twice and confirm the log shows the downgraded display shape, for example `(20,12)-1 = 19`.
3. Roll with super advantage/disadvantage and confirm the payload shows `3d20` and the final total matches the selected branch result.

> [!NOTE]
> Game Log Changes 

1. Open D&D Beyond in two different browsers/browsers (simulating two players).
2. Have one player roll a dice (Eldritch Blast, attack roll, etc.).
3. **Expected**: Both players see the Beyond20-enhanced message in the game log.
4. **Bug fixed**: Raw DDB messages no longer appear in the game log.
5. Test with advantage/disadvantage rolls to confirm they render correctly.

## Reviewer notes
- This intentionally dumbs down custom rolls to fit DDB’s native game log model.
- Extra per-branch dice are folded into branch display / final total instead of being emitted as separate dice sets.
- Main thing to review is the downgrade logic for branch totals vs flat modifiers.