### PR TITLE
fix: dice regex matches bare D1/D0 in sourcebook text (#1126)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "doc": "docs"
     },
     "scripts": {
+        "test": "node test/dice_regex.test.js",
         "gulp": "gulp",
         "clean": "gulp clean",
         "build": "run-s clean build:*",

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -1,4 +1,8 @@
-const DICE_REGEXP = /(^|[^\w])(?:(?:(?:(\d*[dD]\d+(?:ro(?:=|<|<=|>|>=)[0-9]+)?(?:min[0-9]+)?)((?:(?:\s*[-−+]\s*\d+)|(?:\s*[0+]\s*\d*[dD]\d+))*))|((?:[-−+]\s*\d+)+)))($|[^\w])/gm;
+// Bare-die forms `dN`/`DN` are only accepted when N is 2-9 or has two-or-more digits.
+// This excludes `D0`/`D1`, which are not real dice and produced false positives on
+// sourcebook map labels (issue #1126: "doors: A2, B1, C1, D1"). Forms with an explicit
+// count (`0d1`, `1d1`, `2d0`, ...) are unchanged so existing behavior is preserved.
+const DICE_REGEXP = /(^|[^\w])(?:(?:(?:((?:\d+[dD]\d+|[dD](?:[2-9]|\d{2,}))(?:ro(?:=|<|<=|>|>=)[0-9]+)?(?:min[0-9]+)?)((?:(?:\s*[-−+]\s*\d+)|(?:\s*[0+]\s*(?:\d+[dD]\d+|[dD](?:[2-9]|\d{2,}))))*))|((?:[-−+]\s*\d+)+)))($|[^\w])/gm;
 
 function replaceRollsCallback(match, replaceCB) {
     let dice = match[2];

--- a/test/dice_regex.test.js
+++ b/test/dice_regex.test.js
@@ -1,0 +1,143 @@
+// Standalone regression tests for DICE_REGEXP in src/common/utils.js.
+// Run with: node test/dice_regex.test.js
+//
+// The regex is extracted from utils.js at runtime so this file stays in sync
+// without needing the project's bundler. Exits 1 on any failure.
+
+const fs = require('fs');
+const path = require('path');
+
+const utilsPath = path.join(__dirname, '..', 'src', 'common', 'utils.js');
+const src = fs.readFileSync(utilsPath, 'utf8');
+
+const m = src.match(/const DICE_REGEXP = (\/.+\/[gmiusy]+);/);
+if (!m) {
+    console.error('FAIL: Could not locate DICE_REGEXP declaration in src/common/utils.js');
+    process.exit(2);
+}
+// eslint-disable-next-line no-eval
+const DICE_REGEXP = eval(m[1]);
+
+function matchDice(input) {
+    const re = new RegExp(DICE_REGEXP.source, DICE_REGEXP.flags);
+    const out = [];
+    let res;
+    while ((res = re.exec(input)) !== null) {
+        // group 2 = dice token (e.g. "1d20"); group 3 = trailing modifiers/extra dice (e.g. "+3");
+        // group 4 = pure +/- modifier-only match (e.g. "+5").
+        if (res[2]) {
+            const mods = (res[3] || '').replace(/\s+/g, '');
+            out.push(res[2] + mods);
+        } else if (res[4]) {
+            out.push(res[4].replace(/\s+/g, ''));
+        }
+    }
+    return out;
+}
+
+const cases = [
+    // --- Bug fix: bare D0 / D1 must NOT match (issue #1126) ---
+    { name: 'issue #1126 Vecna door label sentence',
+      input: 'Characters can teleport to Vecna’s central chamber by touching the ruby gemstone on one of the following doors: A2, B1, C1, D1.',
+      expect: [] },
+    { name: 'bare uppercase D1 in label',
+      input: 'door D1 is locked',
+      expect: [] },
+    { name: 'bare lowercase d1',
+      input: 'unit d1 reports in',
+      expect: [] },
+    { name: 'bare uppercase D0',
+      input: 'panel D0 is hidden',
+      expect: [] },
+    { name: 'bare lowercase d0',
+      input: 'index d0 of the table',
+      expect: [] },
+    { name: 'map-label list with D1 at end',
+      input: 'A1, B0, C1, D1',
+      expect: [] },
+
+    // --- Explicit-count forms preserve original behavior even for d0/d1 ---
+    { name: 'explicit 1d1 still matches (unchanged behavior)',
+      input: 'roll 1d1',
+      expect: ['1d1'] },
+    { name: 'explicit 2d0 still matches (unchanged behavior)',
+      input: 'roll 2d0',
+      expect: ['2d0'] },
+
+    // --- Regression: standard dice rolls must still match ---
+    { name: 'classic 1d20 attack',
+      input: 'attack with 1d20',
+      expect: ['1d20'] },
+    { name: 'bare lowercase d20',
+      input: 'roll d20',
+      expect: ['d20'] },
+    { name: 'bare uppercase D20',
+      input: 'roll D20',
+      expect: ['D20'] },
+    { name: '2d6+3 damage expression',
+      input: 'deal 2d6+3 damage',
+      expect: ['2d6+3'] },
+    { name: 'bare d8 damage',
+      input: 'longsword d8 slashing',
+      expect: ['d8'] },
+    { name: 'bare d6 small die',
+      input: 'shortbow d6 piercing',
+      expect: ['d6'] },
+    { name: 'd100 percentile',
+      input: 'roll d100',
+      expect: ['d100'] },
+    { name: 'd10 ten-sided',
+      input: 'roll d10',
+      expect: ['d10'] },
+    { name: 'bare d4 force damage',
+      input: 'magic missile d4 force',
+      expect: ['d4'] },
+    { name: 'bare d2 (legitimate two-sided die)',
+      input: 'flip d2 for tiebreaker',
+      expect: ['d2'] },
+    { name: 'mixed dice 1d8+1d6+3',
+      input: 'crit damage 1d8+1d6+3',
+      expect: ['1d8+1d6+3'] },
+    { name: 'reroll modifier d20ro<3',
+      input: 'use d20ro<3',
+      expect: ['d20ro<3'] },
+    { name: 'min modifier d6min2',
+      input: 'use d6min2',
+      expect: ['d6min2'] },
+    { name: 'plain numeric modifier +5',
+      input: 'attack +5 to hit',
+      expect: ['+5'] },
+
+    // --- Embedded d / D inside words must remain ignored ---
+    { name: 'word "and" should not match',
+      input: 'find and read',
+      expect: [] },
+    { name: 'word "doorway" should not match',
+      input: 'walk through the doorway',
+      expect: [] },
+    { name: 'identifier "admin1" should not match',
+      input: 'this is admin1 testing',
+      expect: [] },
+];
+
+let pass = 0;
+let fail = 0;
+const failures = [];
+for (const tc of cases) {
+    const got = matchDice(tc.input);
+    const ok = JSON.stringify(got) === JSON.stringify(tc.expect);
+    if (ok) {
+        pass++;
+        console.log(`PASS  ${tc.name}`);
+    } else {
+        fail++;
+        failures.push({ name: tc.name, input: tc.input, expect: tc.expect, got });
+        console.log(`FAIL  ${tc.name}`);
+        console.log(`      input:    ${JSON.stringify(tc.input)}`);
+        console.log(`      expected: ${JSON.stringify(tc.expect)}`);
+        console.log(`      got:      ${JSON.stringify(got)}`);
+    }
+}
+
+console.log(`\n${pass}/${pass + fail} passed`);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## Summary
Restrict the bare-die `dN`/`DN` form in `DICE_REGEXP` to N=2–9 or N with two-or-more digits, so impossible bare dice like `D0`/`D1` no longer hijack sourcebook map labels (e.g. `A2, B1, C1, D1` in Vecna: Eve of Ruin). Explicit-count forms (`1d1`, `2d0`, …) are unchanged. A standalone `npm test` script is added covering the bug and existing-behavior regressions.

## Type of change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement
- [x] 🧪 Tests (adds or updates tests)
- [ ] 📝 Documentation
- [ ] 🔧 Build/CI
- [ ] 🚨 Breaking change

## ⚠️ AI usage disclosure (required)

- [ ] I did **not** use AI for this PR.
- [x] I **did** use AI for this PR (describe below).

**What was AI-assisted:** The regex change in `src/common/utils.js` and the test cases in `test/dice_regex.test.js` were drafted with Claude (Anthropic, Opus 4.7). I (the PR author) reviewed every change, ran the bundled test script, and confirmed the behavior on the issue's reproducer sentence and on standard dice expressions. No build/CI tooling, documentation, or unrelated code was modified by AI.

This is a resubmission of #1375 — the prior PR was closed after @dmportella asked about AI use; this one discloses it upfront and adds the test coverage that the prior thread noted regex changes need.

## Motivation & context
- Related issue(s): #1126
- Prior PR: #1375 (closed without merge)
- Context: The current `DICE_REGEXP` accepts `\d*[dD]\d+`, which matches bare `D0` and `D1`. Neither is a real die (a 0-sided die is undefined and a 1-sided die has no roll variance), but both occur as map/door labels in published sourcebooks, producing a `custom20.png` icon where the original label should be (issue #1126 screenshot).

## What changed?
- `src/common/utils.js`: tightened the bare-die alternative in `DICE_REGEXP` from `\d*[dD]\d+` to `\d+[dD]\d+|[dD](?:[2-9]|\d{2,})`. Applied in both the primary dice group and the trailing-extra-dice modifier group so compound expressions like `1d8+1d6+3` still parse. Comment added inline explaining the rationale.
- `test/dice_regex.test.js` (new): 25-case standalone Node script. Loads `DICE_REGEXP` directly from `src/common/utils.js` at runtime (no bundler needed) and exits non-zero on any failure.
- `package.json`: added `"test": "node test/dice_regex.test.js"`.

## How to test
1. `git fetch && git checkout fix/d1-d0-false-positive-1126`
2. `npm test` — should print `25/25 passed`.
3. Manual: load the unpacked extension build (`npm run build:chrome` / `:firefox`), open the [Vecna ritual chamber page](https://www.dndbeyond.com/sources/veor/eve-of-ruin#R3RitualChamber), scroll to the doors sentence — `D1` should render as text, not a Beyond20 icon. Sanity check a known-good page (e.g. any monster stat block with `1d20` / `2d6+3`) and confirm dice buttons still appear.

## Reviewer notes
- **Scope is intentionally narrow:** only `D0` and `D1` are excluded. The original issue thread noted `D2` also collides with map labels, but `d2` is a legitimate (if uncommon) die, so excluding it would regress real dice notation. This PR fixes the impossible-die cases and leaves the `D2+` ambiguity as a known trade-off (worth a follow-up if a context-aware approach is wanted).
- **Test framework choice:** I deliberately did not pull in Jest/Mocha — the test file is a single ~150-line Node script with zero new dependencies. Happy to migrate it to whatever you prefer if you'd rather grow this in a different direction.
- **AI use:** disclosed above; commit body also notes it. I'm the human responsible for the change and have verified the behavior.