### PR TITLE
dndbeyond: Unicode fix for minus characters monsters page

### DIFF
--- a/src/common/dice.js
+++ b/src/common/dice.js
@@ -41,10 +41,12 @@ class Beyond20BaseRoll {
     }
 
     cleanupFormula(formula) {
+        // Replace Unicode minus sign (U+2212) with ASCII hyphen-minus (U+002D)
+        formula = formula.replace(/\u2212/g, "-");
         const cleaned = formula
             .replace(/(?:\+\s*)+([+-])/g, "$1") // Change + + and + - into + and - respectively
             .replace(/(?:\-\s*\-)+/g, "+") // Change - - into +
-            .replace(/(?:\-\s*\+)+/g, "-") // Change - - into -
+            .replace(/(?:\-\s*\+)+/g, "-") // Change - + into -
             .replace(/\s+/g, " ") // trim double spaces
         if (cleaned != formula) {
             // Clean it recursively due to order of operations, we may end up with 

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -26,6 +26,8 @@ function cleanRoll(rollText) {
     //clean adjacent '+'s (Roll20 treats it as a d20);
     //eg: (1d10 + + 2 + 3) -> (1d10 + 2 + 3);
     rollText = (rollText || "").toString();
+    // Replace Unicode minus sign (U+2212) with ASCII hyphen-minus (U+002D)
+    rollText = rollText.replace(/\u2212/g, "-");
     rollText = rollText.replace(/\+ \+/g, '+').replace(/\+ \-/g, '-');
     return rollText;
 }


### PR DESCRIPTION
## Summary
Fixes a bug where monster ability, saving throw, and skill rolls with negative modifiers (using Unicode minus U+2212) were incorrectly treated as positive modifiers. The formula parser only recognized ASCII hyphens, causing values like `−2` to be ignored or parsed as `+2`.

## Type of change
<!-- Mark the relevant option(s) -->
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## ⚠️ AI usage disclosure (required)
- [x] I **did** use AI for this PR (describe below).

Drafting this PR description

> ⚠️ **If AI-generated content is identified in this PR and AI usage was not disclosed, the PR will be rejected.**

## Motivation & context
<!-- Why is this change needed? Link to issues, incidents, PRDs, discussions. -->
- Related issue(s): https://github.com/kakaroto/Beyond20/issues/1379
- Context: D&D Beyond uses Unicode minus (U+2212, `−`) for negative modifiers in monster stat blocks, while the extension's formula parser only recognized ASCII hyphen-minus (U+002D, `-`). This caused rolls like `1d20−2` to be parsed incorrectly, returning results as if the modifier was `+2`.

## What changed?
<!-- Bullet the key changes. Keep it focused on behavior & structure. -->
- Added Unicode minus (U+2212) to ASCII hyphen (U+002D) conversion in `src/common/dice.js` `cleanupFormula()` method to handle all roll formula preprocessing
- Added the same conversion in `src/common/utils.js` `cleanRoll()` function to cover the `sendRoll` preprocessing path
- Ensures all negative modifiers from D&D Beyond monster pages are correctly parsed as negative values across all roll types (abilities, saves, skills, attacks)

## How to test
<!-- Provide exact steps a reviewer can follow. Include commands and sample data. -->
1. Open a monster page with negative modifiers on D&D Beyond (e.g., Wraith, which has STR −2, save STR −2)
2. Click the roll button for the Strength ability check or saving throw
3. Verify the roll result correctly subtracts 2 from the d20 roll, not adds 2
4. Test a monster with positive modifiers (e.g., Dexterity +3) to confirm no regressions
5. Rebuild the extension with `gulp build` and reload it in the browser before testing

## Reviewer notes
<!-- Anything you want reviewers to pay attention to: tricky logic, follow-ups, tradeoffs -->
- `cleanupFormula` is called in the `Beyond20BaseRoll` constructor, which all roll classes extend, so this fix covers all roll paths
- The Unicode minus conversion is applied early in formula processing to avoid missing edge cases in downstream regex parsing
- No changes to existing ASCII hyphen handling, so positive modifiers and existing roll logic remain unaffected