### PR TITLE
Add vtt.roll-drauf.de to the list of known VTT domains

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,3 +1,7 @@
+Unreleased
+===
+- **Misc**: Add vtt.roll-drauf.de as a recognized VTT which natively supports Beyond20 (rolls, hp-update, conditions-update and update-combat)
+
 v2.20.1 (June 7th 2026)
 ===
 - **Bugfix**: *Roll20*: Fix duplicate messages in Chrome for Roll20 (by [@dmportella](https://github.com/dmportella))

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -39,6 +39,7 @@ const SUPPORTED_VTT_URLS = [
     "https://dscryb.com/*",
     "https://codex.dragonshorn.com/*",
     "*://*.osrbeyond.com/*",
+    "https://vtt.roll-drauf.de/play*",
     ...DISCORD_ACTIVITY_DOMAINS
 ];
 


### PR DESCRIPTION
## Add vtt.roll-drauf.de to the list of known VTT domains

**What**: Adds `https://vtt.roll-drauf.de/play*` to `SUPPORTED_VTT_URLS` (plus a changelog line), following the pattern of harpy.gg / alchemyrpg.com / dscryb.com.

**Who we are**: [Roll Drauf VTT](https://vtt.roll-drauf.de) is a small web-based virtual tabletop (German-language UI) for playing D&D online with maps, tokens and a shared real-time table.

**Beyond20 support is already live** on the play route (`/play`), implemented against the documented API (https://beyond20.here-for-more.info/api):

- `Beyond20_RenderedRoll` — rolls render as structured roll cards in the table's shared dice log and session chat (attack/damage rows, individual dice, crit highlighting, `roll_info` context like save DCs), broadcast in real time to everyone at the table and persisted in the session history. We build our own cards from the structured payload; the pre-rendered `html` field is not injected.
- `Beyond20_UpdateHP` — syncs current/max HP onto the table token matching the character name.
- `Beyond20_UpdateConditions` — syncs the conditions array (+ exhaustion level) onto the matching token, shown as a marker badge.
- `Beyond20_UpdateCombat` — syncs initiative and the current-turn flag from the encounter tracker into the table's turn-order widget.

Until now our users have had to add the domain under Beyond20's custom-domains advanced option; being on the known-sites list removes that manual step.

The integration is covered by automated browser tests on our side (we dispatch the documented event shapes in CI and assert the table renders/syncs them), so we intend to keep tracking the API.

Happy to adjust the URL pattern or anything else about this entry.
