### PR TITLE
feat: added unarmed fighting style

### DIFF
--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -1532,6 +1532,7 @@ async function rollAction(paneClass, force_to_hit_only = false, force_damages_on
             "unarmed fighting",
             "fighting style: unarmed fighting (armed)",
             "fighting style: unarmed fighting",
+            "unarmed fighting (no weapons/shield)",
             "arms of the astral self",
             "shadow blade",
             "predatory strike",

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -1530,6 +1530,8 @@ async function rollAction(paneClass, force_to_hit_only = false, force_damages_on
             "talons",
             "thunder gauntlets",
             "unarmed fighting",
+            "fighting style: unarmed fighting (armed)",
+            "fighting style: unarmed fighting",
             "arms of the astral self",
             "shadow blade",
             "predatory strike",


### PR DESCRIPTION
## Summary
Adds "fighting style: unarmed fighting" to the list of recognized melee action strings so the extension correctly identifies it as a valid melee attack.

## Type of change

- [x] ✨ New feature (non-breaking change that adds functionality)

## ⚠️ AI usage disclosure (required)

- [x] I did **not** use AI for this PR.

## Motivation & context
- Issue: #1398
- Milestone: 2.20.2

The "fighting style: unarmed fighting" action string was missing from the melee action lookup, causing it to be treated as a non-melee action. This prevents the extension from properly processing attacks made with the Unarmed Fighting fighting style.

## What changed?
- Added `"fighting style: unarmed fighting"` to the melee action array in `character.js`

## How to test
1. Create or load a barbarian character with the Unarmed Fighting fighting style (Fighting style feat)
2. Verify their unarmed strikes appear correctly in the melee action panel
3. Enable rage and roll the attack, you should see the action using the rage damage correctly.

## Reviewer notes
The existing adjacent entry `"fighting style: unarmed fighting (armed)"` was already present; this adds the un-armed variant that was missing.
