### PR TITLE
fix: Address Roll20 URL not being recognized when it's missing a trailing slash

### DIFF
--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -1,4 +1,4 @@
-const ROLL20_URL = "*://app.roll20.net/editor/*";
+const ROLL20_URL = "*://app.roll20.net/editor*";
 const FVTT_URL = "*://*/*game";
 const DNDBEYOND_CHARACTER_URL = "*://*.dndbeyond.com/*characters/*";
 const DNDBEYOND_MONSTER_URL = "*://*.dndbeyond.com/monsters/*";
@@ -75,4 +75,3 @@ const BUTTON_STYLE_CSS = `
     vertical-align: middle;
 }
 `;
-


### PR DESCRIPTION
## Summary
<!-- What does this PR change, in 1–3 sentences? -->

## Type of change
<!-- Mark the relevant option(s) -->
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Tests (adds or updates tests)
- [ ] 📝 Documentation
- [ ] 🔧 Build/CI
- [ ] 🚨 Breaking change

## ⚠️ AI usage disclosure (required)

> ⚠️ If you used AI tools (e.g., ChatGPT, Copilot, Claude, etc.) to generate or substantially modify **code, tests, documentation, or review comments**, you **must** disclose it here and describe what was AI-assisted.

- [x] I did **not** use AI for this PR.
- [ ] I **did** use AI for this PR (describe below).

> ⚠️ **If AI-generated content is identified in this PR and AI usage was not disclosed, the PR will be rejected.**

## Motivation & context
<!-- Why is this change needed? Link to issues, incidents, PRDs, discussions. -->
- Related issue(s): #1381
- Context: It appears Roll20 may have changed its URI for the VTT page and removed the trailing slash, causing the ROLL20_URL constant to no longer match.

## What changed?
<!-- Bullet the key changes. Keep it focused on behavior & structure. -->
- Updated ROLL20_URL constant to match without the trailing slash

## How to test
<!-- Provide exact steps a reviewer can follow. Include commands and sample data. -->
1.
2.
3.

## Reviewer notes
<!-- Anything you want reviewers to pay attention to: tricky logic, follow-ups, tradeoffs -->
- 