### PR TITLE
fix: inject Roll20 no-slash tabs during startup tab scan (#1381)

### DIFF
--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -472,9 +472,26 @@ chromeOrBrowser.permissions.getAll((permissions) => {
             // Skip if it's not a FVTT or custom tab
             const fvttTabs = tabs.filter(tab => isFVTT(tab.title));
             const customTabs = tabs.filter(tab => isCustomDomainUrl(tab) || isSupportedVTT(tab));
-            console.log("Permissions : ", pattern, fvttTabs, customTabs);
+            // No-slash Roll20 tabs (issue #1381): the manifest content_scripts
+            // pattern is *://app.roll20.net/editor/* so a tab at /editor with
+            // no trailing slash is not auto-injected. On Firefox the origin
+            // *://app.roll20.net/* permission is normally already granted, so
+            // inject explicitly here. Without this, users who had Roll20 open
+            // at /editor before the extension started (install, browser
+            // restart, MV3 service-worker wake) end up with an unwired tab
+            // and every roll falls through to "No VTT found". PR #1386 handles
+            // the on-navigation case via onTabsUpdated; this covers the
+            // startup-scan case it left open.
+            const roll20NoSlashTabs = tabs.filter(tab =>
+                isRoll20(tab.title) && !urlMatches(tab.url, ROLL20_URL)
+            );
+            console.log("Permissions : ", pattern, fvttTabs, customTabs, roll20NoSlashTabs);
             executeScripts(fvttTabs, ["dist/fvtt_test.js"]);
             injectGenericSiteScripts(customTabs);
+            if (roll20NoSlashTabs.length > 0) {
+                injectRoll20Scripts(roll20NoSlashTabs);
+                for (const tab of roll20NoSlashTabs) addRoll20Tab(tab);
+            }
         })
     }
 });


### PR DESCRIPTION
## Summary
Close the residual \"No VTT Found when using with Roll20\" path that survived PR #1386. The startup tab scan in `background.js` iterates granted permission origins and injects scripts into existing FVTT and custom-domain tabs but has no Roll20 branch — so a Roll20 tab at `https://app.roll20.net/editor` (no trailing slash) is unwired whenever it was already open before Beyond20 started. Add the matching Roll20 case so the startup scan, the on-navigation handler (PR #1386), and the failure-recovery handler all treat the no-slash tab the same way.

## Type of change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🔧 Build/CI
- [ ] 🚨 Breaking change

## ⚠️ AI usage disclosure (required)

- [ ] I did **not** use AI for this PR.
- [x] I **did** use AI for this PR (describe below).

**What was AI-assisted:** Code-path tracing across `sendMessageToRoll20`, `onRollFailure`, `onTabsUpdated`, and the startup scan; identification of the gap left by PR #1386; and the filter+inject rewrite were drafted with Claude (Anthropic, Opus 4.7). I (the PR author) verified the behavior against the existing `onTabsUpdated` no-slash branch at `background.js:441-444`, which applies the same treatment on the navigation path. No tests are included because exercising `background.js` requires a browser extension runtime.

## Motivation & context
- Issue: #1381 — \"Beyond20: No VTT Found when using with Roll20\"
- Related PR: #1386 (\"roll20: Page Permission request for roll20 editor page\", merged 2026-06-04). That PR added the no-slash handling for the **on-navigation** path (`onTabsUpdated` at `background.js:441-444`) and the **recovery** path (`onRollFailure` at `background.js:224-244`).

**The remaining gap** is the **startup tab scan** at `background.js:467-480`:

```js
chromeOrBrowser.permissions.getAll((permissions) => {
    currentPermissions = permissions;
    for (const pattern of currentPermissions.origins) {
        chrome.tabs.query({ \"url\": pattern }, (tabs) => {
            const fvttTabs = tabs.filter(tab => isFVTT(tab.title));
            const customTabs = tabs.filter(tab => isCustomDomainUrl(tab) || isSupportedVTT(tab));
            console.log(\"Permissions : \", pattern, fvttTabs, customTabs);
            executeScripts(fvttTabs, [\"dist/fvtt_test.js\"]);
            injectGenericSiteScripts(customTabs);
        })
    }
});
```

It only filters for FVTT and custom-domain tabs — no Roll20 case. So if the user had Roll20 open at `/editor` (no slash) **before** Beyond20 started — install, browser restart, extension reload, or MV3 service-worker wake — the content script never gets injected and the tab is never added to `roll20_tabs`. The roll then enters `onRollFailure`, which finds the tab via `ROLL20_URL_NO_SLASH` and calls `addRoll20Tab(roll20Tab)` (line 233) but does not call `injectRoll20Scripts`, so the retry message reaches a tab with no listener and is silently dropped.

That explains the bimodal \"fixed yesterday, broken today\" reports on the issue thread: same Firefox, same v2.20.0, but a service-worker wake or browser restart while a no-slash Roll20 tab was open flips users into the broken state, and re-opening D&D Beyond doesn't recover.

Adding the slash works around it because the manifest's content_scripts pattern (`*://app.roll20.net/editor/*`) matches and auto-injects, bypassing the startup-scan path entirely.

## What changed?
- `src/extension/background.js`, startup tab scan (the trailing `permissions.getAll` block at the bottom of the file): added a `roll20NoSlashTabs` filter — Roll20-titled tabs whose URL does **not** match `ROLL20_URL` — and ran `injectRoll20Scripts` + `addRoll20Tab` on them. Behavior mirrors the no-slash branch already present in `onTabsUpdated` at `background.js:441-444`.

No changes to:
- The slash-URL Roll20 content script auto-injection (manifest-driven; unchanged).
- The on-navigation handler (`onTabsUpdated`).
- The failure-recovery handler (`onRollFailure`).
- FVTT / custom-domain / Discord paths.

## How to test
Reproduce the bug first:
1. Be on Firefox (the implicit `*://app.roll20.net/*` origin permission is needed; Chrome MV3 preserves the slash so this path is Firefox-specific).
2. Open `https://app.roll20.net/editor` (no trailing slash) in a tab.
3. With Beyond20 v2.20.0 installed, reload the extension (this re-runs the startup scan).
4. Open a D&D Beyond character sheet and click a roll. Expect: \"No VTT found that matches your settings.\"

Apply the fix:
1. `git fetch && git checkout fix/roll20-noslash-startup-scan-1381`
2. `npm run build:firefox`, load the unpacked build.
3. Repeat steps 2-4 above. Expect: roll lands in Roll20 chat with no extra interaction.

Sanity checks:
- Slash URL (`/editor/`): should continue to work via the manifest match. No double-injection (the filter excludes URLs matching `ROLL20_URL`).
- On-navigation case (open Roll20 *after* Beyond20 is running): unchanged, still handled by `onTabsUpdated`.
- Chrome (MV3 preserves the slash; users typically don't end up at `/editor` no-slash there): no behavior change because Chrome's `currentPermissions.origins` for Roll20 is path-specific.

## Reviewer notes
- I'm explicitly **not** touching the `onRollFailure` recovery path here. It still calls `addRoll20Tab` without `injectRoll20Scripts`, which leaves a second-order gap when a user grants permission *after* Beyond20 startup AND the `onTabsUpdated` event missed (e.g. permission granted between page-load and roll). That's a smaller surface and warrants its own discussion — happy to follow up if you want. Fixing it well requires awaiting `chrome.scripting.executeScript` before retrying the send so the listener is wired before the message arrives, which changes the recovery's control flow.
- The `console.log` line now includes `roll20NoSlashTabs` for parity with the existing diagnostic output. Drop or keep at your discretion.
- I posted a root-cause comment on #1381 with the same analysis so users searching the thread find context.