### PR TITLE
feat: add support for the 2024 Bladesinger Bladesong

### DIFF
--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -877,6 +877,12 @@ const character_settings = {
         "type": "bool",
         "default": false
     },
+    "wizard-bladesong-2024": {
+        "title": "Wizard: Bladesinger: Bladesong (2024)",
+        "description": "Activate your Bladesong: Advantage on Acrobatics checks, Intelligence for weapon attack and damage rolls, and Intelligence added to Concentration saves",
+        "type": "bool",
+        "default": false
+    },
     "empowered-evocation": {
         "title": "Wizard: Evocation Wizard: Empowered Evocation",
         "description": "Your prowess in Evocation lends power to your Evocation spells",

--- a/src/dndbeyond/base/character.js
+++ b/src/dndbeyond/base/character.js
@@ -286,6 +286,8 @@ class Character extends CharacterBase {
     getFeatureVersionName(feat_name, feat_reference) {
         if (!feat_reference) return feat_name;
         let is2024 = false;
+        // Sources using the 2024 rules whose reference doesn't say "2024"
+        const is2024Source = ["2024", "frhof"].some(src => feat_reference.toLowerCase().includes(src));
         if (
             (
                 feat_name.toLowerCase() === "great weapon master" ||
@@ -304,9 +306,9 @@ class Character extends CharacterBase {
                 feat_name.toLowerCase() === "remarkable athlete" ||
                 feat_name.toLowerCase() === "blessed strikes" ||
                 feat_name.toLowerCase() === "improved blessed strikes" ||
-                feat_name.toLowerCase() === "healer"
-            ) && ( 
-                feat_reference.toLowerCase().includes("2024")) ||
+                feat_name.toLowerCase() === "healer" ||
+                feat_name.toLowerCase() === "bladesong"
+            ) && is2024Source ||
                 feat_reference.toLowerCase().includes("free-rules")
          ) {
             is2024 = true;

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -20,6 +20,59 @@ function addEffect(rollProperties, effect) {
     }
 }
 
+/**
+ * Which Bladesong version is currently active.
+ * @returns {(2014|2024|null)} The active version, or null if the Bladesong is not up
+ */
+function getActiveBladesong() {
+    if (character.hasClassFeature("Bladesong 2024") && character.getSetting("wizard-bladesong-2024", false))
+        return 2024;
+    if (character.hasClassFeature("Bladesong") && character.getSetting("wizard-bladesong", false))
+        return 2014;
+    return null;
+}
+
+/**
+ * The ability modifier D&D Beyond already used for a weapon attack: Dexterity for
+ * ranged, the better of Strength/Dexterity for Finesse, Strength otherwise.
+ */
+function getWeaponAbilityModifier(properties) {
+    const str_mod = parseInt(character.getAbility("STR").mod) || 0;
+    const dex_mod = parseInt(character.getAbility("DEX").mod) || 0;
+    if (properties["Attack Type"] == "Ranged") return dex_mod;
+    if ((properties["Properties"] || "").includes("Finesse")) return Math.max(str_mod, dex_mod);
+    return str_mod;
+}
+
+/**
+ * Folds a flat bonus into a formula's trailing modifier so it renders as a single
+ * number ("1d6+2" + 1 becomes "1d6+3") instead of a separate term.
+ */
+function mergeFlatBonus(formula, bonus) {
+    const trailing = /([+-])\s*(\d+)\s*$/.exec(formula);
+    if (!trailing) return `${formula}${bonus >= 0 ? "+" : ""}${bonus}`;
+    const total = parseInt(`${trailing[1]}${trailing[2]}`) + bonus;
+    return formula.slice(0, trailing.index) + (total >= 0 ? `+${total}` : `${total}`);
+}
+
+/** Whether the two-handed damage is the one being rolled for a weapon. */
+function usesTwoHandedDamage(properties) {
+    const weapon_properties = properties["Properties"] || "";
+    let versatile_choice = character.getSetting("versatile-choice", "both");
+    if (key_modifiers.versatile_one_handed) versatile_choice = "one";
+    if (key_modifiers.versatile_two_handed) versatile_choice = "two";
+    return (weapon_properties.includes("Versatile") && versatile_choice != "one") ||
+        weapon_properties.includes("Two-Handed");
+}
+
+/**
+ * Whether an attack uses two hands, which ends the Bladesong. Unlike the Great Weapon
+ * Fighting check, this isn't melee-only: two-handed ranged weapons use two hands too.
+ */
+function isTwoHandedAttack(properties, action_name = "") {
+    return usesTwoHandedDamage(properties) || IsPoleArmMasterAttack(properties, action_name);
+}
+
 async function rollSkillCheck(paneClass) {
     const skill_name = $("." + paneClass + "__header-name").text();
     let ability = $("." + paneClass + "__header-ability").text();
@@ -101,8 +154,10 @@ async function rollSkillCheck(paneClass) {
             addEffect(roll_properties, "Rage");
         }
     }
-    if (skill_name == "Acrobatics" && character.hasClassFeature("Bladesong") && character.getSetting("wizard-bladesong", false)) {
+    // Wizard: Bladesinger: Bladesong - Agility
+    if (skill_name == "Acrobatics" && getActiveBladesong() !== null) {
         roll_properties["advantage"] = RollType.OVERRIDE_ADVANTAGE;
+        addEffect(roll_properties, "Bladesong");
     }
     roll_properties.d20 = "1d20";
     // Set Reliable Talent flag if character has the feature and skill is proficient/expertise
@@ -280,9 +335,8 @@ function applyAbilityOrSavingThrowEffects({ rollType, ability_name, ability, mod
     // Concentration checks
     if (rollType === "saving-throw" && ability === "CON") {
         const has_warcaster = character.hasFeat("War Caster");
-        const has_bladesong =
-            character.hasClassFeature("Bladesong") &&
-            character.getSetting("wizard-bladesong", false);
+        const bladesong = getActiveBladesong();
+        const has_bladesong = bladesong !== null;
 
         if (has_warcaster || has_bladesong) {
             const confirmation = has_bladesong
@@ -292,7 +346,9 @@ function applyAbilityOrSavingThrowEffects({ rollType, ability_name, ability, mod
             if (confirm(confirmation)) {
                 if (has_bladesong) {
                     const intelligence = character.getAbility("INT") || { mod: 0 };
-                    const bladesongMod = Math.max((parseInt(intelligence.mod) || 0), 1);
+                    const intelligenceMod = parseInt(intelligence.mod) || 0;
+                    // 2024 Focus adds the raw modifier, the 2014 minimum of +1 does not apply
+                    const bladesongMod = bladesong === 2024 ? intelligenceMod : Math.max(intelligenceMod, 1);
                     mod = parseInt(modifier) + bladesongMod;
                     modifier = mod >= 0 ? `+${mod}` : `${mod}`;
                     roll_properties.modifier = modifier;
@@ -628,8 +684,9 @@ function handleSpecialMeleeAttacks(damages=[], damage_types=[], properties, sett
 
     if (character.hasClass("Wizard")) {
         // Wizard: Bladesinging: Song of Victory
+        // 2014 only: the 2024 Bladesong substitutes Intelligence through Bladework instead
         if (character.hasClassFeature("Song of Victory") &&
-            character.getSetting("wizard-bladesong", false)) {
+            getActiveBladesong() === 2014) {
             const intelligence = character.getAbility("INT") || {mod: 0};
             const mod = parseInt(intelligence.mod) || 0;
             damages.push(String(Math.max(mod, 1)));
@@ -684,10 +741,9 @@ function handleSpecialMeleeAttacks(damages=[], damage_types=[], properties, sett
         character.getSetting("charger-feat")) {
             let charge_dmg = "1d8";
             // apply GWF if needed
-            if(((properties["Attack Type"] == "Melee" && ((properties["Properties"].includes("Versatile") && character.getSetting("versatile-choice") != "one") || 
-                properties["Properties"].includes("Two-Handed"))) ||
+            if((properties["Attack Type"] == "Melee" && usesTwoHandedDamage(properties)) ||
                 action_name == "Polearm Master - Bonus Attack" ||
-                action_name == "Pole Strike")) {
+                action_name == "Pole Strike") {
                 if(character.hasGreatWeaponFighting(2014)) {
                     charge_dmg += "ro<=2";
                 } else if(character.hasGreatWeaponFighting(2024)) {
@@ -1064,6 +1120,28 @@ function handleSpecialWeaponAttacks(damages=[], damage_types=[], properties, set
             const charisma_damage_mod =  Math.max(character.getAbility("CHA").mod, 1);
             damages.push(`${charisma_damage_mod}`);
             damage_types.push("Lifedrinker");
+        }
+    }
+
+    if (character.hasClass("Wizard")) {
+        // Wizard: Bladesinging: Bladesong - Bladework (2024)
+        // Uses Intelligence for the attack and damage rolls instead of Strength or Dexterity.
+        // Two-handed attacks end the Bladesong, so they don't benefit from it.
+        if (to_hit !== null &&
+            getActiveBladesong() === 2024 &&
+            properties["Proficient"] == "Yes" &&
+            ["Melee", "Ranged"].includes(properties["Attack Type"]) &&
+            !isTwoHandedAttack(properties, action_name)) {
+            const intelligence_mod = parseInt(character.getAbility("INT").mod) || 0;
+            // Bladework is optional, so only use it when it beats the weapon's own ability
+            const bladework = intelligence_mod - getWeaponAbilityModifier(properties);
+            if (bladework > 0) {
+                // Replaces the weapon's ability modifier, so it merges into the rolls
+                // rather than showing up as a separate bonus
+                to_hit = mergeFlatBonus(to_hit, bladework);
+                if (damages.length > 0) damages[0] = mergeFlatBonus(damages[0], bladework);
+                effects.push("Bladesong");
+            }
         }
     }
 

--- a/src/extension/popup.js
+++ b/src/extension/popup.js
@@ -289,6 +289,10 @@ function populateCharacter(response) {
             e = createHTMLOption("wizard-bladesong", false, character_settings);
             options.append(e);
         }
+        if (response["class-features"].includes("Bladesong 2024")) {
+            e = createHTMLOption("wizard-bladesong-2024", false, character_settings);
+            options.append(e);
+        }
         if (response["class-features"].includes("Dreadful Strikes")) {
             e = createHTMLOption("fey-wanderer-dreadful-strikes", false, character_settings);
             options.append(e);


### PR DESCRIPTION
## Summary

Adds a `Wizard: Bladesinger: Bladesong (2024)` character setting implementing the revised Bladesong (Forgotten Realms: Heroes of Faerûn), alongside the existing 2014 option. The two are mutually exclusive per character, following the version-split convention already used for features like Assassinate.

## Type of change
<!-- Mark the relevant option(s) -->
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Tests (adds or updates tests)
- [ ] 📝 Documentation
- [ ] 🔧 Build/CI
- [ ] 🚨 Breaking change

## ⚠️ AI usage disclosure (required)

- [ ] I did **not** use AI for this PR.
- [x] I **did** use AI for this PR (describe below).

All source changes, the commit message, and this PR description were written by Claude (Claude Opus 5, via Claude Code). My involvement was directing the design, reviewing every change, and testing against a live D&D Beyond character sheet.

Specific points where I pushed back and the AI's initial approach was changed, in case they're useful review signal:

- Its first draft auto-deactivated the setting when the character was Incapacitated or attacked two-handed. No feature in this codebase reads conditions, and every `settings_to_change` write is a one-shot "apply to next roll only" toggle, so that was removed as off-pattern.
- It initially excluded unarmed strikes with a negated `includesNormalized(...)` check. Song of Victory — the direct 2014 predecessor — has no such check, so it was dropped rather than introduce a fourth idiom for "is this a weapon".
- Bladework originally rendered as a separate labelled damage entry. Since it *replaces* the ability modifier rather than adding a source, it now merges into the roll.
- The `usesTwoHandedDamage` extraction was my request, to avoid duplicating the Versatile/Two-Handed logic that already existed for Charger 2024.

## Motivation & context

- Related issue(s): #
- Context: The Bladesinger in *Forgotten Realms: Heroes of Faerûn* reworks Bladesong. The 2014 version's benefits (Acrobatics advantage, a concentration bonus) partly overlap with the new one, but **Bladework** — using Intelligence for weapon attack and damage rolls — is new, and D&D Beyond does not model it. There is no control on the sheet to activate Bladesong, so DDB's displayed to-hit is always the plain Strength/Dexterity value.

## What changed?

- New `wizard-bladesong-2024` setting; the existing `wizard-bladesong` is untouched in behaviour.
- `getFeatureVersionName` now treats `FRHoF` as a 2024 rules source and includes `bladesong` in the name list, so the feature parses as `Bladesong 2024`. Added to the **name-gated** branch only — deliberately not alongside `free-rules`, which applies to every feature from that source regardless of name.
- **Agility**: advantage on Acrobatics, now tagged with a `Bladesong` effect on the roll.
- **Focus**: adds the Intelligence modifier to Constitution saves for concentration. Floored at 0 for 2024, since that wording is optional ("you *can* add"); the 2014 bonus keeps its printed minimum of +1.
- **Bladework**: uses Intelligence for the attack and damage rolls of proficient weapons when it beats Strength/Dexterity, merged into the rolls via a new `mergeFlatBonus` helper rather than added as a separate term.
- Song of Victory is scoped to the 2014 Bladesong so it cannot stack with Bladework.
- Extracted `usesTwoHandedDamage`, now shared with the Charger 2024 Great Weapon Fighting check.

Deliberately **out of scope**, as the extension cannot observe or apply them: the AC bonus, the +10 speed, donning armour or a shield, and use tracking / the 1-minute duration.

## How to test

1. `npm install && npm run build`, then load `build/chrome` as an unpacked extension.
2. Open a Bladesinger with the FRHoF subclass and visit **Features & Traits** once so class features are re-parsed.
3. In the Beyond20 popup, confirm **Wizard: Bladesinger: Bladesong (2024)** appears and the plain "Bladesong" option does not. Enable it.
4. Roll **Acrobatics** — advantage, tagged `Bladesong`.
5. Roll an attack with a proficient **one-handed** weapon where Intelligence exceeds Strength/Dexterity — the to-hit and damage should each be higher by the difference, as single values rather than a separate term.
6. Roll a **Constitution** saving throw and answer yes to the concentration prompt — Intelligence is added.
7. Roll with a **two-handed** weapon, or a Versatile weapon with `versatile-choice` set to "both"/"two" — no Bladework applies.
8. Regression: a 2014 (Tasha's) Bladesinger should still show only the original "Bladesong" option and behave as before.

## Reviewer notes

- **`getWeaponAbilityModifier` is the only ability-substitution construct in the codebase, and I'd welcome scrutiny on it.** Every other `getAbility()` call adds a modifier or sets a threshold; this one subtracts, because Bladework replaces the ability D&D Beyond already used. The reason no precedent exists is that DDB natively handles the other substitution features — Hex Warrior, Battle Smith, Pact of the Blade — so Beyond20 never had to. Bladework isn't modelled there, hence the reconstruction. It infers the ability from weapon properties (Dexterity for ranged, better of Strength/Dexterity for Finesse, else Strength), so it will be wrong where something else overrides the ability, e.g. a Monk multiclass using Dexterity for monk weapons.
- **`usesTwoHandedDamage` slightly changes Charger 2024 behaviour.** The old inline check read `versatile-choice` directly and ignored `key_modifiers`; the shared helper follows `rollItem`'s own resolution, so the versatile hotkeys are now honoured. It also guards against `properties["Properties"]` being undefined, which the old expression did not. Both look like fixes to me, but they are behaviour changes in a Bladesong PR and easy to revert if you'd rather.
- The versions are separated by feature name (`Bladesong` vs `Bladesong 2024`), so a character can only ever match one. If `FRHoF` isn't the right marker, `is2024Source` is the single place to adjust.
- No changelog entry, since `docs/Changelog.md` appears to be written by release commits rather than feature PRs. Happy to add one if you'd prefer.
- Concentration still relies on the existing `confirm()` prompt, since D&D Beyond gives no way to distinguish a concentration save from any other Constitution save.
