### PR TITLE
fix: force one handed or two handed dmg

### DIFF
--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -1144,8 +1144,10 @@ async function rollItem(force_display = false, force_to_hit_only = false, force_
                         versatile_choice = "one"
                     if (key_modifiers.versatile_two_handed)
                         versatile_choice = "two";
-                    if (force_versatile) {
+                    if (force_versatile === "two") {
                         versatile_choice = "two";
+                    } else if (force_versatile === "one") {
+                        versatile_choice = "one";
                     }
                     if (versatile_choice == "one") {
                         damages.push(damage);
@@ -2988,7 +2990,11 @@ function activateQuickRolls() {
         activateQRAction(action, true, false);
     }
     for (let action of actions_damage.toArray()) {
-        activateQRAction(action, false, true, action.previousElementSibling !== null);
+        const parent = action.parentElement;
+        const containers = parent ? parent.querySelectorAll(".integrated-dice__container") : [];
+        const idx = Array.prototype.indexOf.call(containers, action);
+        const force = containers.length > 1 ? (idx === containers.length - 1 ? "two" : "one") : false;
+        activateQRAction(action, false, true, force);
     }
 
     const activateQRSpell = (spell, force_to_hit_only, force_damages_only) => {
@@ -3255,7 +3261,13 @@ function handleCombatAttackIntegratedDie(button) {
     const isToHit = !!button.closest(".ct-combat-attack__tohit, .ddbc-combat-attack__tohit");
     const damageCell = button.closest(".ct-combat-attack__damage, .ddbc-combat-attack__damage");
     const isDamage = !!damageCell;
-    const forceVersatile = !!(damageCell && damageCell.previousElementSibling);
+    let forceVersatile = false;
+    if (damageCell) {
+        const parent = button.parentElement;
+        const containers = parent ? parent.querySelectorAll(".integrated-dice__container") : [];
+        const idx = Array.prototype.indexOf.call(containers, button);
+        forceVersatile = containers.length > 1 ? (idx === containers.length - 1 ? "two" : "one") : false;
+    }
 
     const name = $(row)
         .find(".ct-combat-attack__name .ct-combat-attack__label, .ddbc-combat-attack__name .ddbc-combat-attack__label")


### PR DESCRIPTION
## Summary
Fix versatile weapon damage quick-roll so the 1‑handed button rolls 1‑handed damage and the 2‑handed button rolls 2‑handed damage, regardless of DDB label/icon siblings or the user's "versatile-choice" setting.

## Type of change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## ⚠️ AI usage disclosure (required)
- [x] I **did** use AI for this PR (describe below).

> AI (Claude) was used to analyze the DOM structure, identify both code paths affected by the same bug, and draft the fix code. The logic and correctness were manually verified.

## Motivation & context
- Related issue(s): #1388
- Context: When clicking the 1‑handed damage button on a versatile weapon (e.g. Longsword 1d8+5), the quick-roll either rolled 2‑handed damage (1d10) or both damages, depending on the DOM layout. Two root causes:

  1. **Wrong sibling detection** – `previousElementSibling !== null` was meant to detect the 2‑handed button, but DDB renders label/icon nodes before the first button, making `previousElementSibling` non-null for both buttons.
  2. **Missing "one‑handed" signal** – `force_versatile` was a boolean (`true` → force 2‑handed, `false` → use user default of `"both"`). The 1‑handed button had no way to request *only* 1‑handed damage.

## What changed?
- **`activateQuickRolls`** (line 2992): Replaced `action.previousElementSibling !== null` with a position check using `parentElement.querySelectorAll(".integrated-dice__container")` — scoped to the button's immediate parent, immune to non-container siblings.
- **`handleCombatAttackIntegratedDie`** (line 3264): Same fix for the integrated‑dice hijack path that had the identical bug.
- **`force_versatile` → tristate**: Changed from `boolean` to `false` / `"one"` / `"two"`. `false` means no force (respect user setting), `"one"` forces 1‑handed, `"two"` forces 2‑handed. This is used in `rollItem` (line 1147) to set `versatile_choice` accordingly.

## How to test
1. Open any DDB character sheet with a versatile weapon (e.g. Longsword, Quarterstaff).
2. Click the 1‑handed damage button (e.g. `1d8+5`) — verify the roll uses 1‑handed damage only.
3. Click the 2‑handed damage button (e.g. `1d10+5`) — verify the roll uses versatile damage only.
4. Repeat with a non‑versatile weapon to confirm its damage rolls are unaffected.

## Reviewer notes
- The fix uses `parentElement` (the `ddbc-combat-item-attack__damage` container) rather than `.closest(".ddbc-combat-attack__damage")` to avoid counting buttons from sibling damage‑type containers (e.g. bonus fire damage on a Flame Tongue Longsword).
- Both code paths (`activateQuickRolls` for Beyond20 tooltips, `handleCombatAttackIntegratedDie` for DDB native dice hijack) are fixed with identical logic.