### PR TITLE
fix: dedup Roll20 message routing in no-limit path (#1391)

### DIFF
--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -79,11 +79,24 @@ function sendMessageToRoll20(request, limit = null, failure = null) {
             failure(true)
         }
     } else {
-        sendMessageTo(ROLL20_URL, request, (failed) => {
-            for (let tab of roll20_tabs) {
-                sendMessageWithLog(tab.id, request)
+        // Dedup by tab id: the URL query and the tracked roll20_tabs array can
+        // both reference the same tab (e.g. when activate-icon adds a slash-URL
+        // Roll20 tab to roll20_tabs). Without this, every roll sent to Roll20
+        // with no pinned VTT would be delivered twice — issue #1391, regression
+        // from #1386. The limit path above already dedups the same way.
+        chrome.tabs.query({ "url": ROLL20_URL }, (urlTabs) => {
+            const sentIds = new Set();
+            for (const tab of urlTabs) {
+                if (sentIds.has(tab.id)) continue;
+                sentIds.add(tab.id);
+                sendMessageWithLog(tab.id, request);
             }
-            if (failure) failure(failed && roll20_tabs.length === 0)
+            for (const tab of roll20_tabs) {
+                if (sentIds.has(tab.id)) continue;
+                sentIds.add(tab.id);
+                sendMessageWithLog(tab.id, request);
+            }
+            if (failure) failure(sentIds.size === 0);
         });
     }
 }


### PR DESCRIPTION
## Summary
Fix duplicate Roll20 rolls introduced in v2.20.0. The no-limit branch of `sendMessageToRoll20` was sending each roll twice — once via the `ROLL20_URL` tab query and once by iterating `roll20_tabs` — whenever a Roll20 tab was present in both lists. Replace the two passes with a single tab-id-deduped routing block that mirrors what the limit path already does.

## Type of change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🔧 Build/CI
- [ ] 🚨 Breaking change

## ⚠️ AI usage disclosure (required)

- [ ] I did **not** use AI for this PR.
- [x] I **did** use AI for this PR (describe below).

**What was AI-assisted:** Regression analysis from the user-reported symptom ("Roll20 receives duplicate rolls in v2.20.0") and the Set-based dedup rewrite were drafted with Claude (Anthropic, Opus 4.7). I (the PR author) traced the regression to PR #1386, confirmed the limit-path dedup pattern at `background.js:69-73`, and matched its semantics. No test file is included because this is `background.js` routing logic that requires an extension runtime to exercise.

## Motivation & context
- Closes: #1391
- Regression from: #1386 (\"roll20: Page Permission request for roll20 editor page\", merged 2026-06-04)

PR #1386 added a `roll20_tabs` tracking array as a fallback for Roll20 tabs whose URL doesn't match `*://app.roll20.net/editor/*` (the no-trailing-slash case). The limit path of `sendMessageToRoll20` was updated to merge that array into the URL-query results with a dedup check (`background.js:69-73`):

```js
for (let rtab of roll20_tabs) {
    if (!tabs.find(t => t.id === rtab.id)) {
        tabs.push(rtab);
    }
}
```

The **no-limit** path (lines 81-88) was not updated and instead does two passes with no dedup:

```js
sendMessageTo(ROLL20_URL, request, (failed) => {
    for (let tab of roll20_tabs) {
        sendMessageWithLog(tab.id, request)   // ← duplicates any tab the URL query already hit
    }
    if (failure) failure(failed && roll20_tabs.length === 0)
});
```

A Roll20 tab whose URL matches `ROLL20_URL` can end up in `roll20_tabs` via the `activate-icon` handler at `background.js:302-304`, which calls `addRoll20Tab(tab)` whenever the title looks like Roll20 (no URL check). Once the popup is opened — which fires `activate-icon` — the slash-URL Roll20 tab is in both lists, and every subsequent roll lands in Roll20 chat twice.

## What changed?
- `src/extension/background.js`, no-limit branch of `sendMessageToRoll20`: replaced the two unsynchronized passes with a single `chrome.tabs.query({ url: ROLL20_URL })` whose callback merges the URL-matched tabs and `roll20_tabs` through a `Set` keyed by tab id. Each tab id receives the message exactly once. The `failure` callback is now driven by `sentIds.size === 0`, which is the accurate \"no Roll20 tab received this roll\" signal (the previous version returned success whenever `roll20_tabs` had any entries, even if the query miss + send actually failed).

No changes to:
- The limit/pinned-VTT path (already dedupes).
- `sendMessageToFVTT`, `sendMessageToCustomSites` (use different tracking patterns; not affected).
- The Roll20 content script side, manifest, or anything else.

## How to test
1. `git fetch && git checkout fix/roll20-duplicate-rolls-1391`
2. `npm run build:chrome` (or `:firefox`) and load the unpacked build.
3. Open `https://app.roll20.net/editor/` in one tab and a D&D Beyond character sheet in another. In Beyond20 settings, leave \"VTT to roll to\" unpinned (\"All\").
4. Open the Beyond20 popup once (fires `activate-icon`).
5. Click any roll button → confirm exactly **one** entry in Roll20 chat (previously two).
6. Open `https://app.roll20.net/editor` (no trailing slash) in a Firefox tab — the PR #1386 scenario. Confirm the roll still lands (no regression of that fix).
7. Pin the VTT to a specific Roll20 tab → confirm the limit path still works (it was already correct).
8. With no Roll20 tab open at all, click a roll → confirm the \"No VTT found\" failure path still triggers.

## Reviewer notes
- I considered also tightening `activate-icon`'s `addRoll20Tab` call (`background.js:302`) to skip URL-matched tabs entirely, but kept the change scoped to the routing layer. Defending at the send site is robust regardless of how tabs end up in `roll20_tabs`, and matches the dedup intent already expressed in the limit path.
- AboveVTT is not part of the routing here. Users with AboveVTT in their D&D Beyond tab hit this naturally because they typically leave \"VTT to roll to\" unpinned, but the bug reproduces without AboveVTT.
- No tests are added because exercising `background.js` requires a browser extension runtime. The fix's semantics are checked against the existing limit-path dedup (`background.js:66-77`), which has the same intent and structure.