### PR TITLE
perf: drop attributes:true from encounter MutationObserver

### DIFF
--- a/src/dndbeyond/content-scripts/encounter.js
+++ b/src/dndbeyond/content-scripts/encounter.js
@@ -151,7 +151,13 @@ updateSettings();
 injectCSS(BUTTON_STYLE_CSS);
 chrome.runtime.onMessage.addListener(handleMessage);
 const observer = new window.MutationObserver(documentModified);
-observer.observe(document, { "subtree": true, "childList": true, attributes: true, });
+// childList + subtree only. The documentModified callback ignores its
+// `mutations` parameter and re-scans the DOM from scratch, so attribute
+// notifications add no information but cost a full re-scan per fire. DDB
+// toggles class/style attributes constantly in the combat tracker
+// (drag highlights, focus states, animation classes), which would otherwise
+// drive hundreds of useless callback invocations per turn.
+observer.observe(document, { "subtree": true, "childList": true });
 chrome.runtime.sendMessage({ "action": "activate-icon" });
 sendCustomEvent("disconnect");
 injectPageScript(chrome.runtime.getURL('dist/dndbeyond_mb.js'));


### PR DESCRIPTION
## Summary
Remove `attributes: true` from the global MutationObserver in the encounter content script. The callback ignores its `mutations` parameter and re-scans the DOM from scratch on every fire, so attribute notifications add no information but force a full re-scan per attribute change. DDB's combat tracker thrashes class/style attributes constantly (drag highlights, focus states, animation classes) — on a populated tracker this observer fires hundreds of times per turn for nothing. `childList + subtree` is sufficient for everything `documentModified` actually depends on.

## Type of change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [x] ⚡ Performance improvement
- [ ] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🔧 Build/CI
- [ ] 🚨 Breaking change

## ⚠️ AI usage disclosure (required)

- [ ] I did **not** use AI for this PR.
- [x] I **did** use AI for this PR (describe below).

**What was AI-assisted:** Perf audit and the `attributes`-vs-`childList` analysis were drafted with Claude (Anthropic, Opus 4.7). I (the PR author) verified the conclusion by reading the `documentModified` callback (`encounter.js:8-79`) and confirming the `mutations` parameter is never referenced — only structural DOM is queried via fresh `$(...)` lookups every call.

## Motivation & context
No associated issue; surfaced during a perf review of the content scripts.

The observer at `src/dndbeyond/content-scripts/encounter.js:153-154` is configured with `{ subtree: true, childList: true, attributes: true }` against the whole `document`. The callback `documentModified(mutations, observer)` declares the `mutations` parameter but never reads it — it queries the DOM from scratch on every invocation:

```js
function documentModified(mutations, observer) {
    if (isExtensionDisconnected()) { ... }
    injectCustomRollButton();
    const monster = $(\".encounter-details-monster-summary-info-panel,...\");
    const monster_name = monster.find(\".mon-stat-block__name\").text();
    if (settings[\"sync-combat-tracker\"]) {
        updateCombatTracker();
    }
    // ...
}
```

Because the callback doesn't differentiate between mutation kinds, attribute notifications can only contribute work — never information. And DDB toggles class/style attributes very heavily in the encounter UI: drag highlights on initiative tokens, focus rings on inputs, animation transition classes on cards, etc. Each one schedules a callback that re-scans the panel and (when `sync-combat-tracker` is on) re-serializes the combat tracker state to JSON.

## What changed?
- `src/dndbeyond/content-scripts/encounter.js:154`: dropped `attributes: true` from `observer.observe(...)`. The structural-change observation (`subtree + childList`) is unchanged, so the callback continues to fire on every event it actually responds to: new panel mounts, stat blocks loading, monster swaps, panels closing, DigitalDice notifications. A short comment documents the rationale so this isn't reintroduced later.

No changes to:
- The callback logic itself.
- `documentModified`, `updateCombatTracker`, `injectCustomRollButton`, etc.
- Any other observer in the codebase.

## How to test
1. `git fetch && git checkout perf/encounter-observer-no-attributes`
2. `npm run build:chrome` (or `:firefox`) and load the unpacked build.
3. Open a D&D Beyond encounter / combat tracker page with multiple monsters.
4. Open the page DevTools, switch to Performance, record ~10 seconds while interacting with the tracker (hover initiative tokens, drag a token, click a monster, etc.).
5. Beyond20's `documentModified` callback should fire only on structural changes (new monster opens, panel mounts/unmounts, etc.) instead of continuously while you interact. Functional behavior — roll buttons, monster stat-block parsing, combat tracker sync — should be unchanged.
6. Sanity checks:
   - Open a different monster → roll button still injects.
   - Toggle the combat tracker → sync still fires.
   - Disconnect extension (e.g. extension reload) → the `isExtensionDisconnected()` guard still tears down on the next structural fire (this is no slower than before; same path, fewer triggers).

## Reviewer notes
- **Why not also narrow the observed root?** I considered changing `document` → `document.body` or to a specific encounter container, but DDB remounts those containers across navigations (it's a React app), so an observer attached to a transient root would go stale. `document` is the only safe long-lived root; dropping `attributes: true` is the part that buys real performance without behavior risk.
- **Follow-up candidate.** The audit flagged `src/dndbeyond/content-scripts/character.js:3574` for a similar pattern — global `document` observe with `characterData: true`. The character.js observer's callback does respond to character-data text changes (HP/condition watching), so that one needs a more careful refactor than just dropping a flag. Left for a separate PR if you want it.
- No tests because exercising MutationObserver observers requires a live DDB page.