### PR TITLE
feat: Support for Booming Blade and Green-Flame Blade Conditional Damage

### DIFF
--- a/FVTT-module/beyond20/beyond20.css
+++ b/FVTT-module/beyond20/beyond20.css
@@ -75,6 +75,14 @@
     background: rgba(123, 79, 184, 0.1);
 }
 
+.beyond20-total-damage.beyond20-conditional-total {
+    border: 2px solid #2a9d8f;
+    border-radius: 4px;
+    padding: 2px 8px;
+    margin-top: 4px;
+    background: rgba(42, 157, 143, 0.1);
+}
+
 .beyond20-dice-roller-content {
     background-color: #ddeedd;
     border-radius: 10px;

--- a/FVTT-module/beyond20/beyond20.css
+++ b/FVTT-module/beyond20/beyond20.css
@@ -33,6 +33,7 @@
     background: rgba(0, 0, 0, 0.1);
     border: 1px solid #999;
     margin-bottom: 3px;
+    position: relative;
 }
 
 .beyond20-critical-damage {

--- a/FVTT-module/beyond20/beyond20.css
+++ b/FVTT-module/beyond20/beyond20.css
@@ -60,6 +60,13 @@
     box-shadow: 0 0 2px #0b6900c2 inset;
 }
 
+.beyond20-conditional-damage {
+    font-style: italic;
+    opacity: 0.85;
+    border-left: 2px dashed #666;
+    padding-left: 3px;
+}
+
 .beyond20-dice-roller-content {
     background-color: #ddeedd;
     border-radius: 10px;

--- a/FVTT-module/beyond20/beyond20.css
+++ b/FVTT-module/beyond20/beyond20.css
@@ -67,6 +67,14 @@
     padding-left: 3px;
 }
 
+.beyond20-combined-damage {
+    border: 2px solid #7b4fb8;
+    border-radius: 4px;
+    padding: 2px 8px;
+    margin-top: 4px;
+    background: rgba(123, 79, 184, 0.1);
+}
+
 .beyond20-dice-roller-content {
     background-color: #ddeedd;
     border-radius: 10px;

--- a/docs/api.md
+++ b/docs/api.md
@@ -770,6 +770,7 @@ The damage flags will help determine what kind of damage it is. It is a bitfield
 - `4`: Additonal damage (anything other than the first damage from the weapon/spell)
 - `8`: Healing
 - `16`: Critical damage
+- `32`: Conditional damage (e.g., Booming Blade movement damage, Green-Flame Blade splash damage). This damage is excluded from totals and not doubled on critical hits.
 
 
 ## The DOM API

--- a/src/common/roll_renderer.js
+++ b/src/common/roll_renderer.js
@@ -432,7 +432,23 @@ class Beyond20RollRenderer {
         }
 
         let roll = null;
-        for (let key in total_damages) {
+        const outputOrder = [];
+        const keys = Object.keys(total_damages);
+        const hasCritical = keys.some(k => k.includes("Critical"));
+        const hasConditional = keys.includes("Conditional");
+        
+        if (!hasCritical && hasConditional) {
+            for (const key of keys) {
+                if (key === "Conditional") outputOrder.unshift(key);
+                else outputOrder.push(key);
+            }
+        } else {
+            for (const key of keys) {
+                outputOrder.push(key);
+            }
+        }
+        
+        for (const key of outputOrder) {
             const is_total = (roll === null);
             roll = this._roller.roll(total_damages[key]);
             roll.setRollType("damage");

--- a/src/common/roll_renderer.js
+++ b/src/common/roll_renderer.js
@@ -5,6 +5,7 @@ class DAMAGE_FLAGS {
     static get ADDITIONAL() { return 4; }
     static get HEALING() { return 8; }
     static get CRITICAL() { return 0x10; }
+    static get CONDITIONAL() { return 0x20; }
 }
 
 class Beyond20RollRenderer {
@@ -331,6 +332,7 @@ class Beyond20RollRenderer {
             let dmg_classes = "beyond20-roll-result beyond20-roll-damage";
             if (flags & DAMAGE_FLAGS.CRITICAL) dmg_classes += " beyond20-critical-damage";
             if (flags & DAMAGE_FLAGS.HEALING) dmg_classes += " beyond20-healing";
+            if (flags & DAMAGE_FLAGS.CONDITIONAL) dmg_classes += " beyond20-conditional-damage";
             html += `<div class='${dmg_classes}'><b>${roll_name}</b>${roll_html}</div>`;
             if (add_totals && typeof (roll) !== "string") {
                 let kind_of_damage = "";
@@ -340,6 +342,8 @@ class Beyond20RollRenderer {
                     kind_of_damage = flags & DAMAGE_FLAGS.CRITICAL ? "Critical 2-Handed Damage" : "2-Handed Damage";
                 } else if (flags & DAMAGE_FLAGS.HEALING) {
                     kind_of_damage = "Healing";
+                } else if (flags & DAMAGE_FLAGS.CONDITIONAL) {
+                    continue;
                 } else if (flags & DAMAGE_FLAGS.ADDITIONAL) {
                     // HACK Alert: crappy code;
                     const regular = flags & DAMAGE_FLAGS.CRITICAL ? "Critical Damage" : "Damage";
@@ -621,7 +625,20 @@ class Beyond20RollRenderer {
             const damage_types = request["damage-types"];
             const critical_damages = request["critical-damages"];
             const critical_damage_types = request["critical-damage-types"];
+            
+            const seen_spell_damages = {};
+            const seen_other_damages = {};
+            const spell_damage_counts = {};
 
+            for (let i = 0; i < (damages.length); i++) {
+                const dmg_type = damage_types[i];
+                if (dmg_type.includes("(Booming Blade)") || dmg_type.includes("(Green-Flame Blade)")) {
+                    const base_type = dmg_type.replace(/\s*\(Booming Blade\)/, "").replace(/\s*\(Green-Flame Blade\)/, "");
+                    spell_damage_counts[base_type] = (spell_damage_counts[base_type] || 0) + 1;
+                }
+            }
+
+            const spell_damage_position = {};
             for (let i = 0; i < (damages.length); i++) {
                 const dmg_type = damage_types[i];
                 let damage_flags = DAMAGE_FLAGS.REGULAR;
@@ -633,6 +650,29 @@ class Beyond20RollRenderer {
                     damage_flags = DAMAGE_FLAGS.VERSATILE;
                 } else {
                     damage_flags = DAMAGE_FLAGS.ADDITIONAL;
+                }
+
+                if (dmg_type.includes("(Booming Blade)") || dmg_type.includes("(Green-Flame Blade)")) {
+                    const base_type = dmg_type.replace(/\s*\(Booming Blade\)/, "").replace(/\s*\(Green-Flame Blade\)/, "");
+                    spell_damage_position[base_type] = (spell_damage_position[base_type] || 0) + 1;
+                    if (spell_damage_position[base_type] < spell_damage_counts[base_type]) {
+                    } else {
+                        damage_flags = DAMAGE_FLAGS.CONDITIONAL;
+                    }
+                } else if (dmg_type.includes("(") && dmg_type.includes(")")) {
+                    const base_type = dmg_type.split("(")[0].trim();
+                    if (seen_other_damages[base_type]) {
+                        damage_flags = DAMAGE_FLAGS.CONDITIONAL;
+                    }
+                    seen_other_damages[base_type] = true;
+                } else if (request.name && request.name.toLowerCase().includes("booming blade")) {
+                    if (dmg_type === "Thunder") {
+                        damage_flags = DAMAGE_FLAGS.CONDITIONAL;
+                    }
+                } else if (request.name && request.name.toLowerCase().includes("green flame blade")) {
+                    if (dmg_type === "Fire") {
+                        damage_flags = DAMAGE_FLAGS.CONDITIONAL;
+                    }
                 }
                 const suffix = !(damage_flags & DAMAGE_FLAGS.HEALING) ? " Damage" : "";
                 // Avoid adding an empty string
@@ -692,6 +732,16 @@ class Beyond20RollRenderer {
             }
             if (is_critical) {
                 const critical_damage_rolls = []
+                const seen_critical_other_damages = {};
+                const critical_spell_damage_counts = {};
+                for (let i = 0; i < (critical_damages.length); i++) {
+                    const dmg_type = critical_damage_types[i];
+                    if (dmg_type.includes("(Booming Blade)") || dmg_type.includes("(Green-Flame Blade)")) {
+                        const base_type = dmg_type.replace(/\s*\(Booming Blade\)/, "").replace(/\s*\(Green-Flame Blade\)/, "");
+                        critical_spell_damage_counts[base_type] = (critical_spell_damage_counts[base_type] || 0) + 1;
+                    }
+                }
+                const critical_spell_damage_position = {};
                 for (let i = 0; i < (critical_damages.length); i++) {
                     const roll = this._roller.roll(critical_damages[i]);
                     roll.setRollType("critical-damage");
@@ -707,6 +757,30 @@ class Beyond20RollRenderer {
                     } else {
                         damage_flags = DAMAGE_FLAGS.ADDITIONAL;
                     }
+
+                    if (dmg_type.includes("(Booming Blade)") || dmg_type.includes("(Green-Flame Blade)")) {
+                        const base_type = dmg_type.replace(/\s*\(Booming Blade\)/, "").replace(/\s*\(Green-Flame Blade\)/, "");
+                        critical_spell_damage_position[base_type] = (critical_spell_damage_position[base_type] || 0) + 1;
+                        if (critical_spell_damage_position[base_type] < critical_spell_damage_counts[base_type]) {
+                        } else {
+                            damage_flags = DAMAGE_FLAGS.CONDITIONAL;
+                        }
+                    } else if (dmg_type.includes("(") && dmg_type.includes(")")) {
+                        const base_type = dmg_type.split("(")[0].trim();
+                        if (seen_critical_other_damages[base_type]) {
+                            damage_flags = DAMAGE_FLAGS.CONDITIONAL;
+                        }
+                        seen_critical_other_damages[base_type] = true;
+                    } else if (request.name && request.name.toLowerCase().includes("booming blade")) {
+                        if (dmg_type === "Thunder") {
+                            damage_flags = DAMAGE_FLAGS.CONDITIONAL;
+                        }
+                    } else if (request.name && request.name.toLowerCase().includes("green flame blade")) {
+                        if (dmg_type === "Fire") {
+                            damage_flags = DAMAGE_FLAGS.CONDITIONAL;
+                        }
+                    }
+
                     const suffix = !(damage_flags & DAMAGE_FLAGS.HEALING) ? " Critical Damage" : "";
                     damage_rolls.push([dmg_type + suffix, roll, damage_flags | DAMAGE_FLAGS.CRITICAL]);
                 }

--- a/src/common/roll_renderer.js
+++ b/src/common/roll_renderer.js
@@ -396,6 +396,28 @@ class Beyond20RollRenderer {
                     delete total_damages["Critical 2-Handed Damage"];
                 }
             }
+            
+            const regularDamageKeys = ["Full HP Damage", "Missing HP Damage", "2-Handed Damage", "1-Handed Damage", "Damage"];
+            const criticalDamageKeys = ["Critical Full HP Damage", "Critical Missing HP Damage", "Critical 2-Handed Damage", "Critical 1-Handed Damage", "Critical Damage"];
+            let regularKey = null;
+            let criticalKey = null;
+            for (const key of regularDamageKeys) {
+                if (total_damages[key]) {
+                    regularKey = key;
+                    break;
+                }
+            }
+            for (const key of criticalDamageKeys) {
+                if (total_damages[key]) {
+                    criticalKey = key;
+                    break;
+                }
+            }
+            if (regularKey && criticalKey) {
+                const combinedFormula = `${total_damages[regularKey]} + ${total_damages[criticalKey]}`;
+                total_damages["Combined Total"] = combinedFormula;
+            }
+            
             html += "<div class='beyond20-roll-result'><b><hr/></b></div>";
         }
 
@@ -409,7 +431,9 @@ class Beyond20RollRenderer {
             const roll_html = await this.rollToDetails(roll, is_total);
             let total_classes = "beyond20-total-damage";
             if (key.includes("Critical")) total_classes += " beyond20-critical-damage";
-            html += `<div class='beyond20-roll-result ${total_classes}'><b>Total ${key}: </b>${roll_html}</div>`;
+            if (key === "Combined Total") total_classes += " beyond20-combined-damage";
+            const total_label = key === "Combined Total" ? "Combined Total" : `Total ${key}`;
+            html += `<div class='${total_classes}'><b>${total_label}: </b>${roll_html}</div>`;
         }
 
         if (request.damages && request.damages.length > 0 && 
@@ -730,6 +754,14 @@ class Beyond20RollRenderer {
             } else {
                 is_critical = request.rollCritical;
             }
+            
+            const conditional_indices = new Set();
+            for (let i = 0; i < damage_rolls.length; i++) {
+                if (damage_rolls[i][2] & DAMAGE_FLAGS.CONDITIONAL) {
+                    conditional_indices.add(i);
+                }
+            }
+            
             if (is_critical) {
                 const critical_damage_rolls = []
                 const seen_critical_other_damages = {};
@@ -743,6 +775,9 @@ class Beyond20RollRenderer {
                 }
                 const critical_spell_damage_position = {};
                 for (let i = 0; i < (critical_damages.length); i++) {
+                    if (conditional_indices.has(i)) {
+                        continue;
+                    }
                     const roll = this._roller.roll(critical_damages[i]);
                     roll.setRollType("critical-damage");
                     critical_damage_rolls.push(roll);

--- a/src/common/roll_renderer.js
+++ b/src/common/roll_renderer.js
@@ -319,6 +319,7 @@ class Beyond20RollRenderer {
             add_totals = false;
         }
         const total_damages = {}
+        let conditionalFormula = "";
         for (let [roll_name, roll, flags] of damage_rolls) {
             const is_total = !add_totals && (flags & DAMAGE_FLAGS.CRITICAL) == 0;
             let roll_html = "";
@@ -336,14 +337,19 @@ class Beyond20RollRenderer {
             html += `<div class='${dmg_classes}'><b>${roll_name}</b>${roll_html}</div>`;
             if (add_totals && typeof (roll) !== "string") {
                 let kind_of_damage = "";
-                if (flags & DAMAGE_FLAGS.REGULAR) {
+                if (flags & DAMAGE_FLAGS.CONDITIONAL) {
+                    if (conditionalFormula === "") {
+                        conditionalFormula = String(roll.total);
+                    } else {
+                        conditionalFormula += " + " + String(roll.total);
+                    }
+                    continue;
+                } else if (flags & DAMAGE_FLAGS.REGULAR) {
                     kind_of_damage = flags & DAMAGE_FLAGS.CRITICAL ? "Critical Damage" : "Damage";
                 } else if (flags & DAMAGE_FLAGS.VERSATILE) {
                     kind_of_damage = flags & DAMAGE_FLAGS.CRITICAL ? "Critical 2-Handed Damage" : "2-Handed Damage";
                 } else if (flags & DAMAGE_FLAGS.HEALING) {
                     kind_of_damage = "Healing";
-                } else if (flags & DAMAGE_FLAGS.CONDITIONAL) {
-                    continue;
                 } else if (flags & DAMAGE_FLAGS.ADDITIONAL) {
                     // HACK Alert: crappy code;
                     const regular = flags & DAMAGE_FLAGS.CRITICAL ? "Critical Damage" : "Damage";
@@ -361,6 +367,10 @@ class Beyond20RollRenderer {
                 else
                     total_damages[kind_of_damage] = String(roll.total);
             }
+        }
+        
+        if (conditionalFormula !== "") {
+            total_damages["Conditional"] = conditionalFormula;
         }
 
         if (Object.keys(total_damages).length > 0) {
@@ -415,7 +425,7 @@ class Beyond20RollRenderer {
             }
             if (regularKey && criticalKey) {
                 const combinedFormula = `${total_damages[regularKey]} + ${total_damages[criticalKey]}`;
-                total_damages["Combined Total"] = combinedFormula;
+                total_damages["Combined"] = combinedFormula;
             }
             
             html += "<div class='beyond20-roll-result'><b><hr/></b></div>";
@@ -431,9 +441,9 @@ class Beyond20RollRenderer {
             const roll_html = await this.rollToDetails(roll, is_total);
             let total_classes = "beyond20-total-damage";
             if (key.includes("Critical")) total_classes += " beyond20-critical-damage";
-            if (key === "Combined Total") total_classes += " beyond20-combined-damage";
-            const total_label = key === "Combined Total" ? "Combined Total" : `Total ${key}`;
-            html += `<div class='${total_classes}'><b>${total_label}: </b>${roll_html}</div>`;
+            if (key === "Combined") total_classes += " beyond20-combined-damage";
+            if (key === "Conditional") total_classes += " beyond20-conditional-total";
+            html += `<div class='${total_classes}'><b>Total ${key}: </b>${roll_html}</div>`;
         }
 
         if (request.damages && request.damages.length > 0 && 

--- a/src/extension/beyond20.css
+++ b/src/extension/beyond20.css
@@ -106,6 +106,14 @@
     padding-left: 3px;
 }
 
+.beyond20-combined-damage {
+    border: 2px solid #7b4fb8;
+    border-radius: 4px;
+    padding: 2px 8px;
+    margin-top: 4px;
+    background: rgba(123, 79, 184, 0.1);
+}
+
 .beyond20-dice-roller-content {
     background-color: #ddeedd;
     border-radius: 10px;

--- a/src/extension/beyond20.css
+++ b/src/extension/beyond20.css
@@ -99,6 +99,13 @@
     box-shadow: 0 0 2px #0b6900c2 inset;
 }
 
+.beyond20-conditional-damage {
+    font-style: italic;
+    opacity: 0.85;
+    border-left: 2px dashed #666;
+    padding-left: 3px;
+}
+
 .beyond20-dice-roller-content {
     background-color: #ddeedd;
     border-radius: 10px;

--- a/src/extension/beyond20.css
+++ b/src/extension/beyond20.css
@@ -72,6 +72,7 @@
     background: rgba(0, 0, 0, 0.1);
     border: 1px solid #999;
     margin-bottom: 3px;
+    position: relative;
 }
 
 .beyond20-critical-damage {

--- a/src/extension/beyond20.css
+++ b/src/extension/beyond20.css
@@ -114,6 +114,14 @@
     background: rgba(123, 79, 184, 0.1);
 }
 
+.beyond20-total-damage.beyond20-conditional-total {
+    border: 2px solid #2a9d8f;
+    border-radius: 4px;
+    padding: 2px 8px;
+    margin-top: 4px;
+    background: rgba(42, 157, 143, 0.1);
+}
+
 .beyond20-dice-roller-content {
     background-color: #ddeedd;
     border-radius: 10px;


### PR DESCRIPTION
## Summary
Added support for `Booming Blade` and `Green-Flame Blade` conditional damage: excludes rider damage from totals and prevents critical doubling per RAW.

## Type of change
<!-- Mark the relevant option(s) -->
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)

## ⚠️ AI usage disclosure (required)

> ⚠️ If you used AI tools (e.g., ChatGPT, Copilot, Claude, etc.) to generate or substantially modify **code, tests, documentation, or review comments**, you **must** disclose it here and describe what was AI-assisted.

- [x] I **did** use AI for this PR (describe below).

Drafting this PR description

## Motivation & context
- Related issue(s): https://github.com/kakaroto/Beyond20/issues/1364
- Context: These spells have conditional/rider damage (movement-triggered for Booming Blade, splash for Green-Flame Blade) that is incorrectly included in totals and doubled on crits. Per RAW, rider damages are separate damage events not affected by critical hits.

## What changed?
- Added `DAMAGE_FLAGS.CONDITIONAL` flag to identify rider damages
- Conditional damages excluded from main "Total Damage" and not doubled on critical hits (for now)
- Added "Total Conditional" line showing conditional damage sum
- Added "Total Combined" line when both regular and critical damage exist
- Added distinct CSS styling (teal for conditional, purple for combined)

## How to test
1. Roll an attack with Booming Blade or Green-Flame Blade
2. Verify conditional damage (movement/splash) is italic/dashed border styled
3. Verify conditional damage NOT in main "Total Damage"
4. On critical hit, verify conditional damage NOT doubled
5. Check "Total Conditional" shows conditional damage sum

## Screenshots

> [!IMPORTANT]
> All VTT's tested, Roll20 with all Sheets types, Foundry Latest and Discord Bot

> [!IMPORTANT]
> With this change Critical rolls Now have a Combined Total where all the damages are added. 

<img width="415" height="305" alt="image" src="https://github.com/user-attachments/assets/f625177a-56fa-43b9-9502-f9573dae005a" />

> [!NOTE]
> Low Level Spells

| Normal | Crit |
|------|------| 
| Booming Blade |------| 
| <img width="419" height="244" alt="image" src="https://github.com/user-attachments/assets/1f2f4b39-004e-4f26-80da-92f7d83b7982" /> | <img width="416" height="325" alt="image" src="https://github.com/user-attachments/assets/f745ee75-26bf-43c3-9a30-ec808e68f996" /> |
| Green Flame Blade |------| 
| <img width="420" height="243" alt="image" src="https://github.com/user-attachments/assets/44175974-3a9f-42d3-a386-d7c982f70ef7" /> | <img width="417" height="324" alt="image" src="https://github.com/user-attachments/assets/019c27c8-7e3f-4b80-87da-48cc8c4a5932" /> |

> [!NOTE]
> High Level Spells

| Normal | Crit |
|------|------| 
| Booming Blade |------| 
| <img width="422" height="259" alt="image" src="https://github.com/user-attachments/assets/c384c674-0b53-4e3b-ad41-59e8e5c94d72" /> | <img width="418" height="362" alt="image" src="https://github.com/user-attachments/assets/08462322-9f4d-4325-bf13-4c157692e887" /> |
| Green Flame Blade |------| 
| <img width="416" height="261" alt="image" src="https://github.com/user-attachments/assets/89074757-3410-4289-a850-b97a3e5cf264" />|<img width="414" height="359" alt="image" src="https://github.com/user-attachments/assets/3c455b52-9860-4eda-99c9-043daabe6277" />|