### PR TITLE
fix: 2024 Elemental Affinity damage

### DIFF
--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -1754,7 +1754,7 @@ function handleSpecialSpells(spell_name, damages=[], damage_types=[], {spell_sou
     // Check for Draconic Sorcerer's Elemental Affinity;
     let elementalAffinity = null;
     for (let feature of character._class_features) {
-        const match = feature.match("Elemental Affinity \\((.*)\\)");
+        const match = feature.match("Elemental Affinity \\((.*)\\)") || feature.match("Elemental Affinity: (.*) Damage");
         if (match) {
             elementalAffinity = match[1];
             break;


### PR DESCRIPTION
Fixes #1376

## Describe the bug

2024 Elemental Affinity damage type is not detected. The wording has changed from 2014 to 2024, which prevents the damage type from being detected.

## ⚠️ AI usage disclosure (required)

> ⚠️ If you used AI tools (e.g., ChatGPT, Copilot, Claude, etc.) to generate or substantially modify **code, tests, documentation, or review comments**, you **must** disclose it here and describe what was AI-assisted.

- [x] I **did** use AI for this PR (describe below).

Since I am not that familiar with the codebase (I did put in a small PR or two in the past) I asked Claude to make the change in case it recommended some other related change I was not aware of. This is the prompt I used:

```
Update the Elemental Affinity match to also match on "Elemental Affinity: (.*) Damage"
```

> ⚠️ **If AI-generated content is identified in this PR and AI usage was not disclosed, the PR will be rejected.**

## To Reproduce

Steps to reproduce the behavior:
1. On a 2024 Sorcerer of at least 6th level
2. Select a damage type for Elemental Affinity class option (for example, Lightning)
3. Attack or roll damage for a spell with the selected damage type (for example, Lightning Bolt)
4. See that the Elemental Affinity damage is not included

## Expected behavior

When damage is rolled for a spell with the selected Elemental Affinity damage type, it should be included in the roll results.

## Browser Info

 - Browser: Chrome
 - Version: Version 146.0.7680.178 (Official Build) (arm64)

## What Changed

Added a regex match for the 2024 pattern to detect the Elemental Affinity type.

## Screenshots

After adding the 2024 match, the Elemental Affinity damage is included.
<img width="485" height="361" alt="Screenshot 2026-04-28 at 12 43 26 AM" src="https://github.com/user-attachments/assets/60d0c8b4-b637-4293-877f-d69f5a2ce246" />
