### PR TITLE
fix: dice regex matches bare D1/D0 in sourcebook text (#1126)

### DIFF
--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -1,4 +1,7 @@
-const DICE_REGEXP = /(^|[^\w])(?:(?:(?:(\d*[dD]\d+(?:ro(?:=|<|<=|>|>=)[0-9]+)?(?:min[0-9]+)?)((?:(?:\s*[-−+]\s*\d+)|(?:\s*[0+]\s*\d*[dD]\d+))*))|((?:[-−+]\s*\d+)+)))($|[^\w])/gm;
+// Dice core matches either `NdM` (explicit count, any M) or bare `dM`/`DM` where M is 2..9 or two-plus digits.
+// The bare form excludes d0 and d1, which are never real dice and produce false positives on
+// sourcebook labels like "D1" (e.g. Vecna: Eve of Ruin map door labels).
+const DICE_REGEXP = /(^|[^\w])(?:(?:(?:((?:\d+[dD]\d+|[dD](?:[2-9]|\d{2,}))(?:ro(?:=|<|<=|>|>=)[0-9]+)?(?:min[0-9]+)?)((?:(?:\s*[-−+]\s*\d+)|(?:\s*[0+]\s*(?:\d+[dD]\d+|[dD](?:[2-9]|\d{2,}))))*))|((?:[-−+]\s*\d+)+)))($|[^\w])/gm;
 
 function replaceRollsCallback(match, replaceCB) {
     let dice = match[2];


### PR DESCRIPTION
## Summary

Fixes #1126. The `DICE_REGEXP` in `src/common/utils.js` used `\d*[dD]\d+` for the dice core, which allows *zero* digits before `d`. That makes bare `D0` and `D1` match the regex, so sourcebook labels like the `D1` door in Vecna: Eve of Ruin get swapped out for the Beyond20 roll icon.

This PR narrows the bare form to `[dD](?:[2-9]|\d{2,})` while leaving `NdM` (explicit count) completely untouched. d0 and d1 are never real dice, so this removes the false positive without changing behavior for any real roll notation.

## What still matches (no regressions)

- `d2`, `d3`, `d4`, `d6`, `d8`, `d10`, `d12`, `d20`, `d100`
- `D20`, `D12` (uppercase)
- `1d20`, `2d6+3`, `10d6`, `3d8 + 1d4`
- Explicit `1d1`, `2d1`, `10d1`, `1d0` (preserved for any internal formulas that stand in a fixed value)
- Suffixes: `2d10ro=1`, `d4min2`
- Pure modifiers: `+5`, `-3`

## What no longer matches (the bug)

- Bare `D1`, `d1`, `D0`, `d0`
- `"touching the following doors: A2, B1, C1, D1."` (the exact string from the issue)
- `"Door D1 is locked."`

## Test plan

Regex tested against 23 inputs (bug cases + positive cases + edge cases) — all pass on the new regex, 5 fail on the old.

- [ ] Open the Vecna: Eve of Ruin ritual chamber page on D&D Beyond and confirm `D1` renders as text, not a dice icon
- [ ] Roll a spread of dice on a character sheet (`d20`, `2d6+3`, `1d8 + 2d6`, `d100`) — all still become roll buttons
- [ ] Verify any internal/homebrew formulas that use explicit `1d1` still work (e.g. fixed-damage stand-ins)