### PR TITLE
feat: add crimson rite selection

### DIFF
--- a/src/dndbeyond/base/character.js
+++ b/src/dndbeyond/base/character.js
@@ -459,6 +459,33 @@ class Character extends CharacterBase {
         return this._class_features.filter(f => f.startsWith(`${name}:`)).map(m => m.replace(`${name}: `, ""))
     }
 
+    getCrimsonRiteDamageTypes() {
+        if (!this._settings?.["bloodhunter-crimson-rite"]) return [];
+
+        const features =
+            this._settings?.["class-features"] ??
+            this._class_features ??
+            [];
+
+        const damageTypes = new Set();
+
+        for (const feature of features) {
+            if (typeof feature !== "string") continue;
+            if (!feature.startsWith("Crimson Rite:")) continue;
+            if (!feature.includes("The extra damage dealt by your rite is")) continue;
+
+            const match = feature.match(
+            /The extra damage dealt by your rite is (\w+) damage\b/i
+            );
+
+            if (match) {
+            damageTypes.add(match[1].toLowerCase());
+            }
+        }
+
+        return [...damageTypes];
+    }
+
     getSneakAttackActions() {
         // Define the regex only once
         const regex = /(?:Sneak Attack: )(.*?) \(Cost: (\d+)[dD]\d+\)/;

--- a/src/dndbeyond/base/utils.js
+++ b/src/dndbeyond/base/utils.js
@@ -150,6 +150,50 @@ async function queryDamageTypeFromArray(name, damages, damage_types, possible_ty
     return choice;
 }
 
+function capitalizeDamageType(type) {
+    if (!type) return type;
+    return type.charAt(0).toUpperCase() + type.slice(1).toLowerCase();
+}
+
+async function queryDamageTypeForPlaceholder(name, damages, damage_types, placeholder_type, possible_types) {
+    const idx = damage_types.findIndex(t => t === placeholder_type);
+    if (idx === -1) return;
+
+    const normalized_types = [...new Set(
+        possible_types
+            .filter(Boolean)
+            .map(capitalizeDamageType)
+    )];
+
+    if (normalized_types.length === 0) return;
+
+    const labelFor = (type) => `${placeholder_type} (${type})`;
+
+    // Only one selected rite, so no need to ask
+    if (normalized_types.length === 1) {
+        const label = labelFor(normalized_types[0]);
+        damage_types[idx] = label;
+        return label;
+    }
+
+    const damage_choices = {};
+    for (const type of normalized_types) {
+        damage_choices[labelFor(type)] = damages[idx];
+    }
+
+    const id = `dmg-${name.replace(/[^a-zA-Z0-9]/g, '-')}-${placeholder_type.replace(/[^a-zA-Z0-9]/g, '-')}`;
+    const choice = await dndbeyondDiceRoller.queryDamageType(
+        `${name}: ${placeholder_type}`,
+        damage_choices,
+        id
+    );
+
+    if (choice === null) return null; // query was cancelled
+
+    damage_types[idx] = choice;
+    return choice;
+}
+
 async function queryCunningStrike() {
     const selection = [];
     // Sneak Attack free-rules, pg. 129
@@ -339,6 +383,22 @@ async function buildAttackRoll(character, attack_source, name, description, prop
                 damages[0] = damages[0].replace("d8", ttd_dice);
                 damage_types[0] = damage_types[0] + (ttd_dice === "d8" ? ' (Full HP)' : ' (Missing HP)');
             }
+        } else if (character.hasClass("Blood Hunter") && 
+                (character.getSetting("bloodhunter-crimson-rite", false) &&
+                character.hasClassFeature("Crimson Rite") &&
+                ((properties["Attack Type"] == "Ranged" || properties["Attack Type"] == "Melee") ||
+                action_name.includes("Predatory Strike") || action_name.includes("Polearm Master")))) {
+                    const selectedRiteTypes = character.getCrimsonRiteDamageTypes();
+
+                    const choice = await queryDamageTypeForPlaceholder(
+                    roll_properties.name,
+                    damages,
+                    damage_types,
+                    "Crimson Rite",
+                    selectedRiteTypes
+                    );
+
+                    if (choice === null) return null;
         }  else if (roll_properties.name === "Spirit Shroud") {
             const choice = await queryDamageTypeFromArray(roll_properties.name, damages, damage_types, ["Cold", "Necrotic", "Radiant"]);
             if (choice === null) return null; // Query was cancelled;


### PR DESCRIPTION
## Summary
This PR adds support for resolving Blood Hunter Crimson Rite damage into the actual selected rite damage types at roll time. It parses only the selected Crimson Rite feature entries and replaces the generic `Crimson Rite` damage label with a specific label such as `Crimson Rite (Fire)`.

## Type of change
<!-- Mark the relevant option(s) -->
- [x] ✨ New feature (non-breaking change that adds functionality)

## ⚠️ AI usage disclosure (required)

> ⚠️ If you used AI tools (e.g., ChatGPT, Copilot, Claude, etc.) to generate or substantially modify **code, tests, documentation, or review comments**, you **must** disclose it here and describe what was AI-assisted.

- [x] I **did** use AI for this PR (describe below).

Drafting this PR description

> ⚠️ **If AI-generated content is identified in this PR and AI usage was not disclosed, the PR will be rejected.**

## Motivation & context
- Related issue(s): https://github.com/kakaroto/Beyond20/issues/1090
- Context:
  Blood Hunter characters can select multiple Crimson Rite options, but the current damage output only contains a generic `Crimson Rite` damage type placeholder. This makes the final roll output ambiguous, since the actual rite damage type depends on the selected rite at the moment of attack.

## What changed?
- Added logic to extract selected Crimson Rite damage types from class feature entries that contain the appended descriptive text, such as `The extra damage dealt by your rite is fire damage.`
- Ignored unselected or generic Crimson Rite entries so only active selectable rites are considered
- Added query logic to prompt for the specific Crimson Rite damage type when a roll contains a `Crimson Rite` placeholder
- Replaced the generic damage label with a specific one such as:
  - `Crimson Rite (Fire)`
  - `Crimson Rite (Cold)`
  - `Crimson Rite (Thunder)`

## How to test
1. Load a Blood Hunter character with `bloodhunter-crimson-rite` enabled and multiple rite selections in class features
2. Confirm the selected features include entries like:
   - `Crimson Rite: Rite of the FlameThe extra damage dealt by your rite is fire damage.`
   - `Crimson Rite: Rite of the FrozenThe extra damage dealt by your rite is cold damage.`
   - `Crimson Rite: Rite of the RoarThe extra damage dealt by your rite is thunder damage.`
3. Roll an attack with damage arrays similar to:
   - `damages = ["1d6+2", "1d8"]`
   - `damage_types = ["Piercing", "Crimson Rite"]`
4. Verify the user is prompted only with the selected rite damage types
5. Choose one option and verify the final damage type becomes `Crimson Rite (Fire)` or the corresponding selected type instead of plain `Crimson Rite`
6. Verify that if only one rite is available, no unnecessary prompt is shown and the placeholder is resolved automatically

## Reviewer notes
- The selection logic intentionally relies on the descriptive suffix text to distinguish selected rite entries from generic feature labels
- This change only resolves the displayed/output damage type label and does not alter the damage amount itself
- Follow-up work could generalize this placeholder-to-selected-type pattern for other class features with dynamic damage typing

## Examples

<img width="510" height="197" alt="image" src="https://github.com/user-attachments/assets/67c6bd1c-2507-45f8-9ed1-014e73300aa2" />
<img width="518" height="180" alt="image" src="https://github.com/user-attachments/assets/02aa2d44-f7e9-443f-90c2-3d964339d01b" />
<img width="505" height="349" alt="Screenshot 2026-03-26 184024" src="https://github.com/user-attachments/assets/55763a17-2dfc-43d3-84df-b7c585a01f29" />
<img width="507" height="420" alt="Screenshot 2026-03-26 183941" src="https://github.com/user-attachments/assets/c24d846a-44a6-4a77-8757-120f01168700" />
<img width="341" height="267" alt="image" src="https://github.com/user-attachments/assets/bbc6b913-e3a8-43e3-9a1a-0da94aa1a2e5" />

